### PR TITLE
fix race connection when handling active speakers

### DIFF
--- a/room.go
+++ b/room.go
@@ -179,15 +179,15 @@ func (r *Room) handleActiveSpeakerChange(speakers []*livekit.SpeakerInfo) {
 	seenSids := make(map[string]bool)
 	for _, s := range speakers {
 		seenSids[s.Sid] = true
-		var p Participant
-
 		if s.Sid == r.LocalParticipant.sid {
-			p = r.LocalParticipant
+			r.LocalParticipant.setAudioLevel(s.Level)
+			r.LocalParticipant.setIsSpeaking(true)
+			activeSpeakers = append(activeSpeakers, r.LocalParticipant)
 		} else {
-			p = r.GetParticipant(s.Sid)
-		}
-
-		if p != nil {
+			p := r.GetParticipant(s.Sid)
+			if p == nil {
+				continue
+			}
 			p.setAudioLevel(s.Level)
 			p.setIsSpeaking(true)
 			activeSpeakers = append(activeSpeakers, p)


### PR DESCRIPTION
When an active speaker is disconnecting in some conditions you can get this kind of error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc23ca5]

goroutine 98 [running]:
github.com/livekit/server-sdk-go.(*RemoteParticipant).setAudioLevel(0x0, 0xc03e000000)
	<autogenerated>:1 +0x5
github.com/livekit/server-sdk-go.(*Room).handleActiveSpeakerChange(0xc0004113b0, 0xc00000ea68, 0x1, 0x1)
	server-sdk-go/room.go:196 +0x46c
```

Probable condition is when setting active speakers and have delete from map just before/after it. GC should have marked already the element to be deleted.

This is because `var p Participant` is an interface which can be not be nil when checking but when nil when execute fonction on it. It is really hard to explain and this link: https://getstream.io/blog/fixing-the-billion-dollar-mistake-in-go-by-borrowing-from-rust/ explain better than me on what might occurred.

When setting address directly to var it never happens again