### PR TITLE
Fix republish don't work on full restart #240

### DIFF
--- a/localparticipant.go
+++ b/localparticipant.go
@@ -40,7 +40,7 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 		}
 	}
 
-	pub := NewLocalTrackPublication(kind, track, opts.Name, p.engine.client)
+	pub := NewLocalTrackPublication(kind, track, *opts, p.engine.client)
 	pub.OnRttUpdate(func(rtt uint32) {
 		p.engine.setRTT(rtt)
 	})
@@ -134,7 +134,7 @@ func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalSampleTrack, opt
 
 	mainTrack := tracks[len(tracks)-1]
 
-	pub := NewLocalTrackPublication(KindFromRTPType(mainTrack.Kind()), nil, opts.Name, p.engine.client)
+	pub := NewLocalTrackPublication(KindFromRTPType(mainTrack.Kind()), nil, *opts, p.engine.client)
 
 	var layers []*livekit.VideoLayer
 	for _, st := range tracks {

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -228,6 +228,21 @@ func (p *LocalParticipant) republishTracks() {
 	}
 }
 
+func (p *LocalParticipant) closeTracks() {
+	var localPubs []*LocalTrackPublication
+	p.tracks.Range(func(_, value interface{}) bool {
+		track := value.(*LocalTrackPublication)
+		if track.Track() != nil {
+			localPubs = append(localPubs, track)
+		}
+		return true
+	})
+
+	for _, pub := range localPubs {
+		pub.CloseTrack()
+	}
+}
+
 func (p *LocalParticipant) PublishData(data []byte, kind livekit.DataPacket_Kind, destinationSids []string) error {
 	packet := &livekit.DataPacket{
 		Kind: kind,

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -278,9 +278,7 @@ func (p *LocalParticipant) UnpublishTrack(sid string) error {
 		p.engine.publisher.Negotiate()
 	}
 
-	if localTrack, ok := pub.track.(LocalTrackWithClose); ok {
-		localTrack.Close()
-	}
+	pub.CloseTrack()
 
 	return err
 }

--- a/localsampletrack.go
+++ b/localsampletrack.go
@@ -338,6 +338,20 @@ func (s *LocalSampleTrack) WriteSample(sample media.Sample, opts *SampleWriteOpt
 	return nil
 }
 
+func (s *LocalSampleTrack) Close() error {
+	s.lock.Lock()
+	cancelWrite := s.cancelWrite
+	provider := s.provider
+	s.lock.Unlock()
+	if cancelWrite != nil {
+		cancelWrite()
+	}
+	if provider != nil {
+		provider.Close()
+	}
+	return nil
+}
+
 func (s *LocalSampleTrack) rtcpWorker(rtcpReader interceptor.RTCPReader) {
 	// read incoming rtcp packets, interceptors require this
 	b := make([]byte, rtpInboundMTU)

--- a/publication.go
+++ b/publication.go
@@ -227,18 +227,24 @@ type LocalTrackPublication struct {
 	// set for simulcasted tracks
 	simulcastTracks map[livekit.VideoQuality]*LocalSampleTrack
 	onRttUpdate     func(uint32)
+	opts            TrackPublicationOptions
 }
 
-func NewLocalTrackPublication(kind TrackKind, track Track, name string, client *SignalClient) *LocalTrackPublication {
+func NewLocalTrackPublication(kind TrackKind, track Track, opts TrackPublicationOptions, client *SignalClient) *LocalTrackPublication {
 	pub := &LocalTrackPublication{
 		trackPublicationBase: trackPublicationBase{
 			track:  track,
 			client: client,
 		},
+		opts: opts,
 	}
 	pub.kind.Store(string(kind))
-	pub.name.Store(name)
+	pub.name.Store(opts.Name)
 	return pub
+}
+
+func (p *LocalTrackPublication) PublicationOptions() TrackPublicationOptions {
+	return p.opts
 }
 
 func (p *LocalTrackPublication) TrackLocal() webrtc.TrackLocal {

--- a/publication.go
+++ b/publication.go
@@ -320,6 +320,16 @@ func (p *LocalTrackPublication) OnRttUpdate(cb func(uint32)) {
 	p.lock.Unlock()
 }
 
+func (p *LocalTrackPublication) CloseTrack() {
+	for _, st := range p.simulcastTracks {
+		st.Close()
+	}
+
+	if localTrack, ok := p.track.(LocalTrackWithClose); ok {
+		localTrack.Close()
+	}
+}
+
 type SimulcastTrack struct {
 	trackLocal webrtc.TrackLocal
 	videoLayer *livekit.VideoLayer

--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -174,8 +174,6 @@ func (p *ReaderSampleProvider) OnBind() error {
 
 func (p *ReaderSampleProvider) OnUnbind() error {
 	if !p.dontCloseOnUnbind {
-		logger.Warnw(`Closing reader on unbind, this will cause the reader can't be rebinded when sdk restarting connection on connection failure
-		To avoid this, use ReaderTrackDisableAutoClose() option when creating track, and Call Track.Close() manually after unpulish the track OR disconnect from livekit`, nil)
 		return p.Close()
 	}
 	return nil

--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -43,8 +43,6 @@ type ReaderSampleProvider struct {
 	// for ogg
 	oggreader   *oggreader.OggReader
 	lastGranule uint64
-
-	dontCloseOnUnbind bool
 }
 
 type ReaderSampleProviderOption func(*ReaderSampleProvider)
@@ -70,12 +68,6 @@ func ReaderTrackWithOnWriteComplete(f func()) func(provider *ReaderSampleProvide
 func ReaderTrackWithRTCPHandler(f func(rtcp.Packet)) func(provider *ReaderSampleProvider) {
 	return func(provider *ReaderSampleProvider) {
 		provider.trackOpts = append(provider.trackOpts, WithRTCPHandler(f))
-	}
-}
-
-func ReaderTrackDisableAutoClose() func(provider *ReaderSampleProvider) {
-	return func(provider *ReaderSampleProvider) {
-		provider.dontCloseOnUnbind = true
 	}
 }
 
@@ -146,7 +138,7 @@ func NewLocalReaderTrack(in io.ReadCloser, mime string, options ...ReaderSampleP
 
 func (p *ReaderSampleProvider) OnBind() error {
 	// If we are not closing on unbind, don't do anything on rebind
-	if p.dontCloseOnUnbind && (p.ivfreader != nil || p.h264reader != nil || p.oggreader != nil) {
+	if p.ivfreader != nil || p.h264reader != nil || p.oggreader != nil {
 		return nil
 	}
 
@@ -173,9 +165,6 @@ func (p *ReaderSampleProvider) OnBind() error {
 }
 
 func (p *ReaderSampleProvider) OnUnbind() error {
-	if !p.dontCloseOnUnbind {
-		return p.Close()
-	}
 	return nil
 }
 

--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -174,6 +174,8 @@ func (p *ReaderSampleProvider) OnBind() error {
 
 func (p *ReaderSampleProvider) OnUnbind() error {
 	if !p.dontCloseOnUnbind {
+		logger.Warnw(`Closing reader on unbind, this will cause the reader can't be rebinded when sdk restarting connection on connection failure
+		To avoid this, use ReaderTrackDisableAutoClose() option when creating track, and Call Track.Close() manually after unpulish the track OR disconnect from livekit`, nil)
 		return p.Close()
 	}
 	return nil

--- a/room.go
+++ b/room.go
@@ -195,18 +195,7 @@ func (r *Room) Disconnect() {
 	_ = r.engine.client.SendLeave()
 	r.engine.Close()
 
-	var localPubs []*LocalTrackPublication
-	r.LocalParticipant.tracks.Range(func(_, value interface{}) bool {
-		track := value.(*LocalTrackPublication)
-		if track.Track() != nil {
-			localPubs = append(localPubs, track)
-		}
-		return true
-	})
-
-	for _, pub := range localPubs {
-		pub.CloseTrack()
-	}
+	r.LocalParticipant.closeTracks()
 }
 
 func (r *Room) GetParticipant(sid string) *RemoteParticipant {

--- a/room.go
+++ b/room.go
@@ -304,9 +304,8 @@ func (r *Room) handleRestarted(joinRes *livekit.JoinResponse) {
 
 	for _, pub := range localPubs {
 		if track := pub.TrackLocal(); track != nil {
-			r.LocalParticipant.PublishTrack(track, &TrackPublicationOptions{
-				Name: pub.Name(),
-			})
+			opt := pub.PublicationOptions()
+			r.LocalParticipant.PublishTrack(track, &opt)
 		}
 	}
 	r.callback.OnReconnected()

--- a/room.go
+++ b/room.go
@@ -205,9 +205,7 @@ func (r *Room) Disconnect() {
 	})
 
 	for _, pub := range localPubs {
-		if track, ok := pub.TrackLocal().(LocalTrackWithClose); ok && track != nil {
-			track.Close()
-		}
+		pub.CloseTrack()
 	}
 }
 

--- a/sampleprovider.go
+++ b/sampleprovider.go
@@ -10,6 +10,7 @@ type SampleProvider interface {
 	NextSample() (media.Sample, error)
 	OnBind() error
 	OnUnbind() error
+	Close() error
 }
 
 type AudioSampleProvider interface {
@@ -26,6 +27,10 @@ func (p *BaseSampleProvider) OnBind() error {
 }
 
 func (p *BaseSampleProvider) OnUnbind() error {
+	return nil
+}
+
+func (p *BaseSampleProvider) Close() error {
 	return nil
 }
 

--- a/track.go
+++ b/track.go
@@ -9,6 +9,11 @@ type Track interface {
 	ID() string
 }
 
+type LocalTrackWithClose interface {
+	webrtc.TrackLocal
+	Close() error
+}
+
 type TrackKind string
 
 const (


### PR DESCRIPTION
The `LocalSampleTrack` will call SampleProvider.OnUnbind and cause it close the reader, if sdk republish the track on full reconnect, the republish track will failed on SampleProvider.Bind as the reader has been already closed. 
To fix the issue and keep API don't break already exists application, the PR add a `ReaderTrackDisableAutoClose` Option to SamplePrivoider which tells sdk don't close the reader when track unbinded, so the reader can continue read sample after track republished, also add `Close` method to the `LocalSampleTrack` for application to clean resource if `ReaderTrackDisableAutoClose` is enabled.
If application don't enable `ReaderTrackDisableAutoClose`, sdk will keep its behavior like before that clean reader on unbind and don't support republish on full reconnect.