### PR TITLE
More granular errors (actually only one more).

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrCannotFindTrack          = errors.New("could not find the track")
 	ErrInvalidParameter         = errors.New("invalid parameter")
 	ErrCannotConnectSignal      = errors.New("could not establish signal connection")
+	ErrCannotDialSignal         = errors.New("could not dial signal connection")
 )

--- a/signalclient.go
+++ b/signalclient.go
@@ -83,12 +83,14 @@ func (c *SignalClient) Join(urlPrefix string, token string, params *ConnectParam
 	header := newHeaderWithToken(token)
 	conn, hresp, err := websocket.DefaultDialer.Dial(u.String(), header)
 	if err != nil {
+		// TODO-REMOVE - logging to check if we can distinguish Dial error vs app error. Remove log below also after collecting some data
 		logger.Errorw("error establishing signal connection", err, "httpResponse", hresp)
 		// use validate endpoint to get the actual error
 		validateSuffix := strings.Replace(urlSuffix, "/rtc", "/rtc/validate", 1)
 
 		hresp, err := http.Get(ToHttpURL(urlPrefix) + validateSuffix)
 		if err != nil {
+			logger.Errorw("error getting validation", err, "httpResponse", hresp)
 			return nil, ErrCannotDialSignal
 		} else if hresp.StatusCode == http.StatusOK {
 			// no specific errors to return if validate succeeds


### PR DESCRIPTION
Main goal of this is to distinguish whether connection to the controller (signal channel) failed or if that succeeded, but could not get a media node for the connection.

In the current scheme of things, if websocket dial fails, a simple http.Get is done on `/rtc/validate` endpoint to understand the error better.

Just adding one more error return type.
I think if the error is `ErrCannotConnectSignal`, that is the one case where the media node could not be found.

Also logging the websocket dial error and HTTP response as that method can return the HTTP response (if any) along with error `ErrBadHandshake` for things like redirect, auth etc (https://github.com/gorilla/websocket/blob/af47554f343b4675b30172ac301638d350db34a5/client.go#L149). Want to observe what that returns and check if we can do an early return for dial failures. NOTE: Things could change between the web socket dial and the second http.Get. So, it would be nice to see if we can make a decision purely based on websocket dial return value.

For reviewers: the idea here is to not trip media self health checks on controller Dial failures.