### PR TITLE
Set lastTS to last sample timestamp.

### DIFF
--- a/localtrack.go
+++ b/localtrack.go
@@ -377,6 +377,9 @@ func (s *LocalTrack) WriteSample(sample media.Sample, opts *SampleWriteOptions) 
 		}
 
 		s.lastTS = sample.Timestamp
+		if !s.lastTS.IsZero() {
+			s.lastTS = s.lastTS.Add(time.Duration(-elapsedDurationSeconds * float64(time.Second)))
+		}
 	} else {
 		// reject samples that move backward in time
 		switch {
@@ -439,9 +442,7 @@ func (s *LocalTrack) WriteSample(sample media.Sample, opts *SampleWriteOptions) 
 
 	packets := s.packetizer.Packetize(sample.Data, samplesPerPacket)
 
-	if !s.lastTS.IsZero() {
-		s.lastTS = s.lastTS.Add(time.Duration(float64(samples) / s.clockRate * float64(time.Second)))
-	}
+	s.lastTS = sample.Timestamp
 	s.lastRTPTimestamp = currentRTPTimestamp
 	s.lock.Unlock()
 

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package lksdk
 
-const Version = "2.0.1"
+const Version = "2.0.5"


### PR DESCRIPTION
Was using adjusted last time stamp based on number of samples. But, that does not work if somebody is blasting samples. For example, if somebody is blasting 10 seconds worth of samples in 1 second, the adjusted last TS would have moved past the incoming timestamp after the first sample and the subsequent samples would have been dropped as out-of-order.

The change here is to use the incoming time stamp as is for lastTS.

But, this does fail in the scenario of
- Blast 10 seconds worth of audio in one second.
- 20 seconds later, send another sample. In this case, the gap should be 10 seconds, but this change will make it look like 19 seconds.

Need to think more about handling that case. Avoiding the out-of-order strangle for now.