### PR TITLE
Fix signal client dropping initial messages

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -3,11 +3,12 @@ package lksdk
 import (
 	"time"
 
-	"github.com/livekit/protocol/livekit"
 	"github.com/pion/webrtc/v3"
 	"go.uber.org/atomic"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/livekit/protocol/livekit"
 )
 
 const reliableDataChannelName = "_reliable"
@@ -59,6 +60,8 @@ func (e *RTCEngine) Join(url string, token string, params *ConnectParams) (*live
 	if err = e.configure(res); err != nil {
 		return nil, err
 	}
+
+	e.client.Start()
 
 	// send offer
 	if !res.SubscriberPrimary {


### PR DESCRIPTION
When the server sends offer and subsequent details to the client too
quickly, SignalClient would process those messages before callbacks
have been set up.