### PR TITLE
Fix callback for participant disconnected

### DIFF
--- a/room.go
+++ b/room.go
@@ -158,7 +158,7 @@ func (r *Room) handleParticipantDisconnect(p *RemoteParticipant) {
 	defer r.lock.Unlock()
 	delete(r.Participants, p.SID())
 	p.unpublishAllTracks()
-	r.Callback.OnParticipantConnected(p)
+	r.Callback.OnParticipantDisconnected(p)
 }
 
 func (r *Room) handleActiveSpeakerChange(speakers []*livekit.SpeakerInfo) {


### PR DESCRIPTION
This is a small fix for the callback when participant disconnect, it actually use `OnParticipantConnected` instead of `OnParticipantDisconnected`