### PR TITLE
correctly read opus packets duration

### DIFF
--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -40,8 +40,7 @@ type ReaderSampleProvider struct {
 	h264reader *h264reader.H264Reader
 
 	// for ogg
-	oggreader   *oggreader.OggReader
-	lastGranule uint64
+	oggreader *oggreader.OggReader
 }
 
 type ReaderSampleProviderOption func(*ReaderSampleProvider)

--- a/utils.go
+++ b/utils.go
@@ -7,8 +7,59 @@ import (
 	"github.com/pion/webrtc/v3"
 	"github.com/thoas/go-funk"
 
+	"errors"
 	"github.com/livekit/protocol/livekit"
+	"time"
 )
+
+var (
+	ErrInvalidOpusPacket = errors.New("invalid opus packet")
+)
+
+// Parse the duration of a an OpusPacket
+// https://www.rfc-editor.org/rfc/rfc6716#section-3.1
+func ParseOpusPacketDuration(data []byte) (time.Duration, error) {
+	durations := [32]uint64{
+		480, 960, 1920, 2880, // Silk-Only
+		480, 960, 1920, 2880, // Silk-Only
+		480, 960, 1920, 2880, // Silk-Only
+		480, 960, // Hybrid
+		480, 960, // Hybrid
+		120, 240, 480, 960, // Celt-Only
+		120, 240, 480, 960, // Celt-Only
+		120, 240, 480, 960, // Celt-Only
+		120, 240, 480, 960, // Celt-Only
+	}
+
+	if len(data) < 1 {
+		return 0, ErrInvalidOpusPacket
+	}
+
+	toc := data[0]
+	var nframes int
+	switch toc & 3 {
+	case 0:
+		nframes = 1
+	case 1:
+		nframes = 2
+	case 2:
+		nframes = 2
+	case 3:
+		if len(data) < 2 {
+			return 0, ErrInvalidOpusPacket
+		}
+		nframes = int(data[1] & 63)
+	}
+
+	frameDuration := int64(durations[toc>>3])
+	duration := int64(nframes * int(frameDuration))
+	if duration > 5760 { // 120ms
+		return 0, ErrInvalidOpusPacket
+	}
+
+	ms := duration * 1000 / 48000
+	return time.Duration(ms) * time.Millisecond, nil
+}
 
 func ToProtoSessionDescription(sd webrtc.SessionDescription) *livekit.SessionDescription {
 	return &livekit.SessionDescription{


### PR DESCRIPTION
This may fix #192 
Also the oggreader should correctly read the next opus packet instead of the page.
I will implement that when I have the time 