### PR TITLE
feat: Introduce `trackrecorder` package to save track to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .idea/
 docs/
 bin/
+.vscode/

--- a/pkg/trackrecorder/media.go
+++ b/pkg/trackrecorder/media.go
@@ -1,0 +1,68 @@
+package trackrecorder
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/livekit/server-sdk-go/pkg/samplebuilder"
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/pion/webrtc/v3/pkg/media/h264writer"
+	"github.com/pion/webrtc/v3/pkg/media/ivfwriter"
+	"github.com/pion/webrtc/v3/pkg/media/oggwriter"
+)
+
+type MediaExtension string
+
+const (
+	MediaOGG  MediaExtension = "ogg"
+	MediaIVF  MediaExtension = "ivf"
+	MediaH264 MediaExtension = "h264"
+)
+
+func GetMediaExtension(mimeType string) MediaExtension {
+	if strings.EqualFold(mimeType, webrtc.MimeTypeVP8) {
+		return MediaIVF
+	}
+	if strings.EqualFold(mimeType, webrtc.MimeTypeH264) {
+		return MediaH264
+	}
+	if strings.EqualFold(mimeType, webrtc.MimeTypeOpus) {
+		return MediaOGG
+	}
+	return ""
+}
+
+var ErrCodecNotSupported = errors.New("codec not supported")
+
+func createMediaWriter(out io.Writer, codec webrtc.RTPCodecParameters) (media.Writer, error) {
+	switch GetMediaExtension(codec.MimeType) {
+	case MediaIVF:
+		return ivfwriter.NewWith(out)
+	case MediaH264:
+		return h264writer.NewWith(out), nil
+	case MediaOGG:
+		return oggwriter.NewWith(out, 48000, codec.Channels)
+	default:
+		return nil, ErrCodecNotSupported
+	}
+}
+
+func createSampleBuilder(codec webrtc.RTPCodecParameters, opts ...samplebuilder.Option) *samplebuilder.SampleBuilder {
+	var depacketizer rtp.Depacketizer
+	var maxLate uint16 = 1000
+	switch codec.MimeType {
+	case webrtc.MimeTypeVP8:
+		depacketizer = &codecs.VP8Packet{}
+	case webrtc.MimeTypeH264:
+		depacketizer = &codecs.H264Packet{}
+	case webrtc.MimeTypeOpus:
+		depacketizer = &codecs.OpusPacket{}
+	default:
+		return nil
+	}
+	return samplebuilder.New(maxLate, depacketizer, codec.ClockRate, opts...)
+}

--- a/pkg/trackrecorder/media.go
+++ b/pkg/trackrecorder/media.go
@@ -51,16 +51,26 @@ func createMediaWriter(out io.Writer, codec webrtc.RTPCodecParameters) (media.Wr
 	}
 }
 
