### PR TITLE
Makes livekit.RoomService unexported to avoid confusion

### DIFF
--- a/egressclient.go
+++ b/egressclient.go
@@ -9,7 +9,7 @@ import (
 )
 
 type EgressClient struct {
-	livekit.Egress
+	egressClient livekit.Egress
 	authBase
 }
 
@@ -17,7 +17,7 @@ func NewEgressClient(url string, apiKey string, secretKey string) *EgressClient 
 	url = ToHttpURL(url)
 	client := livekit.NewEgressProtobufClient(url, &http.Client{})
 	return &EgressClient{
-		Egress: client,
+		egressClient: client,
 		authBase: authBase{
 			apiKey:    apiKey,
 			apiSecret: secretKey,
@@ -30,7 +30,7 @@ func (c *EgressClient) StartRoomCompositeEgress(ctx context.Context, req *liveki
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.StartRoomCompositeEgress(ctx, req)
+	return c.egressClient.StartRoomCompositeEgress(ctx, req)
 }
 
 func (c *EgressClient) StartTrackCompositeEgress(ctx context.Context, req *livekit.TrackCompositeEgressRequest) (*livekit.EgressInfo, error) {
@@ -38,7 +38,7 @@ func (c *EgressClient) StartTrackCompositeEgress(ctx context.Context, req *livek
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.StartTrackCompositeEgress(ctx, req)
+	return c.egressClient.StartTrackCompositeEgress(ctx, req)
 }
 
 func (c *EgressClient) StartTrackEgress(ctx context.Context, req *livekit.TrackEgressRequest) (*livekit.EgressInfo, error) {
@@ -46,7 +46,7 @@ func (c *EgressClient) StartTrackEgress(ctx context.Context, req *livekit.TrackE
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.StartTrackEgress(ctx, req)
+	return c.egressClient.StartTrackEgress(ctx, req)
 }
 
 func (c *EgressClient) StartWebEgress(ctx context.Context, req *livekit.WebEgressRequest) (*livekit.EgressInfo, error) {
@@ -54,7 +54,7 @@ func (c *EgressClient) StartWebEgress(ctx context.Context, req *livekit.WebEgres
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.StartWebEgress(ctx, req)
+	return c.egressClient.StartWebEgress(ctx, req)
 }
 
 func (c *EgressClient) UpdateLayout(ctx context.Context, req *livekit.UpdateLayoutRequest) (*livekit.EgressInfo, error) {
@@ -62,7 +62,7 @@ func (c *EgressClient) UpdateLayout(ctx context.Context, req *livekit.UpdateLayo
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.UpdateLayout(ctx, req)
+	return c.egressClient.UpdateLayout(ctx, req)
 }
 
 func (c *EgressClient) UpdateStream(ctx context.Context, req *livekit.UpdateStreamRequest) (*livekit.EgressInfo, error) {
@@ -70,7 +70,7 @@ func (c *EgressClient) UpdateStream(ctx context.Context, req *livekit.UpdateStre
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.UpdateStream(ctx, req)
+	return c.egressClient.UpdateStream(ctx, req)
 }
 
 func (c *EgressClient) ListEgress(ctx context.Context, req *livekit.ListEgressRequest) (*livekit.ListEgressResponse, error) {
@@ -78,7 +78,7 @@ func (c *EgressClient) ListEgress(ctx context.Context, req *livekit.ListEgressRe
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.ListEgress(ctx, req)
+	return c.egressClient.ListEgress(ctx, req)
 }
 
 func (c *EgressClient) StopEgress(ctx context.Context, req *livekit.StopEgressRequest) (*livekit.EgressInfo, error) {
@@ -86,5 +86,5 @@ func (c *EgressClient) StopEgress(ctx context.Context, req *livekit.StopEgressRe
 	if err != nil {
 		return nil, err
 	}
-	return c.Egress.StopEgress(ctx, req)
+	return c.egressClient.StopEgress(ctx, req)
 }

--- a/ingressclient.go
+++ b/ingressclient.go
@@ -9,7 +9,7 @@ import (
 )
 
 type IngressClient struct {
-	livekit.Ingress
+	ingressClient livekit.Ingress
 	authBase
 }
 
@@ -17,7 +17,7 @@ func NewIngressClient(url string, apiKey string, secretKey string) *IngressClien
 	url = ToHttpURL(url)
 	client := livekit.NewIngressProtobufClient(url, &http.Client{})
 	return &IngressClient{
-		Ingress: client,
+		ingressClient: client,
 		authBase: authBase{
 			apiKey:    apiKey,
 			apiSecret: secretKey,
@@ -34,7 +34,7 @@ func (c *IngressClient) CreateIngress(ctx context.Context, in *livekit.CreateIng
 	if err != nil {
 		return nil, err
 	}
-	return c.Ingress.CreateIngress(ctx, in)
+	return c.ingressClient.CreateIngress(ctx, in)
 }
 
 func (c *IngressClient) UpdateIngress(ctx context.Context, in *livekit.UpdateIngressRequest) (*livekit.IngressInfo, error) {
@@ -46,7 +46,7 @@ func (c *IngressClient) UpdateIngress(ctx context.Context, in *livekit.UpdateIng
 	if err != nil {
 		return nil, err
 	}
-	return c.Ingress.UpdateIngress(ctx, in)
+	return c.ingressClient.UpdateIngress(ctx, in)
 }
 
 func (c *IngressClient) ListIngress(ctx context.Context, in *livekit.ListIngressRequest) (*livekit.ListIngressResponse, error) {
@@ -58,7 +58,7 @@ func (c *IngressClient) ListIngress(ctx context.Context, in *livekit.ListIngress
 	if err != nil {
 		return nil, err
 	}
-	return c.Ingress.ListIngress(ctx, in)
+	return c.ingressClient.ListIngress(ctx, in)
 }
 
 func (c *IngressClient) DeleteIngress(ctx context.Context, in *livekit.DeleteIngressRequest) (*livekit.IngressInfo, error) {
@@ -70,5 +70,5 @@ func (c *IngressClient) DeleteIngress(ctx context.Context, in *livekit.DeleteIng
 	if err != nil {
 		return nil, err
 	}
-	return c.Ingress.DeleteIngress(ctx, in)
+	return c.ingressClient.DeleteIngress(ctx, in)
 }

--- a/roomclient.go
+++ b/roomclient.go
@@ -2,6 +2,7 @@ package lksdk
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/livekit/protocol/auth"
@@ -9,15 +10,16 @@ import (
 )
 
 type RoomServiceClient struct {
-	livekit.RoomService
+	roomService livekit.RoomService
 	authBase
 }
 
 func NewRoomServiceClient(url string, apiKey string, secretKey string) *RoomServiceClient {
+	fmt.Println("working?")
 	url = ToHttpURL(url)
 	client := livekit.NewRoomServiceProtobufClient(url, &http.Client{})
 	return &RoomServiceClient{
-		RoomService: client,
+		roomService: client,
 		authBase: authBase{
 			apiKey:    apiKey,
 			apiSecret: secretKey,
@@ -31,7 +33,7 @@ func (c *RoomServiceClient) CreateRoom(ctx context.Context, req *livekit.CreateR
 		return nil, err
 	}
 
-	return c.RoomService.CreateRoom(ctx, req)
+	return c.roomService.CreateRoom(ctx, req)
 }
 
 func (c *RoomServiceClient) ListRooms(ctx context.Context, req *livekit.ListRoomsRequest) (*livekit.ListRoomsResponse, error) {
@@ -40,7 +42,7 @@ func (c *RoomServiceClient) ListRooms(ctx context.Context, req *livekit.ListRoom
 		return nil, err
 	}
 
-	return c.RoomService.ListRooms(ctx, req)
+	return c.roomService.ListRooms(ctx, req)
 }
 
 func (c *RoomServiceClient) DeleteRoom(ctx context.Context, req *livekit.DeleteRoomRequest) (*livekit.DeleteRoomResponse, error) {
@@ -49,7 +51,7 @@ func (c *RoomServiceClient) DeleteRoom(ctx context.Context, req *livekit.DeleteR
 		return nil, err
 	}
 
-	return c.RoomService.DeleteRoom(ctx, req)
+	return c.roomService.DeleteRoom(ctx, req)
 }
 
 func (c *RoomServiceClient) ListParticipants(ctx context.Context, req *livekit.ListParticipantsRequest) (*livekit.ListParticipantsResponse, error) {
@@ -58,7 +60,7 @@ func (c *RoomServiceClient) ListParticipants(ctx context.Context, req *livekit.L
 		return nil, err
 	}
 
-	return c.RoomService.ListParticipants(ctx, req)
+	return c.roomService.ListParticipants(ctx, req)
 }
 
 func (c *RoomServiceClient) GetParticipant(ctx context.Context, req *livekit.RoomParticipantIdentity) (*livekit.ParticipantInfo, error) {
@@ -67,7 +69,7 @@ func (c *RoomServiceClient) GetParticipant(ctx context.Context, req *livekit.Roo
 		return nil, err
 	}
 
-	return c.RoomService.GetParticipant(ctx, req)
+	return c.roomService.GetParticipant(ctx, req)
 }
 
 func (c *RoomServiceClient) RemoveParticipant(ctx context.Context, req *livekit.RoomParticipantIdentity) (*livekit.RemoveParticipantResponse, error) {
@@ -76,7 +78,7 @@ func (c *RoomServiceClient) RemoveParticipant(ctx context.Context, req *livekit.
 		return nil, err
 	}
 
-	return c.RoomService.RemoveParticipant(ctx, req)
+	return c.roomService.RemoveParticipant(ctx, req)
 }
 
 func (c *RoomServiceClient) MutePublishedTrack(ctx context.Context, req *livekit.MuteRoomTrackRequest) (*livekit.MuteRoomTrackResponse, error) {
@@ -85,7 +87,7 @@ func (c *RoomServiceClient) MutePublishedTrack(ctx context.Context, req *livekit
 		return nil, err
 	}
 
-	return c.RoomService.MutePublishedTrack(ctx, req)
+	return c.roomService.MutePublishedTrack(ctx, req)
 }
 
 func (c *RoomServiceClient) UpdateParticipant(ctx context.Context, req *livekit.UpdateParticipantRequest) (*livekit.ParticipantInfo, error) {
@@ -93,7 +95,7 @@ func (c *RoomServiceClient) UpdateParticipant(ctx context.Context, req *livekit.
 	if err != nil {
 		return nil, err
 	}
-	return c.RoomService.UpdateParticipant(ctx, req)
+	return c.roomService.UpdateParticipant(ctx, req)
 }
 
 func (c *RoomServiceClient) UpdateSubscriptions(ctx context.Context, req *livekit.UpdateSubscriptionsRequest) (*livekit.UpdateSubscriptionsResponse, error) {
@@ -101,7 +103,7 @@ func (c *RoomServiceClient) UpdateSubscriptions(ctx context.Context, req *liveki
 	if err != nil {
 		return nil, err
 	}
-	return c.RoomService.UpdateSubscriptions(ctx, req)
+	return c.roomService.UpdateSubscriptions(ctx, req)
 }
 
 func (c *RoomServiceClient) UpdateRoomMetadata(ctx context.Context, req *livekit.UpdateRoomMetadataRequest) (*livekit.Room, error) {
@@ -109,7 +111,7 @@ func (c *RoomServiceClient) UpdateRoomMetadata(ctx context.Context, req *livekit
 	if err != nil {
 		return nil, err
 	}
-	return c.RoomService.UpdateRoomMetadata(ctx, req)
+	return c.roomService.UpdateRoomMetadata(ctx, req)
 }
 
 func (c *RoomServiceClient) SendData(ctx context.Context, req *livekit.SendDataRequest) (*livekit.SendDataResponse, error) {
@@ -117,7 +119,7 @@ func (c *RoomServiceClient) SendData(ctx context.Context, req *livekit.SendDataR
 	if err != nil {
 		return nil, err
 	}
-	return c.RoomService.SendData(ctx, req)
+	return c.roomService.SendData(ctx, req)
 }
 
 func (c *RoomServiceClient) CreateToken() *auth.AccessToken {


### PR DESCRIPTION
Hi,
Since methods of `RoomServiceClient`, in `server-sdk-go`, are adding authentication, exporting `RoomService` would make it confusing to use. 

If i call `client.RoomService.ListRooms(context.Background(), &livekit.ListRoomsRequest{})` i would get an authentication error, However calling `client.ListRooms(context.Background(), &livekit.ListRoomsRequest{})` will work. 

This issue exists for other clients as well and if you are agree with me i would be happy to make this change to all the clients.

Thanks.