### PR TITLE
Use sync map instead of map with lock

### DIFF
--- a/participant.go
+++ b/participant.go
@@ -18,7 +18,6 @@ type Participant interface {
 	Metadata() string
 }
 
-// map[string]TrackPublication
 type baseParticipant struct {
 	sid        string
 	identity   string


### PR DESCRIPTION
This PR replace map for participants and tracks to sync map for ease usage.

Discussion can be found here: https://github.com/livekit/server-sdk-go/pull/9#issuecomment-887751966

Breaking change for user inside:
- list of participants in a room can't be accessed anymore by getting `Participants` attribute. Instead, user should always use method `GetParticipants()` or `GetParticipant(sid string)`