+const (
+	maxVideoLate = 1000 // nearly 2s for fhd video
+	maxAudioLate = 200  // 4s for audio
+)
+
 func createSampleBuilder(codec webrtc.RTPCodecParameters, opts ...samplebuilder.Option) *samplebuilder.SampleBuilder {
-	var depacketizer rtp.Depacketizer
-	var maxLate uint16 = 1000
+	var (
+		depacketizer rtp.Depacketizer
+		maxLate      uint16
+	)
 	switch codec.MimeType {
 	case webrtc.MimeTypeVP8:
 		depacketizer = &codecs.VP8Packet{}
+		maxLate = maxVideoLate
 	case webrtc.MimeTypeH264:
 		depacketizer = &codecs.H264Packet{}
+		maxLate = maxVideoLate
 	case webrtc.MimeTypeOpus:
 		depacketizer = &codecs.OpusPacket{}
+		maxLate = maxAudioLate
 	default:
 		return nil
 	}

--- a/pkg/trackrecorder/media_test.go
+++ b/pkg/trackrecorder/media_test.go
@@ -1,0 +1,164 @@
+package trackrecorder
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtensionOpus(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeOpus)
+	require.Equal(t, MediaOGG, ext)
+}
+
+func TestExtensionVP8(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeVP8)
+	require.Equal(t, MediaIVF, ext)
+}
+
+func TestExtensionH264(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeH264)
+	require.Equal(t, MediaH264, ext)
+}
+
+func TestExtensionVP9GetEmptyString(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeVP9)
+	require.Empty(t, ext)
+}
+
+func TestExtensionH265GetEmptyString(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeH265)
+	require.Equal(t, MediaExtension(""), ext)
+}
+
+func TestExtensionAV1GetEmptyString(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeAV1)
+	require.Equal(t, MediaExtension(""), ext)
+}
+
+func TestExtensionG722GetEmptyString(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypeG722)
+	require.Equal(t, MediaExtension(""), ext)
+}
+
+func TestExtensionPCMUGetEmptyString(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypePCMU)
+	require.Equal(t, MediaExtension(""), ext)
+}
+
+func TestExtensionPCMAGetEmptyString(t *testing.T) {
+	ext := GetMediaExtension(webrtc.MimeTypePCMA)
+	require.Equal(t, MediaExtension(""), ext)
+}
+
+func TestGetH264Writer(t *testing.T) {
+	sink := NewBufferSink("")
+	defer sink.Close()
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeH264,
+			Channels: 1,
+		},
+	}
+	mw, err := createMediaWriter(sink, codec)
+	require.NoError(t, err)
+	require.Implements(t, (*media.Writer)(nil), mw)
+}
+
+func TestGetIVFWriter(t *testing.T) {
+	sink := NewBufferSink("")
+	defer sink.Close()
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP8,
+			Channels: 1,
+		},
+	}
+	mw, err := createMediaWriter(sink, codec)
+	require.NoError(t, err)
+	require.Implements(t, (*media.Writer)(nil), mw)
+}
+
+func TestGetOGGWriter(t *testing.T) {
+	sink := NewBufferSink("")
+	defer sink.Close()
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeOpus,
+			Channels: 2,
+		},
+	}
+	mw, err := createMediaWriter(sink, codec)
+	require.NoError(t, err)
+	require.Implements(t, (*media.Writer)(nil), mw)
+}
+
+func TestGetUnsupportedWriter(t *testing.T) {
+	sink := NewBufferSink("")
+	defer sink.Close()
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeAV1,
+			Channels: 1,
+		},
+	}
+	_, err := createMediaWriter(sink, codec)
+	require.ErrorIs(t, ErrCodecNotSupported, err)
+}
+
+func TestVP8SampleBuilder(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP8,
+			Channels: 1,
+		},
+	}
+	sb := createSampleBuilder(codec)
+	require.NotNil(t, sb)
+}
+
+func TestH264SampleBuilder(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeH264,
+			Channels: 1,
+		},
+	}
+	sb := createSampleBuilder(codec)
+	require.NotNil(t, sb)
+}
+
+func TestOpusSampleBuilder(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeOpus,
+			Channels: 1,
+		},
+	}
+	sb := createSampleBuilder(codec)
+	require.NotNil(t, sb)
+}
+
+func TestVP9SampleBuilderUnsupportedCodec(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP9,
+			Channels: 1,
+		},
+	}
+	sb := createSampleBuilder(codec)
+	require.Nil(t, sb)
+}
+
+func TestUnsupportedCodecSampleBuilder(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeAV1,
+			Channels: 1,
+		},
+	}
+	sb := createSampleBuilder(codec)
+	require.Nil(t, sb)
+}

