### PR TITLE
Accept either ws: or http: interchangeably

### DIFF
--- a/egressclient.go
+++ b/egressclient.go
@@ -14,6 +14,7 @@ type EgressClient struct {
 }
 
 func NewEgressClient(url string, apiKey string, secretKey string) *EgressClient {
+	url = ToHttpURL(url)
 	client := livekit.NewEgressProtobufClient(url, &http.Client{})
 	return &EgressClient{
 		Egress: client,

--- a/roomclient.go
+++ b/roomclient.go
@@ -14,6 +14,7 @@ type RoomServiceClient struct {
 }
 
 func NewRoomServiceClient(url string, apiKey string, secretKey string) *RoomServiceClient {
+	url = ToHttpURL(url)
 	client := livekit.NewRoomServiceProtobufClient(url, &http.Client{})
 	return &RoomServiceClient{
 		RoomService: client,

--- a/signalclient.go
+++ b/signalclient.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 	"sync"
 
 	"github.com/gorilla/websocket"
-	"github.com/livekit/protocol/livekit"
 	"github.com/pion/webrtc/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/protocol/livekit"
 )
 
 const PROTOCOL = 7
@@ -41,10 +41,7 @@ func NewSignalClient() *SignalClient {
 }
 
 func (c *SignalClient) Join(urlPrefix string, token string, params *ConnectParams) (*livekit.JoinResponse, error) {
-	if strings.HasPrefix(urlPrefix, "http") {
-		urlPrefix = strings.Replace(urlPrefix, "http", "ws", 1)
-	}
-
+	urlPrefix = ToWebsocketURL(urlPrefix)
 	urlSuffix := fmt.Sprintf("/rtc?protocol=%d&sdk=go&version=%s", PROTOCOL, Version)
 
 	if params.AutoSubscribe {

--- a/utils.go
+++ b/utils.go
@@ -2,10 +2,12 @@ package lksdk
 
 import (
 	"encoding/json"
+	"strings"
 
-	"github.com/livekit/protocol/livekit"
 	"github.com/pion/webrtc/v3"
 	"github.com/thoas/go-funk"
+
+	"github.com/livekit/protocol/livekit"
 )
 
 func ToProtoSessionDescription(sd webrtc.SessionDescription) *livekit.SessionDescription {
@@ -56,4 +58,18 @@ func FromProtoIceServers(iceservers []*livekit.ICEServer) []webrtc.ICEServer {
 		}
 	})
 	return servers.([]webrtc.ICEServer)
+}
+
+func ToHttpURL(url string) string {
+	if strings.HasPrefix(url, "ws") {
+		return strings.Replace(url, "ws", "http", 1)
+	}
+	return url
+}
+
+func ToWebsocketURL(url string) string {
+	if strings.HasPrefix(url, "http") {
+		return strings.Replace(url, "http", "ws", 1)
+	}
+	return url
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,25 @@
+package lksdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToHttpURL(t *testing.T) {
+	t.Run("websocket input", func(t *testing.T) {
+		require.Equal(t, "http://url.com", ToHttpURL("ws://url.com"))
+	})
+	t.Run("https input", func(t *testing.T) {
+		require.Equal(t, "https://url.com", ToHttpURL("https://url.com"))
+	})
+}
+
+func TestToWebsocketURL(t *testing.T) {
+	t.Run("websocket input", func(t *testing.T) {
+		require.Equal(t, "ws://url.com", ToWebsocketURL("ws://url.com"))
+	})
+	t.Run("https input", func(t *testing.T) {
+		require.Equal(t, "wss://url.com", ToWebsocketURL("https://url.com"))
+	})
+}


### PR DESCRIPTION
RoomService requires an HTTP url, but connecting to a room requires
WS. This is confusing for the end user. We are handling the differences
within the SDK to make this easier.

Fixes #42 