### PR TITLE
Limit rtp packet payload size

### DIFF
--- a/pkg/interceptor/limitsizeinteceptor.go
+++ b/pkg/interceptor/limitsizeinteceptor.go
@@ -1,0 +1,38 @@
+package interceptor
+
+import (
+	"fmt"
+
+	"github.com/pion/interceptor"
+	"github.com/pion/rtp"
+)
+
+const (
+	MaxPayloadSize = 1200
+)
+
+var ErrPayloadSizeTooLarge = fmt.Errorf("packetization payload size should not greater than %d bytes", MaxPayloadSize)
+
+type LimitSizeInterceptorFactory struct {
+}
+
+func NewLimitSizeInterceptorFactory() *LimitSizeInterceptorFactory {
+	return &LimitSizeInterceptorFactory{}
+}
+
+func (l *LimitSizeInterceptorFactory) NewInterceptor(id string) (interceptor.Interceptor, error) {
+	return &LimitSizeInterceptor{}, nil
+}
+
+type LimitSizeInterceptor struct {
+	interceptor.NoOp
+}
+
+func (l *LimitSizeInterceptor) BindLocalStream(stream *interceptor.StreamInfo, writer interceptor.RTPWriter) interceptor.RTPWriter {
+	return interceptor.RTPWriterFunc(func(header *rtp.Header, payload []byte, attributes interceptor.Attributes) (int, error) {
+		if len(payload) > MaxPayloadSize {
+			return 0, ErrPayloadSizeTooLarge
+		}
+		return writer.Write(header, payload, attributes)
+	})
+}

--- a/transport.go
+++ b/transport.go
@@ -117,6 +117,8 @@ func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
 		return nil, err
 	}
 
+	i.Add(sdkinterceptor.NewLimitSizeInterceptorFactory())
+
 	se := webrtc.SettingEngine{}
 	se.SetSRTPProtectionProfiles(dtls.SRTP_AEAD_AES_128_GCM, dtls.SRTP_AES128_CM_HMAC_SHA1_80)
 	se.SetDTLSRetransmissionInterval(dtlsRetransmissionInterval)


### PR DESCRIPTION
Limit the rtp packet payload size to 1200 as same as libwebrtc limit to make sure the udp packet don't exceed mtu and udp message payload size in various network & device.