--- a/pkg/trackrecorder/recorder.go
+++ b/pkg/trackrecorder/recorder.go
@@ -1,0 +1,120 @@
+package trackrecorder
+
+import (
+	"context"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/livekit/server-sdk-go/pkg/samplebuilder"
+	"github.com/pion/rtp"
+	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media"
+)
+
+type Recorder interface {
+	Start(context.Context, *webrtc.TrackRemote)
+	Stop()
+	Sink() Sink
+}
+
+type recorder struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	sink Sink
+	mw   media.Writer
+	sb   *samplebuilder.SampleBuilder
+}
+
+func New(filename string, codec webrtc.RTPCodecParameters, opts ...samplebuilder.Option) (Recorder, error) {
+	sink, err := NewFileSink(filename)
+	if err != nil {
+		return nil, err
+	}
+	return NewWith(sink, codec)
+}
+
+func NewWith(sink Sink, codec webrtc.RTPCodecParameters, opts ...samplebuilder.Option) (Recorder, error) {
+	mw, err := createMediaWriter(sink, codec)
+	if err != nil {
+		return nil, err
+	}
+	return &recorder{
+		sink: sink,
+		mw:   mw,
+		sb:   createSampleBuilder(codec, opts...),
+	}, nil
+}
+
+func (r *recorder) Start(ctx context.Context, track *webrtc.TrackRemote) {
+	// Copy context since it's a good practice
+	r.ctx, r.cancel = context.WithCancel(ctx)
+
+	// Start recording in a goroutine
+	go r.startRecording(track)
+}
+
+func (r *recorder) Stop() {
+	// Signal goroutine to stop
+	r.cancel()
+}
+
+func (r *recorder) Sink() Sink {
+	return r.sink
+}
+
+func (r *recorder) startRecording(track *webrtc.TrackRemote) {
+	var err error
+	defer func() {
+		// Log any errors
+		if err != nil {
+			logger.Errorw("recorder error: ", err)
+		}
+
+		// Close sink
+		err = r.sink.Close()
+		if err != nil {
+			logger.Errorw("sink error: ", err)
+		}
+	}()
+
+	// Process RTP packets forever until stopped
+	var packet *rtp.Packet
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+			// Read RTP stream
+			packet, _, err = track.ReadRTP()
+			if err != nil {
+				return
+			}
+
+			// Write packet to sink
+			err = r.writeToSink(packet)
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (r *recorder) writeToSink(p *rtp.Packet) (err error) {
+	// If no sample buffer is used, write directly to sink
+	if r.sb == nil {
+		return r.mw.WriteRTP(p)
+	}
+
+	// If sample buffer is used, write to buffer first
+	r.sb.Push(p)
+
+	// And from the buffered packets, write to sink
+	for _, p := range r.sb.PopPackets() {
+		err = r.mw.WriteRTP(p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/trackrecorder/recorder_test.go
+++ b/pkg/trackrecorder/recorder_test.go
@@ -1,0 +1,275 @@
+package trackrecorder
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/livekit/protocol/auth"
+	lksdk "github.com/livekit/server-sdk-go"
+	"github.com/pion/rtp"
+	"github.com/pion/webrtc/v3"
+	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/stretchr/testify/require"
+)
+
+func mockPacket(id uint16, p []byte) *rtp.Packet {
+	return &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: id,
+		},
+		Payload: p,
+	}
+}
+
+func promoteRecorder(r Recorder) *recorder {
+	rec, ok := r.(*recorder)
+	if !ok {
+		panic("cannot promote Recorder to *recorder")
+	}
+	return rec
+}
+
+func TestCreateRecorderForVideo(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP8,
+		},
+	}
+	sink := NewBufferSink("test")
+
+	tr, err := NewWith(sink, codec)
+	require.NoError(t, err)
+	require.NotNil(t, tr)
+
+	rec := promoteRecorder(tr)
+	require.NotNil(t, rec.sb)
+	require.NotNil(t, rec.mw)
+}
+
+func TestCreateRecorderForAudio(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeOpus,
+			Channels: 2,
+		},
+	}
+	sink := NewBufferSink("test")
+
+	tr, err := NewWith(sink, codec)
+	require.NoError(t, err)
+	require.NotNil(t, tr)
+
+	rec := promoteRecorder(tr)
+	require.NotNil(t, rec.sb)
+	require.NotNil(t, rec.mw)
+}
+
+func TestFailCreateRecorderForUnsupportedCodec(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeAV1,
+		},
+	}
+	sink := NewBufferSink("test")
+	_, err := NewWith(sink, codec)
+	require.ErrorIs(t, err, ErrCodecNotSupported)
+}
+
+func TestWritePacketsWithSampleBuffer(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			// Choose between VP8, H264 and Opus
+			MimeType: webrtc.MimeTypeH264,
+			Channels: 2,
+		},
+	}
+	sink := NewBufferSink("test")
+	tr, _ := NewWith(sink, codec)
+	rec := promoteRecorder(tr)
+	require.NotNil(t, rec.sb)
+
+	// Write multiple packets
+	for i := 0; i < 10; i++ {
+		payload := []byte(fmt.Sprintf("Hello World %d\n!", i))
+		packet := mockPacket(uint16(i), payload)
+		err := rec.writeToSink(packet)
+		require.NoError(t, err)
+	}
+}
+
+func TestWritePacketsWithoutSampleBuffer(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP8,
+			Channels: 1,
+		},
+	}
+	sink := NewBufferSink("test")
+	tr, _ := NewWith(sink, codec)
+	rec := promoteRecorder(tr)
+
+	// Set sample buffer to be nil
+	rec.sb = nil
+
+	// Write multiple packets and still expect no errors
+	for i := 0; i < 10; i++ {
+		payload := []byte(fmt.Sprintf("Hello World %d\n!", i))
+		packet := mockPacket(uint16(i), payload)
+		err := rec.writeToSink(packet)
+		require.NoError(t, err)
+	}
+}
+
+func TestSinkEquality(t *testing.T) {
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP8,
+		},
+	}
+	sink := NewBufferSink("test")
+	tr, _ := NewWith(sink, codec)
+
+	// Expect stored sink is the same as passed sink
+	require.Equal(t, sink, tr.Sink())
+}
+
+func getEnvOrFail(key string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		log.Fatalf("%s not set", key)
+	}
+	return val
+}
+
+func TestRecorderUsageScenario(t *testing.T) {
+	url := getEnvOrFail("LIVEKIT_URL")
+	apiKey := getEnvOrFail("LIVEKIT_API_KEY")
+	apiSecret := getEnvOrFail("LIVEKIT_API_SECRET")
+	testRoomName := "livekit-egress-test"
+	TRUE := true
+	FALSE := false
+	participantID := "lk-participant"
+	recorderID := "lk-recorder"
+
+	// -----
+	// Generate access tokens for participant and recorder
+	// -----
+
+	pAT := auth.NewAccessToken(apiKey, apiSecret)
+	pGrant := &auth.VideoGrant{
+		RoomJoin:     true,
+		Room:         testRoomName,
+		CanPublish:   &TRUE,
+		CanSubscribe: &TRUE,
+	}
+	pAT.AddGrant(pGrant).SetIdentity(participantID).SetValidFor(time.Hour)
+	pToken, err := pAT.ToJWT()
+	require.NoError(t, err)
+
+	rAT := auth.NewAccessToken(apiKey, apiSecret)
+	rGrant := &auth.VideoGrant{
+		RoomJoin:       true,
+		Room:           testRoomName,
+		CanPublish:     &FALSE,
+		CanPublishData: &FALSE,
+		CanSubscribe:   &TRUE,
+		Hidden:         true,
+		Recorder:       true,
+	}
+	rAT.AddGrant(rGrant).SetIdentity(recorderID).SetValidFor(time.Hour)
+	rToken, err := rAT.ToJWT()
+	require.NoError(t, err)
+
+	// -----
+	// Connect to room
+	// -----
+
+	var pRoom, rRoom *lksdk.Room
+
+	pRoom, err = lksdk.ConnectToRoomWithToken(url, pToken)
+	require.NoError(t, err)
+	defer pRoom.Disconnect()
+
+	rRoom, err = lksdk.ConnectToRoomWithToken(url, rToken)
+	require.NoError(t, err)
+	defer rRoom.Disconnect()
+
+	// -----
+	// Create track for participant to publish
+	// -----
+
+	preferredCodec := webrtc.MimeTypeVP8
+
+	sampleTrack, err := lksdk.NewLocalSampleTrack(webrtc.RTPCodecCapability{
+		MimeType:  preferredCodec,
+		ClockRate: 90000,
+		Channels:  1,
+	})
+	require.NoError(t, err)
+
+	publication, err := pRoom.LocalParticipant.PublishTrack(sampleTrack, &lksdk.TrackPublicationOptions{
+		Name: participantID + "-video",
+	})
+	require.NoError(t, err)
+
+	// -----
+	// Publish static media packets until we receive stop signal
+	// -----
+
+	sampleProvider := lksdk.NewNullSampleProvider(90000)
+	sampleDone := make(chan struct{}, 1)
+	go func() {
+		var sample media.Sample
+		for {
+			select {
+			case <-sampleDone:
+				pRoom.LocalParticipant.UnpublishTrack(publication.SID())
+				return
+			default:
+				sample, err = sampleProvider.NextSample()
+				require.NoError(t, err)
+				sampleTrack.WriteSample(sample, nil)
+			}
+		}
+	}()
+
+	// -----
+	// Create recorder since we know the codec we'll be publishing
+	// -----
+	ctx := context.Background()
+	codec := webrtc.RTPCodecParameters{
+		RTPCodecCapability: webrtc.RTPCodecCapability{
+			MimeType: webrtc.MimeTypeVP8,
+		},
+	}
+	var rec Recorder
+	rec, err = New(participantID+"-video.ivf", codec)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	rRoom.Callback.OnTrackSubscribed = func(track *webrtc.TrackRemote, publication *lksdk.RemoteTrackPublication, rp *lksdk.RemoteParticipant) {
+		require.NotNil(t, rec)
+		rec.Start(ctx, track)
+	}
+
+	// -----
+	// Let participant publish track for a while,
+	// then stop publishing and recording
+	// -----
+	time.Sleep(time.Second * 5)
+	close(sampleDone)
+
+	require.NotNil(t, rec)
+	rec.Stop()
+
+	// In real-world scenario, once Stop() is invoked, the main function will keep running.
+	// Let's introduce a small delay for the recorder to finish gracefully and improve code coverage
+	time.Sleep(time.Second * 1)
+
+	// Remember to remove video file afterwards
+	os.Remove(participantID + "-video.ivf")
+}

