### PR TITLE
Allow access metadata on interface participant

### DIFF
--- a/participant.go
+++ b/participant.go
@@ -15,6 +15,7 @@ type Participant interface {
 	setAudioLevel(level float32)
 	setIsSpeaking(speaking bool)
 	Tracks() []TrackPublication
+	Metadata() string
 }
 
 type baseParticipant struct {


### PR DESCRIPTION
This is a fix for allowing access to metadata function which seems to be forgotten.

It is linked to pull request https://github.com/livekit/server-sdk-go/pull/2
