### PR TITLE
Make AutoSubscribe configurable

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -41,8 +41,8 @@ func NewRTCEngine() *RTCEngine {
 	}
 }
 
-func (e *RTCEngine) Join(url string, token string) (*livekit.JoinResponse, error) {
-	res, err := e.client.Join(url, token)
+func (e *RTCEngine) Join(url string, token string, params *ConnectParams) (*livekit.JoinResponse, error) {
+	res, err := e.client.Join(url, token, params)
 	if err != nil {
 		return nil, err
 	}

--- a/room.go
+++ b/room.go
@@ -63,7 +63,9 @@ func ConnectToRoom(url string, info ConnectInfo, opts ...ConnectOption) (*Room, 
 }
 
 func ConnectToRoomWithToken(url, token string, opts ...ConnectOption) (*Room, error) {
-	params := &ConnectParams{}
+	params := &ConnectParams{
+		AutoSubscribe: true,
+	}
 	for _, opt := range opts {
 		opt(params)
 	}

--- a/signalclient.go
+++ b/signalclient.go
@@ -39,11 +39,20 @@ func NewSignalClient() *SignalClient {
 	return c
 }
 
-func (c *SignalClient) Join(urlPrefix string, token string) (*livekit.JoinResponse, error) {
+func (c *SignalClient) Join(urlPrefix string, token string, params *ConnectParams) (*livekit.JoinResponse, error) {
 	if strings.HasPrefix(urlPrefix, "http") {
 		urlPrefix = strings.Replace(urlPrefix, "http", "ws", 1)
 	}
-	u, err := url.Parse(fmt.Sprintf("%s/rtc?protocol=%d", urlPrefix, PROTOCOL))
+
+	urlSuffix := fmt.Sprintf("/rtc?protocol=%d", PROTOCOL)
+
+	if params.AutoSubscribe {
+		urlSuffix += "&auto_subscribe=1"
+	} else {
+		urlSuffix += "&auto_subscribe=0"
+	}
+
+	u, err := url.Parse(urlPrefix + urlSuffix)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows to set the `AutoSubscribe` parameter when connecting to a room. As discussed on [Slack](https://livekit-users.slack.com/archives/C025KM0S1CK/p1628842764055900).

Usage:

```go
// Disable auto-subcriptions:
room, err := lksdk.ConnectToRoom(host, lksdk.ConnectInfo{
		APIKey:              apiKey,
		APISecret:           apiSecret,
		RoomName:            roomName,
		ParticipantIdentity: identity,
	}, lksdk.WithAutoSubscribe(false))

// using ConnectToRoomWithToken:
room, err := lksdk.ConnectToRoomWithToken(host, token, lksdk.WithAutoSubscribe(false))
```

The current behaviour does not change: `ConnectParams.AutoSubscribe` defaults to `true`.