### PR TITLE
Prevent race in participant update.

### DIFF
--- a/participant.go
+++ b/participant.go
@@ -163,8 +163,13 @@ func (p *baseParticipant) setConnectionQualityInfo(info *livekit.ConnectionQuali
 	p.roomCallback.OnConnectionQualityChanged(info, p)
 }
 
-func (p *baseParticipant) updateInfo(pi *livekit.ParticipantInfo, participant Participant) {
+func (p *baseParticipant) updateInfo(pi *livekit.ParticipantInfo, participant Participant) bool {
 	p.lock.Lock()
+	if p.info != nil && p.info.Version > pi.Version {
+		// already updated with a later version
+		p.lock.Unlock()
+		return false
+	}
 	p.info = pi
 	p.identity = pi.Identity
 	p.sid = pi.Sid
@@ -177,6 +182,7 @@ func (p *baseParticipant) updateInfo(pi *livekit.ParticipantInfo, participant Pa
 		p.Callback.OnMetadataChanged(oldMetadata, participant)
 		p.roomCallback.OnMetadataChanged(oldMetadata, participant)
 	}
+	return true
 }
 
 func (p *baseParticipant) addPublication(publication TrackPublication) {

--- a/remoteparticipant.go
+++ b/remoteparticipant.go
@@ -40,7 +40,10 @@ func newRemoteParticipant(pi *livekit.ParticipantInfo, roomCallback *RoomCallbac
 }
 
 func (p *RemoteParticipant) updateInfo(pi *livekit.ParticipantInfo) {
-	p.baseParticipant.updateInfo(pi, p)
+	if !p.baseParticipant.updateInfo(pi, p) {
+		// not a valid update, could be due to older version
+		return
+	}
 	// update tracks
 	validPubs := make(map[string]TrackPublication)
 	newPubs := make(map[string]TrackPublication)

--- a/room.go
+++ b/room.go
@@ -350,19 +350,19 @@ func (r *Room) handleParticipantUpdate(participants []*livekit.ParticipantInfo) 
 			continue
 		}
 
-		p := r.GetParticipant(pi.Sid)
-		isNew := p == nil
+		rp := r.GetParticipant(pi.Sid)
+		isNew := rp == nil
 
 		if pi.State == livekit.ParticipantInfo_DISCONNECTED {
 			// remove
-			if p != nil {
-				r.handleParticipantDisconnect(p)
+			if rp != nil {
+				r.handleParticipantDisconnect(rp)
 			}
 		} else if isNew {
-			p = r.addRemoteParticipant(pi, true)
-			go r.callback.OnParticipantConnected(p)
+			rp = r.addRemoteParticipant(pi, true)
+			go r.callback.OnParticipantConnected(rp)
 		} else {
-			p.updateInfo(pi)
+			rp.updateInfo(pi)
 		}
 	}
 }


### PR DESCRIPTION
In load test, participant updates were racing causing subscription failures. The sequence is
- Join response received
- Read worker started
- Add remote participants from join response
- But, before that could happen, because the read worker is active, there was a participant update which contained track information. That path added the remote participant before join response handler could add it.
- Eventually join response path comes around and adds the remote participant, but that version of remote participant info does not have the tracks yet. And it ends up overwriting the participant info. And it also drops tracks that are not there in the update.
- As the order got reversed, tracks added by participant update path gets wiped out by join response path.
- And subscription fails.

Adding a simple fix to reject participant info updates that are older version.

It will probably be better to process join response fully? Maybe, start the read worker only after processing join response?

NOTE: When the remote participant gets created via the participant update path, the local participant itself is not set up fully.