### PR TITLE
Makes it possible to change the HTTP client

### DIFF
--- a/egressclient.go
+++ b/egressclient.go
@@ -16,7 +16,6 @@ package lksdk
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -30,7 +29,8 @@ type EgressClient struct {
 
 func NewEgressClient(url string, apiKey string, secretKey string, opts ...twirp.ClientOption) *EgressClient {
 	url = ToHttpURL(url)
-	client := livekit.NewEgressProtobufClient(url, &http.Client{}, opts...)
+	httpClient := DefaultHttpClientProvider.newHttpClient("egress")
+	client := livekit.NewEgressProtobufClient(url, httpClient, opts...)
 	return &EgressClient{
 		egressClient: client,
 		authBase: authBase{

--- a/httpclientprovider.go
+++ b/httpclientprovider.go
@@ -1,0 +1,21 @@
+package lksdk
+
+import "net/http"
+
+type HttpClientProvider struct {
+	NewHttpClient func(name string) *http.Client
+}
+
+var DefaultHttpClientProvider = &HttpClientProvider{}
+
+func (p *HttpClientProvider) newHttpClient(name string) *http.Client {
+	fn := p.NewHttpClient
+	if fn == nil {
+		fn = defaultNewHttpClient
+	}
+	return fn(name)
+}
+
+func defaultNewHttpClient(name string) *http.Client {
+	return &http.Client{}
+}

--- a/ingressclient.go
+++ b/ingressclient.go
@@ -16,7 +16,6 @@ package lksdk
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -30,7 +29,8 @@ type IngressClient struct {
 
 func NewIngressClient(url string, apiKey string, secretKey string, opts ...twirp.ClientOption) *IngressClient {
 	url = ToHttpURL(url)
-	client := livekit.NewIngressProtobufClient(url, &http.Client{}, opts...)
+	httpClient := DefaultHttpClientProvider.newHttpClient("ingress")
+	client := livekit.NewIngressProtobufClient(url, httpClient, opts...)
 	return &IngressClient{
 		ingressClient: client,
 		authBase: authBase{

--- a/roomclient.go
+++ b/roomclient.go
@@ -16,7 +16,6 @@ package lksdk
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -30,7 +29,8 @@ type RoomServiceClient struct {
 
 func NewRoomServiceClient(url string, apiKey string, secretKey string, opts ...twirp.ClientOption) *RoomServiceClient {
 	url = ToHttpURL(url)
-	client := livekit.NewRoomServiceProtobufClient(url, &http.Client{}, opts...)
+	httpClient := DefaultHttpClientProvider.newHttpClient("room_service")
+	client := livekit.NewRoomServiceProtobufClient(url, httpClient, opts...)
 	return &RoomServiceClient{
 		roomService: client,
 		authBase: authBase{

--- a/sipclient.go
+++ b/sipclient.go
@@ -16,7 +16,6 @@ package lksdk
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/livekit/protocol/auth"
 	"github.com/livekit/protocol/livekit"
@@ -29,8 +28,9 @@ type SIPClient struct {
 }
 
 func NewSIPClient(url string, apiKey string, secretKey string, opts ...twirp.ClientOption) *SIPClient {
+	httpClient := DefaultHttpClientProvider.newHttpClient("sip")
 	return &SIPClient{
-		sipClient: livekit.NewSIPProtobufClient(ToHttpURL(url), &http.Client{}, opts...),
+		sipClient: livekit.NewSIPProtobufClient(ToHttpURL(url), httpClient, opts...),
 		authBase: authBase{
 			apiKey:    apiKey,
 			apiSecret: secretKey,


### PR DESCRIPTION
Add provider for collect prometheus metric of http client

This is sample
```
	lksdk.DefaultHttpClientProvider.NewHttpClient = func(name string) *http.Client {
		return &http.Client{Transport: instrumentRoundTripper(reg, name, http.DefaultTransport)}
	}
        // need to copy method instrumentRoundTripper from https://github.com/prometheus/client_golang/blob/main/tutorial/whatsup/reference/main.go#L283-L319
```