### PR TITLE
Publish from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,30 @@ The above encodes H264 with CBS of 2Mbps with a minimum keyframe interval of 120
 file := "video.ivf"
 track, err := lksdk.NewLocalFileTrack(file,
 	// control FPS to ensure synchronization
-	lksdk.FileTrackWithFrameDuration(33 * time.Millisecond),
-	lksdk.FileTrackWithOnWriteComplete(func() { fmt.Println("track finished") }),
+	lksdk.MediaTrackWithFrameDuration(33 * time.Millisecond),
+	lksdk.MediaTrackWithOnWriteComplete(func() { fmt.Println("track finished") }),
 )
 if err != nil {
     return err
 }
 if _, err = room.LocalParticipant.PublishTrack(track, file); err != nil {
+    return err
+}
+```
+
+### Publish from io.ReadCloser implementation
+
+```go
+// - `in` implements io.ReadCloser, such as buffer or file
+// - `mime` has to be one of webrtc.MimeType...
+track, err := lksdk.NewLocalReaderTrack(in, mime,
+	lksdk.MediaTrackWithFrameDuration(33 * time.Millisecond),
+	lksdk.MediaTrackWithOnWriteComplete(func() { fmt.Println("track finished") }),
+)
+if err != nil {
+	return err
+}
+if _, err = room.LocalParticipant.PublishTrack(track, &lksdk.TrackPublicationOptions{}); err != nil {
     return err
 }
 ```

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ var (
 	ErrConnectionTimeout        = errors.New("could not connect after timeout")
 	ErrTrackPublishTimeout      = errors.New("timed out publishing track")
 	ErrCannotDetermineMime      = errors.New("cannot determine mimetype from file extension")
-	ErrUnsupportedFileType      = errors.New("MediaSampleProvider does not support this mime type")
+	ErrUnsupportedFileType      = errors.New("ReaderSampleProvider does not support this mime type")
 	ErrUnsupportedSimulcastKind = errors.New("simulcast is only supported for video")
 	ErrInvalidSimulcastTrack    = errors.New("simulcast track was not initiated correctly")
 	ErrCannotFindTrack          = errors.New("could not find the track")

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ var (
 	ErrConnectionTimeout        = errors.New("could not connect after timeout")
 	ErrTrackPublishTimeout      = errors.New("timed out publishing track")
 	ErrCannotDetermineMime      = errors.New("cannot determine mimetype from file extension")
-	ErrUnsupportedFileType      = errors.New("FileSampleProvider does not support this mime type")
+	ErrUnsupportedFileType      = errors.New("MediaSampleProvider does not support this mime type")
 	ErrUnsupportedSimulcastKind = errors.New("simulcast is only supported for video")
 	ErrInvalidSimulcastTrack    = errors.New("simulcast track was not initiated correctly")
 	ErrCannotFindTrack          = errors.New("could not find the track")

--- a/mediasampleprovider.go
+++ b/mediasampleprovider.go
@@ -94,6 +94,7 @@ func NewLocalFileTrack(file string, options ...MediaSampleProviderOption) (*Loca
 }
 
 // NewLocalReaderTrack uses io.ReadCloser interface to adapt to various ingress types
+// - mime: has to be one of webrtc.MimeType...
 func NewLocalReaderTrack(in io.ReadCloser, mime string, options ...MediaSampleProviderOption) (*LocalSampleTrack, error) {
 	provider := &MediaSampleProvider{
 		Mime:   mime,


### PR DESCRIPTION
- FileSampleProvider refactored to MediaSampleProvider, which reads from `io.ReadCloser` interface to handle multiple egress types
- Expose 2 methods to create track: `NewLocalFileTrack` (which does the same thing as before) and `NewLocalReaderTrack` (which is more low-level; accepts `io.ReadCloser`)
- Publishing from stdin is as simple as `NewLocalReaderTrack(os.Stdin, ...)`