### PR TITLE
Deferred track subscribe.

### DIFF
--- a/room.go
+++ b/room.go
@@ -400,7 +400,7 @@ func (r *Room) clearParticipantDefers(sid livekit.ParticipantID, pi *livekit.Par
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	for trackID, _ := range r.sidDefers[sid] {
+	for trackID := range r.sidDefers[sid] {
 		found := false
 		for _, ti := range pi.Tracks {
 			if livekit.TrackID(ti.GetSid()) == trackID {


### PR DESCRIPTION
It was not running at all in the following scenario
- existing room with a participant
- join from Go SDK participant
- somehow get a deferred update (needs more investigation if server is sending the track before participant update or Go SDK has a race, probably Go SDK as this happens even before JoinResponse is processed)
- that deferred track subscribe never runs as there are no more remote participant updates
- even if there were remote participant updates, it ran only when the SID changed.

Fix it by running it more gratuitously (after remote participant is created or getting another track subscribe).

There is the issue of track going away before defer can run. Have to work on that.
UPDATE on ☝️ : Added code to clear defers on unpublish in this [commit](https://github.com/livekit/server-sdk-go/pull/561/commits/238774a708f5027fc1664f48ee1e4a389d2740d3).