### PR TITLE
Add pacer module for publishing tracks

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -192,6 +192,7 @@ func (e *RTCEngine) configure(res *livekit.JoinResponse) error {
 	if e.publisher, err = NewPCTransport(PCTransportParams{
 		Configuration:        configuration,
 		RetransmitBufferSize: e.connParams.RetransmitBufferSize,
+		Pacer:                e.connParams.Pacer,
 	}); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.3.0
 	github.com/go-logr/stdr v1.2.2
 	github.com/gorilla/websocket v1.5.1
-	github.com/livekit/mediatransportutil v0.0.0-20231128042044-05525c8278cb
+	github.com/livekit/mediatransportutil v0.0.0-20231129064833-1bc9d06b219d
 	github.com/livekit/protocol v1.9.2
 	github.com/magefile/mage v1.15.0
 	github.com/pion/dtls/v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/lithammer/shortuuid/v4 v4.0.0 h1:QRbbVkfgNippHOS8PXDkti4NaWeyYfcBTHtw
 github.com/lithammer/shortuuid/v4 v4.0.0/go.mod h1:Zs8puNcrvf2rV9rTH51ZLLcj7ZXqQI3lv67aw4KiB1Y=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1 h1:jm09419p0lqTkDaKb5iXdynYrzB84ErPPO4LbRASk58=
 github.com/livekit/mageutil v0.0.0-20230125210925-54e8a70427c1/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/mediatransportutil v0.0.0-20231128042044-05525c8278cb h1:KiGg4k+kYQD9NjKixaSDMMeYOO2//XBM4IROTI1Itjo=
-github.com/livekit/mediatransportutil v0.0.0-20231128042044-05525c8278cb/go.mod h1:GBzn9xL+mivI1pW+tyExcKgbc0VOc29I9yJsNcAVaAc=
+github.com/livekit/mediatransportutil v0.0.0-20231129064833-1bc9d06b219d h1:C9CBJM38giLq1d52QFPlmF0kXnayAKNWbjfzhM2jzwk=
+github.com/livekit/mediatransportutil v0.0.0-20231129064833-1bc9d06b219d/go.mod h1:GBzn9xL+mivI1pW+tyExcKgbc0VOc29I9yJsNcAVaAc=
 github.com/livekit/protocol v1.9.2 h1:gkKNjVwTbRNO1d5ZxTDHoZrOv4CMvGa1/oPwmCHp8oE=
 github.com/livekit/protocol v1.9.2/go.mod h1:8f342d5nvfNp9YAEfJokSR+zbNFpaivgU0h6vwaYhes=
 github.com/livekit/psrpc v0.5.2 h1:+MvG8Otm/J6MTg2MP/uuMbrkxOWsrj2hDhu/I1VIU1U=

--- a/pkg/interceptor/pacerinteceptor.go
+++ b/pkg/interceptor/pacerinteceptor.go
@@ -1,0 +1,108 @@
+package interceptor
+
+import (
+	"sync"
+
+	"github.com/livekit/mediatransportutil/pkg/pacer"
+	"github.com/pion/interceptor"
+	"github.com/pion/rtp"
+)
+
+type PacerInterceptorFactory struct {
+	pacer pacer.Factory
+	pool  *PacketPool
+}
+
+func NewPacerInterceptorFactory(pacer pacer.Factory) *PacerInterceptorFactory {
+	return &PacerInterceptorFactory{
+		pacer: pacer,
+		pool:  NewPacketPool(500, 1500),
+	}
+}
+
+func (p *PacerInterceptorFactory) NewInterceptor(id string) (interceptor.Interceptor, error) {
+	pacer, err := p.pacer.NewPacer()
+	if err != nil {
+		return nil, err
+	}
+	return &PacerInterceptor{
+		pacer: pacer,
+		pool:  p.pool,
+	}, nil
+}
+
+// PacerInterceptor is an interceptor that paces outgoing packets to avoid congestion on the bursty traffic of huge frames.
+type PacerInterceptor struct {
+	interceptor.NoOp
+
+	pool  *PacketPool
+	pacer pacer.Pacer
+}
+
+// BindRTCPWriter lets you modify any outgoing RTCP packets. It is called once per PeerConnection. The returned method
+// will be called once per packet batch.
+func (pi *PacerInterceptor) BindRTCPWriter(writer interceptor.RTCPWriter) interceptor.RTCPWriter {
+	pi.pacer.Start()
+	return writer
+}
+
+func (pi *PacerInterceptor) BindLocalStream(stream *interceptor.StreamInfo, writer interceptor.RTPWriter) interceptor.RTPWriter {
+	var (
+		lock         sync.Mutex
+		lastSeq      uint16
+		firstPktSeen bool
+	)
+	pacerWriter := func(header *rtp.Header, payload []byte) (int, error) {
+		return writer.Write(header, payload, interceptor.Attributes{})
+	}
+	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
+		// send packets immediately if it's retransmit to reduce frame freeze
+		var isRetransmit bool
+		seq := header.SequenceNumber
+		lock.Lock()
+		if firstPktSeen {
+			if diff := seq - lastSeq; diff == 0 || diff > 0x8000 {
+				isRetransmit = true
+			} else {
+				lastSeq = seq
+			}
+		} else {
+			firstPktSeen = true
+			lastSeq = seq
+		}
+		lock.Unlock()
+		if isRetransmit {
+			return writer.Write(header, payload, attributes)
+		}
+
+		pktSize := len(payload) + header.MarshalSize()
+		poolEntity, pool := pi.pool.Get(pktSize)
+		buf := *poolEntity
+		n, err := header.MarshalTo(buf)
+		if err != nil {
+			if pool != nil {
+				pool.Put(poolEntity)
+			}
+			return 0, err
+		}
+		copy(buf[n:], payload)
+		var headCopy rtp.Header
+		headCopy.Unmarshal(buf)
+
+		pkt := &pacer.Packet{
+			Header:     &headCopy,
+			Payload:    payload,
+			Writer:     pacerWriter,
+			Pool:       pool,
+			PoolEntity: poolEntity,
+		}
+		pi.pacer.Enqueue(pkt)
+		return pktSize, nil
+	})
+
+}
+
+func (pi *PacerInterceptor) Close() error {
+	pi.pacer.Stop()
+	return nil
+}

