### PR TITLE
Handle offer errors during resume connection

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -584,9 +584,11 @@ func (e *RTCEngine) resumeConnection() error {
 	publisher := e.publisher
 	e.pclock.Unlock()
 	if sendOffer {
-		publisher.createAndSendOffer(&webrtc.OfferOptions{
+		if err := publisher.createAndSendOffer(&webrtc.OfferOptions{
 			ICERestart: true,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	if err = e.waitUntilConnected(); err != nil {


### PR DESCRIPTION
When an error occurs during the webrtc offer creation during connection resume, the resume should be considered failed and an error returned. 

**Why?**

I have seen some situations where the offer creation fails, with the following error message:
```
"msg"="could not negotiate" "error"="ICEAgent does not exist: unable to restart ICETransport"
```
I would have expected to see a retry, but instead the `OnReconnected` is called. This would indicate that the room connection is established, but it is not. The `ParticipantCallback` is never called, and the `OnDataReceived` are quiet. Even when messages are sent to this participant, they are not received.

This change makes sure that errors like this one result in a failure of `resumeConnection()` and thus trigger a proper retry.

To show the impact; the `could not negotiate` happened 51 times in the last 7 days.