### PR TITLE
Allow using a custom dialer

### DIFF
--- a/room.go
+++ b/room.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/gorilla/websocket"
 	"github.com/pion/interceptor"
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
@@ -86,6 +87,8 @@ type connectParams struct {
 	Interceptors []interceptor.Factory
 
 	ICETransportPolicy webrtc.ICETransportPolicy
+
+	Dialer *websocket.Dialer
 }
 
 type ConnectOption func(*connectParams)
@@ -119,6 +122,12 @@ func WithInterceptors(interceptors []interceptor.Factory) ConnectOption {
 func WithICETransportPolicy(iceTransportPolicy webrtc.ICETransportPolicy) ConnectOption {
 	return func(p *connectParams) {
 		p.ICETransportPolicy = iceTransportPolicy
+	}
+}
+
+func WithDialer(dialer *websocket.Dialer) ConnectOption {
+	return func(p *connectParams) {
+		p.Dialer = dialer
 	}
 }
 

--- a/signalclient.go
+++ b/signalclient.go
@@ -137,7 +137,12 @@ func (c *SignalClient) connect(urlPrefix string, token string, params connectPar
 	}
 
 	header := newHeaderWithToken(token)
-	conn, hresp, err := websocket.DefaultDialer.Dial(u.String(), header)
+	dialer := websocket.DefaultDialer
+	if params.Dialer != nil {
+		dialer = params.Dialer
+	}
+
+	conn, hresp, err := dialer.Dial(u.String(), header)
 	if err != nil {
 		var fields []interface{}
 		if hresp != nil {


### PR DESCRIPTION
Small patch to allow us overriding the dialer that's used to create the signaling client.

We need this so that our way of using TLS is supported (per server certificates).