### PR TITLE
Close the correct connection.

### DIFF
--- a/room.go
+++ b/room.go
@@ -321,6 +321,7 @@ func (r *Room) handleRestarted(joinRes *livekit.JoinResponse) {
 	r.name = joinRes.Room.Name
 	r.sid = joinRes.Room.Sid
 	r.metadata = joinRes.Room.Metadata
+	r.serverInfo = joinRes.ServerInfo
 	r.lock.Unlock()
 
 	r.LocalParticipant.updateInfo(joinRes.Participant)


### PR DESCRIPTION
When trying to resume, server could return a LeaveRequest signalling a full reconnect. In that case, the connection to be closed is the one that was open previously and not the one which received `LeaveRequest`.

Delay caching of conn only if it is an expected initial response (Join OR Reconnect).

Still feels a bit iffy, but addresses the full reconnect in a dozen tries whereas previously it was failing everytime before.