### PR TITLE
Do not attempt to send an offer if the PCTransport was closed

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -368,6 +368,11 @@ func (e *RTCEngine) configure(
 
 	// configure client
 	e.client.OnAnswer = func(sd webrtc.SessionDescription) {
+		if e.closed.Load() {
+			e.log.Debugw("ignoring SDP answer after closed")
+			return
+		}
+
 		if err := e.publisher.SetRemoteDescription(sd); err != nil {
 			e.log.Errorw("could not set remote description", err)
 		} else {
@@ -375,6 +380,11 @@ func (e *RTCEngine) configure(
 		}
 	}
 	e.client.OnTrickle = func(init webrtc.ICECandidateInit, target livekit.SignalTarget) {
+		if e.closed.Load() {
+			e.log.Debugw("ignoring trickle after closed")
+			return
+		}
+
 		var err error
 		e.log.Debugw("remote ICE candidate",
 			"target", target,
@@ -390,6 +400,11 @@ func (e *RTCEngine) configure(
 		}
 	}
 	e.client.OnOffer = func(sd webrtc.SessionDescription) {
+		if e.closed.Load() {
+			e.log.Debugw("ignoring SDP offer after closed")
+			return
+		}
+
 		e.log.Debugw("received offer for subscriber")
 		if err := e.subscriber.SetRemoteDescription(sd); err != nil {
 			e.log.Errorw("could not set remote description", err)

--- a/errors.go
+++ b/errors.go
@@ -29,4 +29,5 @@ var (
 	ErrCannotConnectSignal      = errors.New("could not establish signal connection")
 	ErrCannotDialSignal         = errors.New("could not dial signal connection")
 	ErrNoPeerConnection         = errors.New("peer connection not established")
+	ErrAborted                  = errors.New("operation was aborted")
 )


### PR DESCRIPTION
This causes the PCTransport Close method to block on the object lock to ensure closing it is properly serialized with other operations on the object.