### PR TITLE
Allow data messages sent via server API to pass through

### DIFF
--- a/room.go
+++ b/room.go
@@ -314,10 +314,9 @@ func (r *Room) handleDataReceived(userPacket *livekit.UserPacket) {
 		return
 	}
 	p := r.GetParticipant(userPacket.ParticipantSid)
-	if p == nil {
-		return
+	if p != nil {
+		p.Callback.OnDataReceived(userPacket.Payload, p)
 	}
-	p.Callback.OnDataReceived(userPacket.Payload, p)
 	r.callback.OnDataReceived(userPacket.Payload, p)
 }
 


### PR DESCRIPTION
When data messages are sent via RoomService API, it doesn't have a participant associated with it. We'll should still fire the right callbacks.