### PR TITLE
Close previous conn when switching to new conn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ func ServeHTTP(w http.ResponseWriter, r *http.Request) {
 ```
 
 <!--BEGIN_REPO_NAV-->
+
 <br/><table>
+
 <thead><tr><th colspan="2">LiveKit Ecosystem</th></tr></thead>
 <tbody>
 <tr><td>Client SDKs</td><td><a href="https://github.com/livekit/components-js">Components</a> · <a href="https://github.com/livekit/client-sdk-js">JavaScript</a> · <a href="https://github.com/livekit/client-sdk-swift">iOS/macOS</a> · <a href="https://github.com/livekit/client-sdk-android">Android</a> · <a href="https://github.com/livekit/client-sdk-flutter">Flutter</a> · <a href="https://github.com/livekit/client-sdk-react-native">React Native</a> · <a href="https://github.com/livekit/client-sdk-rust">Rust</a> · <a href="https://github.com/livekit/client-sdk-python">Python</a> · <a href="https://github.com/livekit/client-sdk-unity-web">Unity (web)</a> · <a href="https://github.com/livekit/client-sdk-unity">Unity (beta)</a></td></tr><tr></tr>

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livekit/server-sdk-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/bep/debounce v1.2.1

--- a/signalclient.go
+++ b/signalclient.go
@@ -179,7 +179,7 @@ func (c *SignalClient) Close() {
 	if conn != nil {
 		_ = conn.Close()
 	}
-	if isStarted {
+	if isStarted && readerClosedCh != nil {
 		<-readerClosedCh
 	}
 }

--- a/signalclient.go
+++ b/signalclient.go
@@ -181,7 +181,7 @@ func (c *SignalClient) Close() {
 	if isStarted {
 		<-c.readerClosedCh
 	}
-	if conn != nil {
+	if conn != nil && c.OnClose != nil {
 		c.OnClose()
 	}
 }

--- a/signalclient.go
+++ b/signalclient.go
@@ -181,9 +181,6 @@ func (c *SignalClient) Close() {
 	if isStarted {
 		<-c.readerClosedCh
 	}
-	if conn != nil && c.OnClose != nil {
-		c.OnClose()
-	}
 }
 
 func (c *SignalClient) SendICECandidate(candidate webrtc.ICECandidateInit, target livekit.SignalTarget) error {
@@ -352,6 +349,10 @@ func (c *SignalClient) readWorker() {
 		c.isStarted.Store(false)
 		c.conn.Store(nil)
 		close(c.readerClosedCh)
+
+		if c.OnClose != nil {
+			c.OnClose()
+		}
 	}()
 	if pending := c.pendingResponse; pending != nil {
 		c.handleResponse(pending)

--- a/signalclient.go
+++ b/signalclient.go
@@ -346,11 +346,12 @@ func (c *SignalClient) handleResponse(res *livekit.SignalResponse) {
 func (c *SignalClient) readWorker() {
 	defer func() {
 		c.isStarted.Store(false)
+		c.conn.Store((*websocket.Conn)(nil))
+		close(c.readerClosedCh)
+
 		if c.OnClose != nil {
 			c.OnClose()
 		}
-		c.conn.Store((*websocket.Conn)(nil))
-		close(c.readerClosedCh)
 	}()
 	if pending := c.pendingResponse; pending != nil {
 		c.handleResponse(pending)

--- a/signalclient.go
+++ b/signalclient.go
@@ -174,11 +174,15 @@ func (c *SignalClient) Join(urlPrefix string, token string, params *ConnectParam
 
 func (c *SignalClient) Close() {
 	isStarted := c.IsStarted()
-	if conn := c.websocketConn(); conn != nil {
+	conn := c.websocketConn()
+	if conn != nil {
 		_ = conn.Close()
 	}
 	if isStarted {
 		<-c.readerClosedCh
+	}
+	if conn != nil {
+		c.OnClose()
 	}
 }
 
@@ -348,10 +352,6 @@ func (c *SignalClient) readWorker() {
 		c.isStarted.Store(false)
 		c.conn.Store((*websocket.Conn)(nil))
 		close(c.readerClosedCh)
-
-		if c.OnClose != nil {
-			c.OnClose()
-		}
 	}()
 	if pending := c.pendingResponse; pending != nil {
 		c.handleResponse(pending)


### PR DESCRIPTION
This is a different attempt at
https://github.com/livekit/server-sdk-go/pull/350. Feels a bit cleaner, i. e. if the internal `conn atomic.Value` is replaced, the previous `conn` is closed before doing that.