### PR TITLE
Fix attribute update

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -20,12 +20,17 @@ import (
 	"github.com/livekit/protocol/livekit"
 )
 
+// ParticipantAttributesChangedFunc is callback for Participant attribute change event.
+// The function is called with an already updated participant state and the map of changes attributes.
+// Deleted attributes will have empty string value in the changed map.
+type ParticipantAttributesChangedFunc func(changed map[string]string, p Participant)
+
 type ParticipantCallback struct {
 	// for all participants
 	OnTrackMuted               func(pub TrackPublication, p Participant)
 	OnTrackUnmuted             func(pub TrackPublication, p Participant)
 	OnMetadataChanged          func(oldMetadata string, p Participant)
-	OnAttributesChanged        func(oldAttrs map[string]string, p Participant)
+	OnAttributesChanged        ParticipantAttributesChangedFunc
 	OnIsSpeakingChanged        func(p Participant)
 	OnConnectionQualityChanged func(update *livekit.ConnectionQualityInfo, p Participant)
 
@@ -44,7 +49,7 @@ func NewParticipantCallback() *ParticipantCallback {
 		OnTrackMuted:               func(pub TrackPublication, p Participant) {},
 		OnTrackUnmuted:             func(pub TrackPublication, p Participant) {},
 		OnMetadataChanged:          func(oldMetadata string, p Participant) {},
-		OnAttributesChanged:        func(oldAttrs map[string]string, p Participant) {},
+		OnAttributesChanged:        func(changed map[string]string, p Participant) {},
 		OnIsSpeakingChanged:        func(p Participant) {},
 		OnConnectionQualityChanged: func(update *livekit.ConnectionQualityInfo, p Participant) {},
 		OnTrackSubscribed:          func(track *webrtc.TrackRemote, publication *RemoteTrackPublication, rp *RemoteParticipant) {},

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,7 +47,9 @@ var (
 
 func TestMain(m *testing.M) {
 	keys := strings.Split(os.Getenv("LIVEKIT_KEYS"), ": ")
-	apiKey, apiSecret = keys[0], keys[1]
+	if len(keys) >= 2 {
+		apiKey, apiSecret = keys[0], keys[1]
+	}
 
 	os.Exit(m.Run())
 }

--- a/participant_test.go
+++ b/participant_test.go
@@ -1,0 +1,21 @@
+package lksdk
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAttributeChanges(t *testing.T) {
+	diff := attributeChanges(map[string]string{
+		"a": "1",
+		"b": "2",
+	}, map[string]string{
+		"a": "2",
+		"c": "3",
+	})
+	require.Equal(t, map[string]string{
+		"a": "2",
+		"b": "",
+		"c": "3",
+	}, diff)
+}


### PR DESCRIPTION
Previous attribute update assumed server update sends delta attributes and not the whole state. This PR fixes this assumption and overrides attributes with ones sent by the server.