### PR TITLE
Rename connectParams -> SignalClientConnectParams (to make it exportable)

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -62,7 +62,7 @@ type RTCEngine struct {
 
 	url        string
 	token      atomic.String
-	connParams *connectParams
+	connParams *SignalClientConnectParams
 
 	JoinTimeout time.Duration
 
@@ -138,7 +138,7 @@ func (e *RTCEngine) SetLogger(l protoLogger.Logger) {
 	}
 }
 
-func (e *RTCEngine) Join(url string, token string, params *connectParams) (*livekit.JoinResponse, error) {
+func (e *RTCEngine) Join(url string, token string, params *SignalClientConnectParams) (*livekit.JoinResponse, error) {
 	res, err := e.client.Join(url, token, *params)
 	if err != nil {
 		return nil, err

--- a/room.go
+++ b/room.go
@@ -89,7 +89,7 @@ type ConnectInfo struct {
 }
 
 // not exposed to users. clients should use ConnectOption
-type connectParams struct {
+type SignalClientConnectParams struct {
 	AutoSubscribe          bool
 	Reconnect              bool
 	DisableRegionDiscovery bool
@@ -103,10 +103,10 @@ type connectParams struct {
 	ICETransportPolicy webrtc.ICETransportPolicy
 }
 
-type ConnectOption func(*connectParams)
+type ConnectOption func(*SignalClientConnectParams)
 
 func WithAutoSubscribe(val bool) ConnectOption {
-	return func(p *connectParams) {
+	return func(p *SignalClientConnectParams) {
 		p.AutoSubscribe = val
 	}
 }
@@ -114,7 +114,7 @@ func WithAutoSubscribe(val bool) ConnectOption {
 // Retransmit buffer size to reponse to nack request,
 // must be one of: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768
 func WithRetransmitBufferSize(val uint16) ConnectOption {
-	return func(p *connectParams) {
+	return func(p *SignalClientConnectParams) {
 		p.RetransmitBufferSize = val
 	}
 }
@@ -122,25 +122,25 @@ func WithRetransmitBufferSize(val uint16) ConnectOption {
 // WithPacer enables the use of a pacer on this connection
 // A pacer helps to smooth out video packet rate to avoid overwhelming downstream. Learn more at: https://chromium.googlesource.com/external/webrtc/+/master/modules/pacing/g3doc/index.md
 func WithPacer(pacer pacer.Factory) ConnectOption {
-	return func(p *connectParams) {
+	return func(p *SignalClientConnectParams) {
 		p.Pacer = pacer
 	}
 }
 
 func WithInterceptors(interceptors []interceptor.Factory) ConnectOption {
-	return func(p *connectParams) {
+	return func(p *SignalClientConnectParams) {
 		p.Interceptors = interceptors
 	}
 }
 
 func WithICETransportPolicy(iceTransportPolicy webrtc.ICETransportPolicy) ConnectOption {
-	return func(p *connectParams) {
+	return func(p *SignalClientConnectParams) {
 		p.ICETransportPolicy = iceTransportPolicy
 	}
 }
 
 func WithDisableRegionDiscovery() ConnectOption {
-	return func(p *connectParams) {
+	return func(p *SignalClientConnectParams) {
 		p.DisableRegionDiscovery = true
 	}
 }
@@ -257,7 +257,7 @@ func (r *Room) PrepareConnection(url, token string) error {
 
 // Join - joins the room as with default permissions
 func (r *Room) Join(url string, info ConnectInfo, opts ...ConnectOption) error {
-	var params connectParams
+	var params SignalClientConnectParams
 	for _, opt := range opts {
 		opt(&params)
 	}
@@ -285,7 +285,7 @@ func (r *Room) Join(url string, info ConnectInfo, opts ...ConnectOption) error {
 
 // JoinWithToken - customize participant options by generating your own token
 func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
-	params := &connectParams{
+	params := &SignalClientConnectParams{
 		AutoSubscribe: true,
 	}
 	for _, opt := range opts {

--- a/signalclient.go
+++ b/signalclient.go
@@ -81,7 +81,7 @@ func (c *SignalClient) IsStarted() bool {
 	return c.isStarted.Load()
 }
 
-func (c *SignalClient) Join(urlPrefix string, token string, params connectParams) (*livekit.JoinResponse, error) {
+func (c *SignalClient) Join(urlPrefix string, token string, params SignalClientConnectParams) (*livekit.JoinResponse, error) {
 	res, err := c.connect(urlPrefix, token, params, "")
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (c *SignalClient) Join(urlPrefix string, token string, params connectParams
 
 // Reconnect starts a new WebSocket connection to the server, passing in reconnect=1
 // when successful, it'll return a ReconnectResponse; older versions of the server will not send back a ReconnectResponse
-func (c *SignalClient) Reconnect(urlPrefix string, token string, params connectParams, participantSID string) (*livekit.ReconnectResponse, error) {
+func (c *SignalClient) Reconnect(urlPrefix string, token string, params SignalClientConnectParams, participantSID string) (*livekit.ReconnectResponse, error) {
 	params.Reconnect = true
 	res, err := c.connect(urlPrefix, token, params, participantSID)
 	if err != nil {
@@ -121,7 +121,7 @@ func (c *SignalClient) Reconnect(urlPrefix string, token string, params connectP
 	return nil, nil
 }
 
-func (c *SignalClient) connect(urlPrefix string, token string, params connectParams, participantSID string) (*livekit.SignalResponse, error) {
+func (c *SignalClient) connect(urlPrefix string, token string, params SignalClientConnectParams, participantSID string) (*livekit.SignalResponse, error) {
 	if urlPrefix == "" {
 		return nil, ErrURLNotProvided
 	}

--- a/signalclient_test.go
+++ b/signalclient_test.go
@@ -23,13 +23,13 @@ import (
 func TestSignalClient_Join(t *testing.T) {
 	t.Run("rejects empty URLs", func(t *testing.T) {
 		c := NewSignalClient()
-		_, err := c.Join("", "", connectParams{})
+		_, err := c.Join("", "", SignalClientConnectParams{})
 		require.Equal(t, ErrURLNotProvided, err)
 	})
 
 	t.Run("errors on invalid URLs", func(t *testing.T) {
 		c := NewSignalClient()
-		_, err := c.Join("https://invalid-livekit-url", "", connectParams{})
+		_, err := c.Join("https://invalid-livekit-url", "", SignalClientConnectParams{})
 		require.Error(t, err)
 		require.NotEqual(t, ErrURLNotProvided, err)
 	})


### PR DESCRIPTION
Fix https://github.com/livekit/server-sdk-go/issues/534