### PR TITLE
correctly handle LocalParticipant on update

### DIFF
--- a/room.go
+++ b/room.go
@@ -333,6 +333,11 @@ func (r *Room) handleDataReceived(userPacket *livekit.UserPacket) {
 
 func (r *Room) handleParticipantUpdate(participants []*livekit.ParticipantInfo) {
 	for _, pi := range participants {
+		if pi.Sid == r.LocalParticipant.SID() || pi.Identity == r.LocalParticipant.Identity() {
+			r.LocalParticipant.updateInfo(pi)
+			continue
+		}
+
 		p := r.GetParticipant(pi.Sid)
 		isNew := p == nil
 


### PR DESCRIPTION
This caused all remote events ( TrackPublished, ParticipantConnected, TrackSubscribed, ... ) to be called for local resources.
Also it can be a breaking change for our users because `len(room.GetParticipant())` is now decremented by 1