### PR TITLE
allow access to metadata on participant struct

### DIFF
--- a/participant.go
+++ b/participant.go
@@ -56,6 +56,10 @@ func (p *baseParticipant) Identity() string {
 	return p.identity
 }
 
+func (p *baseParticipant) Metadata() string {
+	return p.metadata
+}
+
 func (p *baseParticipant) IsSpeaking() bool {
 	val := p.isSpeaking.Load()
 	if speaking, ok := val.(bool); ok {


### PR DESCRIPTION
For now, user can't access to metadata store in a participant, the only way to get it is to use listener.

This make following code possible:

```go
import (
  lksdk "github.com/livekit/server-sdk-go"
)

func main() {
  host := "<host>"
  apiKey := "api-key"
  apiSecret := "api-secret"
  roomName := "myroom"
  identity := "botuser"
	room, err := lksdk.ConnectToRoom(host, lksdk.ConnectInfo{
		APIKey:              apiKey,
		APISecret:           apiSecret,
		RoomName:            roomName,
		ParticipantIdentity: identity,
	})
	if err != nil {
		panic(err)
	}

  room.Callback.OnParticipantConnected = func(participant *lksdk.RemoteParticipant) {
     metadata = participant.Metadata()
  }

}
```