### PR TITLE
readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ func main() {
   room.Disconnect()
 }
 
-func trackSubscribed(track *webrtc.TrackRemote, publication lksdk.TrackPublication, rp *lksdk.RemoteParticipant) {
+func trackSubscribed(track *webrtc.TrackRemote, publication *lksdk.RemoteTrackPublication, rp *lksdk.RemoteParticipant) {
 
 }
 ```


### PR DESCRIPTION
This fixes a small typo in the README content.

Fixes #37