### PR TITLE
Add OnTranscription Handler

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -46,7 +46,7 @@ type ParticipantCallback struct {
 	OnTrackUnpublished        func(publication *RemoteTrackPublication, rp *RemoteParticipant)
 	OnDataReceived            func(data []byte, params DataReceiveParams) // Deprecated: Use OnDataPacket instead
 	OnDataPacket              func(data DataPacket, params DataReceiveParams)
-	OnTranscriptionReceived   func(transcriptionSegments []*TranscriptionSegment, p Participant, publication *RemoteTrackPublication)
+	OnTranscriptionReceived   func(transcriptionSegments []*TranscriptionSegment, p Participant, publication TrackPublication)
 }
 
 func NewParticipantCallback() *ParticipantCallback {
@@ -67,8 +67,7 @@ func NewParticipantCallback() *ParticipantCallback {
 		OnTrackUnpublished:         func(publication *RemoteTrackPublication, rp *RemoteParticipant) {},
 		OnDataReceived:             func(data []byte, params DataReceiveParams) {},
 		OnDataPacket:               func(data DataPacket, params DataReceiveParams) {},
-		OnTranscriptionReceived: func(transcriptionSegments []*TranscriptionSegment, p Participant, publication *RemoteTrackPublication) {
-		},
+		OnTranscriptionReceived:    func(transcriptionSegments []*TranscriptionSegment, p Participant, publication TrackPublication) {},
 	}
 }
 

--- a/callback.go
+++ b/callback.go
@@ -46,6 +46,7 @@ type ParticipantCallback struct {
 	OnTrackUnpublished        func(publication *RemoteTrackPublication, rp *RemoteParticipant)
 	OnDataReceived            func(data []byte, params DataReceiveParams) // Deprecated: Use OnDataPacket instead
 	OnDataPacket              func(data DataPacket, params DataReceiveParams)
+	OnTranscriptionReceived   func(transcriptionSegments []*TranscriptionSegment, p Participant, publication *RemoteTrackPublication)
 }
 
 func NewParticipantCallback() *ParticipantCallback {
@@ -66,6 +67,8 @@ func NewParticipantCallback() *ParticipantCallback {
 		OnTrackUnpublished:         func(publication *RemoteTrackPublication, rp *RemoteParticipant) {},
 		OnDataReceived:             func(data []byte, params DataReceiveParams) {},
 		OnDataPacket:               func(data DataPacket, params DataReceiveParams) {},
+		OnTranscriptionReceived: func(transcriptionSegments []*TranscriptionSegment, p Participant, publication *RemoteTrackPublication) {
+		},
 	}
 }
 
@@ -114,6 +117,9 @@ func (cb *ParticipantCallback) Merge(other *ParticipantCallback) {
 	}
 	if other.OnDataPacket != nil {
 		cb.OnDataPacket = other.OnDataPacket
+	}
+	if other.OnTranscriptionReceived != nil {
+		cb.OnTranscriptionReceived = other.OnTranscriptionReceived
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -81,6 +81,7 @@ type RTCEngine struct {
 	OnRestarted             func(*livekit.JoinResponse)
 	OnResuming              func()
 	OnResumed               func()
+	OnTranscription         func(*livekit.Transcription)
 
 	// callbacks to get data
 	CbGetLocalParticipantSID func() string
@@ -560,6 +561,10 @@ func (e *RTCEngine) handleDataPacket(msg webrtc.DataChannelMessage) {
 	case *livekit.DataPacket_SipDtmf:
 		if e.OnDataPacket != nil {
 			e.OnDataPacket(identity, msg.SipDtmf)
+		}
+	case *livekit.DataPacket_Transcription:
+		if e.OnTranscription != nil {
+			e.OnTranscription(msg.Transcription)
 		}
 	}
 }

--- a/room.go
+++ b/room.go
@@ -717,13 +717,19 @@ func (r *Room) handleLocalTrackUnpublished(msg *livekit.TrackUnpublishedResponse
 }
 
 func (r *Room) handleTranscriptionReceived(transcription *livekit.Transcription) {
-	// find the participant
+	var (
+		p           Participant
+		publication TrackPublication
+	)
+
 	if transcription.TranscribedParticipantIdentity == r.LocalParticipant.Identity() {
-		// if sent by itself, do not handle data
-		return
+		p = r.LocalParticipant
+		publication = r.LocalParticipant.getPublication(transcription.TrackId)
+	} else {
+		rp := r.GetParticipantByIdentity(transcription.TranscribedParticipantIdentity)
+		publication = rp.getPublication(transcription.TrackId)
+		p = rp
 	}
-	p := r.GetParticipantByIdentity(transcription.TranscribedParticipantIdentity)
-	publication := p.getPublication(transcription.TrackId)
 	transcriptionSegments := ExtractTranscriptionSegments(transcription)
 
 	r.callback.OnTranscriptionReceived(transcriptionSegments, p, publication)

--- a/transcription.go
+++ b/transcription.go
@@ -1,0 +1,47 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lksdk
+
+import (
+	"github.com/livekit/protocol/livekit"
+)
+
+type TranscriptionSegment struct {
+	ID        string
+	Text      string
+	Language  string
+	StartTime uint64
+	EndTime   uint64
+	Final     bool
+}
+
+func ExtractTranscriptionSegments(transcription *livekit.Transcription) []*TranscriptionSegment {
+	var segments []*TranscriptionSegment
+	if transcription == nil {
+		return segments
+	}
+	segments = make([]*TranscriptionSegment, len(transcription.Segments))
+	for i := range transcription.Segments {
+		segments[i] = &TranscriptionSegment{
+			ID:        transcription.Segments[i].Id,
+			Text:      transcription.Segments[i].Text,
+			Language:  transcription.Segments[i].Language,
+			StartTime: transcription.Segments[i].StartTime,
+			EndTime:   transcription.Segments[i].EndTime,
+			Final:     transcription.Segments[i].Final,
+		}
+	}
+	return segments
+}


### PR DESCRIPTION
This PR adds an OnTranscription handler to manage transcription events in the Go SDK, following the implementation in [livekit/client-sdk-js#1119](https://github.com/livekit/client-sdk-js/pull/1119) for consistency.

Key Updates:
- Implements OnTranscription callback.
- Matches JavaScript SDK behavior.
- Enhances transcription handling in the Go SDK.