### PR TITLE
handle lossy data packet messages which fix speakers update

### DIFF
--- a/participant.go
+++ b/participant.go
@@ -89,7 +89,7 @@ func (p *baseParticipant) setAudioLevel(level float32) {
 
 func (p *baseParticipant) setIsSpeaking(speaking bool) {
 	lastSpeaking := p.IsSpeaking()
-	if speaking != lastSpeaking {
+	if speaking == lastSpeaking {
 		return
 	}
 	p.isSpeaking.Store(speaking)


### PR DESCRIPTION
Livekit server use two differents protocol for sending speakers update: https://github.com/livekit/livekit-server/blob/master/pkg/rtc/room.go#L519-L525

It's seems that's server send lossy data packet for speakers update to room from go sdk. But they are not handled so I started implementation for reading it in the same for as `SignalClient`. This currently handle speakers update and I don't really know what should be handled too. 

This also include a small fix on `Participan.setIsSpeaking` which was not update speaking if the state of speaking state change. It should be inverted obviously 