### PR TITLE
returning an error when track is not found in `UnpublishTrack`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrUnsupportedFileType      = errors.New("FileSampleProvider does not support this mime type")
 	ErrUnsupportedSimulcastKind = errors.New("simulcast is only supported for video")
 	ErrInvalidSimulcastTrack    = errors.New("simulcast track was not initiated correctly")
+	ErrCannotFindTrack          = errors.New("Could not find the track")
 )

--- a/errors.go
+++ b/errors.go
@@ -9,5 +9,5 @@ var (
 	ErrUnsupportedFileType      = errors.New("FileSampleProvider does not support this mime type")
 	ErrUnsupportedSimulcastKind = errors.New("simulcast is only supported for video")
 	ErrInvalidSimulcastTrack    = errors.New("simulcast track was not initiated correctly")
-	ErrCannotFindTrack          = errors.New("Could not find the track")
+	ErrCannotFindTrack          = errors.New("could not find the track")
 )

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -241,7 +241,7 @@ func (p *LocalParticipant) PublishData(data []byte, kind livekit.DataPacket_Kind
 func (p *LocalParticipant) UnpublishTrack(sid string) error {
 	obj, loaded := p.tracks.LoadAndDelete(sid)
 	if !loaded {
-		return nil
+		return ErrCannotFindTrack
 	}
 	p.audioTracks.Delete(sid)
 	p.videoTracks.Delete(sid)


### PR DESCRIPTION
fixes #55 

when `UnpublishTrack` is getting called and the track with is not found, it shall return an error.