--- a/pkg/interceptor/packetpool.go
+++ b/pkg/interceptor/packetpool.go
@@ -1,0 +1,31 @@
+package interceptor
+
+import "sync"
+
+type PacketPool struct {
+	pools map[int]*sync.Pool // key: size
+}
+
+func NewPacketPool(size ...int) *PacketPool {
+	pools := make(map[int]*sync.Pool)
+	for _, s := range size {
+		bufSize := s
+		pools[bufSize] = &sync.Pool{
+			New: func() interface{} {
+				b := make([]byte, bufSize)
+				return &b
+			},
+		}
+	}
+	return &PacketPool{pools: pools}
+}
+
+func (p *PacketPool) Get(size int) (*[]byte, *sync.Pool) {
+	for s, pool := range p.pools {
+		if s >= size {
+			return pool.Get().(*[]byte), pool
+		}
+	}
+	b := make([]byte, size)
+	return &b, nil
+}

--- a/room.go
+++ b/room.go
@@ -25,6 +25,7 @@ import (
 	"github.com/thoas/go-funk"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/livekit/mediatransportutil/pkg/pacer"
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
 )
@@ -67,6 +68,8 @@ type ConnectParams struct {
 	Callback      *RoomCallback
 
 	RetransmitBufferSize uint16
+
+	Pacer pacer.Factory
 }
 
 type ConnectOption func(*ConnectParams)
@@ -82,6 +85,12 @@ func WithAutoSubscribe(val bool) ConnectOption {
 func WithRetransmitBufferSize(val uint16) ConnectOption {
 	return func(p *ConnectParams) {
 		p.RetransmitBufferSize = val
+	}
+}
+
+func WithPacer(pacer pacer.Factory) ConnectOption {
+	return func(p *ConnectParams) {
+		p.Pacer = pacer
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pion/sdp/v3"
 	"github.com/pion/webrtc/v3"
 
+	"github.com/livekit/mediatransportutil/pkg/pacer"
 	lksdp "github.com/livekit/protocol/sdp"
 	sdkinterceptor "github.com/livekit/server-sdk-go/pkg/interceptor"
 )
@@ -62,6 +63,7 @@ type PCTransportParams struct {
 	Configuration webrtc.Configuration
 
 	RetransmitBufferSize uint16
+	Pacer                pacer.Factory
 }
 
 func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
@@ -97,6 +99,11 @@ func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
 
 	m.RegisterFeedback(webrtc.RTCPFeedback{Type: "nack"}, webrtc.RTPCodecTypeVideo)
 	m.RegisterFeedback(webrtc.RTCPFeedback{Type: "nack", Parameter: "pli"}, webrtc.RTPCodecTypeVideo)
+
+	if params.Pacer != nil {
+		i.Add(sdkinterceptor.NewPacerInterceptorFactory(params.Pacer))
+	}
+
 	i.Add(responder)
 	i.Add(generator)
 


### PR DESCRIPTION
When the go-sdk publishes a high bitrate video track, the instant bitrates might rise too high to overwhelm the network/sfu buffer and cause freeze by packet loss/unorder. This PR adds a pacing module to control the output bitrate at target rate, it will also limit the pending queue latency by increasing the output bitrate temporarily. 
Below code uses the pacer to control output bitrate at 3Mbps and 2s max latency :

```
	pacer := pacer.NewPacerFactory(pacer.LeakyBucketPacer, pacer.WithBitrate(3000000), pacer.WithMaxLatency(2*time.Second))

	room, err := lksdk.ConnectToRoom(host, lksdk.ConnectInfo{
		APIKey:              apiKey,
		APISecret:           apiSecret,
		RoomName:            roomName,
		ParticipantIdentity: identity,
	}, &lksdk.RoomCallback{
		ParticipantCallback: lksdk.ParticipantCallback{
			OnTrackSubscribed: onTrackSubscribed,
		},
	}, lksdk.WithPacer(pacer))
```