--- a/pkg/trackrecorder/sink.go
+++ b/pkg/trackrecorder/sink.go
@@ -1,0 +1,44 @@
+package trackrecorder
+
+import (
+	"os"
+
+	"github.com/pion/transport/packetio"
+)
+
+type Sink interface {
+	Name() string
+	Read([]byte) (int, error)
+	Write([]byte) (int, error)
+	Close() error
+}
+
+func NewFileSink(filename string) (Sink, error) {
+	return os.Create(filename)
+}
+
+type bufferSink struct {
+	id     string
+	buffer *packetio.Buffer
+}
+
+func NewBufferSink(id string) Sink {
+	buffer := packetio.NewBuffer()
+	return &bufferSink{id, buffer}
+}
+
+func (s *bufferSink) Name() string {
+	return s.id
+}
+
+func (s *bufferSink) Read(p []byte) (int, error) {
+	return s.buffer.Read(p)
+}
+
+func (s *bufferSink) Write(p []byte) (int, error) {
+	return s.buffer.Write(p)
+}
+
+func (s *bufferSink) Close() error {
+	return s.buffer.Close()
+}

--- a/pkg/trackrecorder/sink_test.go
+++ b/pkg/trackrecorder/sink_test.go
@@ -1,0 +1,69 @@
+package trackrecorder
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateFileSink(t *testing.T) {
+	filename := "testing.txt"
+	sink, err := NewFileSink(filename)
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+	require.Equal(t, filename, sink.Name())
+
+	// Cleanup
+	err = sink.Close()
+	require.NoError(t, err)
+	os.Remove(filename)
+}
+
+func TestWriteFileSink(t *testing.T) {
+	filename := "testing.txt"
+	sink, _ := NewFileSink(filename)
+	defer func() {
+		sink.Close()
+		os.Remove(filename)
+	}()
+
+	n, err := sink.Write([]byte("Hello"))
+	require.NoError(t, err)
+	require.Equal(t, len("Hello"), n)
+}
+
+func TestCreateBufferSink(t *testing.T) {
+	id := "testing"
+	sink := NewBufferSink(id)
+	require.NotNil(t, sink)
+	require.Equal(t, id, sink.Name())
+
+	err := sink.Close()
+	require.NoError(t, err)
+}
+
+func TestWriteBufferSink(t *testing.T) {
+	id := "testing"
+	sink := NewBufferSink(id)
+	defer sink.Close()
+
+	p := []byte{'c', 'g', 'c'}
+	n, err := sink.Write(p)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+}
+
+func TestReadBufferSink(t *testing.T) {
+	id := "testing"
+	sink := NewBufferSink(id)
+	defer sink.Close()
+
+	p := []byte{'c', 'g', 'c'}
+	r := make([]byte, 3)
+	sink.Write(p)
+	n, err := sink.Read(r)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "cgc", string(r))
+}


### PR DESCRIPTION
Continuation from https://github.com/livekit/server-sdk-go/pull/32 as there were multiple significant changes to the SDK. The track recorder now uses context as it is preferred to cancel goroutines. The previous implementation used channels, which is fine, but there were instances where blocking occurs. Goroutine seems more idiomatic as well. 

The package also exposes some helpers, such as to determine extension based on codec. I can write an example of how to use the new package (if approved), but not sure if I should make a new example or improve on existing one in `examples/filesaver`.