### PR TITLE
Update remote participant info on a recreate

### DIFF
--- a/localparticipant.go
+++ b/localparticipant.go
@@ -270,10 +270,6 @@ func (p *LocalParticipant) GetPublisherPeerConnection() *webrtc.PeerConnection {
 
 func (p *LocalParticipant) updateInfo(info *livekit.ParticipantInfo) {
 	p.baseParticipant.updateInfo(info, p)
-	p.lock.Lock()
-	p.sid = info.Sid
-	p.identity = info.Identity
-	p.lock.Unlock()
 
 	// detect tracks that have been muted remotely, and apply changes
 	for _, ti := range info.Tracks {


### PR DESCRIPTION
A new remote participant could be created when handling OnTrack.
This could happen with fast connect.
Remote participant could also be added from join response.
Update participant info when re-creating.

Also, use map with lock for remote participants as there were
range calls on sync.Map in several places.

Before this, there were track subscription failures due to fast connect.