### PR TITLE
Send local participant SID with reconnect=1.

### DIFF
--- a/room.go
+++ b/room.go
@@ -197,8 +197,11 @@ func NewRoom(callback *RoomCallback) *Room {
 	engine.OnRestarted = r.handleRestarted
 	engine.OnResuming = r.handleResuming
 	engine.OnResumed = r.handleResumed
-	engine.client.OnLocalTrackUnpublished = r.handleLocalTrackUnpublished
-	engine.client.OnTrackRemoteMuted = r.handleTrackRemoteMuted
+	engine.OnLocalTrackUnpublished = r.handleLocalTrackUnpublished
+	engine.OnTrackRemoteMuted = r.handleTrackRemoteMuted
+
+	// callbacks engine can use to get data
+	engine.CbGetLocalParticipantSID = r.getLocalParticipantSID
 
 	return r
 }
@@ -817,6 +820,12 @@ func (r *Room) Simulate(scenario SimulateScenario) {
 		})
 	}
 }
+
+func (r *Room) getLocalParticipantSID() string {
+	return r.LocalParticipant.SID()
+}
+
+// ---------------------------------------------------------
 
 func unpackStreamID(packed string) (participantId string, trackId string) {
 	parts := strings.Split(packed, "|")

--- a/signalclient.go
+++ b/signalclient.go
@@ -82,7 +82,7 @@ func (c *SignalClient) IsStarted() bool {
 }
 
 func (c *SignalClient) Join(urlPrefix string, token string, params connectParams) (*livekit.JoinResponse, error) {
-	res, err := c.connect(urlPrefix, token, params)
+	res, err := c.connect(urlPrefix, token, params, "")
 	if err != nil {
 		return nil, err
 	}
@@ -97,9 +97,9 @@ func (c *SignalClient) Join(urlPrefix string, token string, params connectParams
 
 // Reconnect starts a new WebSocket connection to the server, passing in reconnect=1
 // when successful, it'll return a ReconnectResponse; older versions of the server will not send back a ReconnectResponse
-func (c *SignalClient) Reconnect(urlPrefix string, token string, params connectParams) (*livekit.ReconnectResponse, error) {
+func (c *SignalClient) Reconnect(urlPrefix string, token string, params connectParams, participantSID string) (*livekit.ReconnectResponse, error) {
 	params.Reconnect = true
-	res, err := c.connect(urlPrefix, token, params)
+	res, err := c.connect(urlPrefix, token, params, participantSID)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (c *SignalClient) Reconnect(urlPrefix string, token string, params connectP
 	return nil, nil
 }
 
-func (c *SignalClient) connect(urlPrefix string, token string, params connectParams) (*livekit.SignalResponse, error) {
+func (c *SignalClient) connect(urlPrefix string, token string, params connectParams, participantSID string) (*livekit.SignalResponse, error) {
 	if urlPrefix == "" {
 		return nil, ErrURLNotProvided
 	}
@@ -135,6 +135,9 @@ func (c *SignalClient) connect(urlPrefix string, token string, params connectPar
 	}
 	if params.Reconnect {
 		urlSuffix += "&reconnect=1"
+		if participantSID != "" {
+			urlSuffix += fmt.Sprintf("&sid=%s", participantSID)
+		}
 	}
 	urlSuffix += getStatsParamString()
 


### PR DESCRIPTION
Also, some minor clean up as room was reaching into client and setting a callback (for track unpublished) which was also going through engine. Just make it so that the chain is always room -> engine -> signalclient.