### PR TITLE
Fix unpublish log name

### DIFF
--- a/localparticipant.go
+++ b/localparticipant.go
@@ -398,7 +398,7 @@ func (p *LocalParticipant) UnpublishTrack(sid string) error {
 
 	pub.CloseTrack()
 
-	logger.Infow("unpublished track", "name", pub.Name, "sid", sid)
+	logger.Infow("unpublished track", "name", pub.Name(), "sid", sid)
 
 	return err
 }


### PR DESCRIPTION
In #426 we added logs to print track unpublications. Now I notice the name seems off:
```
"level"=0 "msg"="unpublished track" "name"="<unhandled-func>" "sid"="TR_VC8SRooGZKzKKb"
```
Let's fix that...

After this change, the log looks like this:
```
"level"=0 "msg"="unpublished track" "name"="front" "sid"="TR_VCBDzfrHRZgNpN"
```