### PR TITLE
return the lk api error message on signal connection failures

### DIFF
--- a/signalclient.go
+++ b/signalclient.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"sync"
 
@@ -81,9 +82,15 @@ func (c *SignalClient) Join(urlPrefix string, token string, params *ConnectParam
 	}
 
 	header := newHeaderWithToken(token)
-	conn, _, err := websocket.DefaultDialer.Dial(u.String(), header)
+	conn, dialRes, err := websocket.DefaultDialer.Dial(u.String(), header)
 	if err != nil {
-		return nil, fmt.Errorf("%w dial error: %s", ErrSignalError, err.Error())
+		errorMessage := err.Error()
+		if dialRes != nil {
+			if b, err := ioutil.ReadAll(dialRes.Body); err == nil && len(b) > 0 {
+				errorMessage = string(b)
+			}
+		}
+		return nil, fmt.Errorf("%w dial error: %s", ErrSignalError, errorMessage)
 	}
 	c.isClosed.Store(false)
 	c.conn.Store(conn)


### PR DESCRIPTION
when the singalling connection fails the error currently contains the http error message (ie bad handshake) which isn't very useful. instead return the response body which contains the api error (ie authentication failed because etc...)