### PR TITLE
Fallback to reconnect correctly in resume failed

### DIFF
--- a/signalclient.go
+++ b/signalclient.go
@@ -153,6 +153,9 @@ func (c *SignalClient) Join(urlPrefix string, token string, params *ConnectParam
 		logger.Debugw("reconnect received response", "response", res.String())
 		if res != nil {
 			if res.GetLeave() != nil {
+				if c.OnLeave != nil {
+					c.OnLeave(res.GetLeave())
+				}
 				return nil, fmt.Errorf("reconnect received left, reason: %s", res.GetLeave().GetReason())
 			}
 			c.pendingResponse = res

--- a/transport.go
+++ b/transport.go
@@ -33,6 +33,11 @@ import (
 
 const (
 	negotiationFrequency = 150 * time.Millisecond
+
+	dtlsRetransmissionInterval = 100 * time.Millisecond
+	iceDisconnectedTimeout     = 10 * time.Second // compatible for ice-lite with firefox client
+	iceFailedTimeout           = 5 * time.Second
+	iceKeepaliveInterval       = 2 * time.Second
 )
 
 // PCTransport is a wrapper around PeerConnection, with some helper methods
@@ -107,6 +112,8 @@ func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
 
 	se := webrtc.SettingEngine{}
 	se.SetSRTPProtectionProfiles(dtls.SRTP_AEAD_AES_128_GCM, dtls.SRTP_AES128_CM_HMAC_SHA1_80)
+	se.SetDTLSRetransmissionInterval(dtlsRetransmissionInterval)
+	se.SetICETimeouts(iceDisconnectedTimeout, iceFailedTimeout, iceKeepaliveInterval)
 
 	api := webrtc.NewAPI(webrtc.WithMediaEngine(m), webrtc.WithSettingEngine(se), webrtc.WithInterceptorRegistry(i))
 	pc, err := api.NewPeerConnection(params.Configuration)

--- a/transport.go
+++ b/transport.go
@@ -35,7 +35,7 @@ const (
 	negotiationFrequency = 150 * time.Millisecond
 
 	dtlsRetransmissionInterval = 100 * time.Millisecond
-	iceDisconnectedTimeout     = 10 * time.Second // compatible for ice-lite with firefox client
+	iceDisconnectedTimeout     = 10 * time.Second
 	iceFailedTimeout           = 5 * time.Second
 	iceKeepaliveInterval       = 2 * time.Second
 )


### PR DESCRIPTION
If client received LeaveRequest with CanReconnect when resuming connection, it should fallback to full reconnect instead of retry resume.
Also use same parameters with livekit sfu for ice/dtls timeout