### PR TITLE
Final jitter updates

### DIFF
--- a/pkg/jitter/buffer.go
+++ b/pkg/jitter/buffer.go
@@ -398,10 +398,6 @@ func before32(a, b uint32) bool {
 	return (b-a)&0x80000000 == 0
 }
 
-func after32(a, b uint32) bool {
-	return (a-b)&0x80000000 == 0
-}
-
 func outsideRange(a, b uint16) bool {
 	return a-b > 3000 && b-a > 3000
 }

--- a/pkg/jitter/buffer.go
+++ b/pkg/jitter/buffer.go
@@ -288,7 +288,7 @@ func (b *Buffer) drop() {
 		(b.head.start && before32(b.head.packet.Timestamp-b.maxSampleSize, b.minTS) ||
 			!b.head.start && before32(b.head.packet.Timestamp, b.minTS)) {
 		// lost packets will now be too old even if we receive them
-		// on sequence number reset, skip callback because we don't know if we lost any
+		// on sequence number reset, skip callback because we don't know whether we lost any
 		if !b.head.reset {
 			b.logger.Debugw("packet dropped",
 				"sequence number", b.prevSN+1,
@@ -315,7 +315,6 @@ func (b *Buffer) drop() {
 	for c := b.head; c != nil; {
 		// check if timestamp >= than minimum
 		if (c.start && before32(b.minTS, c.packet.Timestamp)) || (!c.start && !before32(c.packet.Timestamp, b.minTS)) {
-			// if !before32(c.packet.Timestamp, b.minTS) {
 			break
 		}
 

--- a/pkg/jitter/buffer_test.go
+++ b/pkg/jitter/buffer_test.go
@@ -113,6 +113,7 @@ func TestJitterBuffer(t *testing.T) {
 
 	// packets 2-59 would now be too old, consider them lost
 	require.Len(t, b.Pop(false), 60)
+	require.Equal(t, 2, onPacketDroppedCalled)
 
 	// sn and ts jumps with drops
 	b.Push(testTailPacket(121, 104))
@@ -134,7 +135,7 @@ func TestJitterBuffer(t *testing.T) {
 	b.Push(testTailPacket(8003, 1031))
 
 	require.Len(t, b.Pop(false), 4)
-	require.Equal(t, 2, onPacketDroppedCalled)
+	require.Equal(t, 3, onPacketDroppedCalled)
 
 	// ts wrap
 	b.Push(testHeadPacket(1000, 4294967295))


### PR DESCRIPTION
* Calls onPacketDropped when packets are never received
* Fixes initialization issue where it expected SN to start at 1
* Waits max time after sequence number jump to allow for jitter around the gap
* Fixes issue where it would still push the rest of a sample if the partition head was dropped
* Adds more test scenarios