### PR TITLE
Fix pli missed cause by two goroutine compete rtcp reader

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -173,10 +173,6 @@ func (e *RTCEngine) TrackPublishedChan() <-chan *livekit.TrackPublishedResponse 
 }
 
 func (e *RTCEngine) setRTT(rtt uint32) {
-	if pc := e.publisher; pc != nil {
-		pc.SetRTT(rtt)
-	}
-
 	if pc := e.subscriber; pc != nil {
 		pc.SetRTT(rtt)
 	}
@@ -193,6 +189,7 @@ func (e *RTCEngine) configure(res *livekit.JoinResponse) error {
 		Configuration:        configuration,
 		RetransmitBufferSize: e.connParams.RetransmitBufferSize,
 		Pacer:                e.connParams.Pacer,
+		OnRTTUpdate:          e.setRTT,
 	}); err != nil {
 		return err
 	}

--- a/localsampletrack.go
+++ b/localsampletrack.go
@@ -387,6 +387,7 @@ func (s *LocalSampleTrack) rtcpWorker(rtcpReader interceptor.RTCPReader) {
 
 		pkts, err := rtcp.Unmarshal(b[:i])
 		if err != nil {
+			logger.Warnw("could not unmarshal rtcp", err)
 			return
 		}
 		for _, packet := range pkts {

--- a/pkg/interceptor/rttinteceptor.go
+++ b/pkg/interceptor/rttinteceptor.go
@@ -1,0 +1,66 @@
+package interceptor
+
+import (
+	"github.com/livekit/mediatransportutil"
+	"github.com/pion/interceptor"
+	"github.com/pion/rtcp"
+)
+
+type RTTInterceptorFactory struct {
+	onRttUpdate func(rtt uint32)
+}
+
+func NewRTTInterceptorFactory(onRttUpdate func(rtt uint32)) *RTTInterceptorFactory {
+	return &RTTInterceptorFactory{
+		onRttUpdate: onRttUpdate,
+	}
+}
+
+func (r *RTTInterceptorFactory) NewInterceptor(_ string) (interceptor.Interceptor, error) {
+	return NewRTTInterceptor(r.onRttUpdate), nil
+}
+
+type RTTInterceptor struct {
+	interceptor.NoOp
+
+	onRttUpdate func(rtt uint32)
+}
+
+func NewRTTInterceptor(onRttUpdate func(rtt uint32)) *RTTInterceptor {
+	return &RTTInterceptor{
+		onRttUpdate: onRttUpdate,
+	}
+}
+
+func (r *RTTInterceptor) BindRTCPReader(reader interceptor.RTCPReader) interceptor.RTCPReader {
+	return interceptor.RTCPReaderFunc(func(b []byte, a interceptor.Attributes) (int, interceptor.Attributes, error) {
+		i, attr, err := reader.Read(b, a)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		if attr == nil {
+			attr = make(interceptor.Attributes)
+		}
+		pkts, err := attr.GetRTCPPackets(b[:i])
+		if err != nil {
+			return 0, nil, err
+		}
+
+	rttCaculate:
+		for _, packet := range pkts {
+			if rr, ok := packet.(*rtcp.ReceiverReport); ok {
+				for _, report := range rr.Reports {
+					rtt, err := mediatransportutil.GetRttMsFromReceiverReportOnly(&report)
+					if err == nil && rtt != 0 {
+						r.onRttUpdate(rtt)
+					}
+
+					break rttCaculate
+				}
+			}
+		}
+
+		return i, attr, err
+	})
+}


### PR DESCRIPTION
There were two goroutine to read rtcp when publishing a LocalSampleTrack, one is publication to calculate rtt and the other is LocalSampleTrack itself, cause pli hander rely on LocalSampleTrack's rtcp callback might miss pli request.