### PR TITLE
Do not fail to initialize the jitter buffer if the first enqueued buffer is not a partition start

### DIFF
--- a/pkg/jitter/buffer.go
+++ b/pkg/jitter/buffer.go
@@ -78,7 +78,7 @@ func (b *Buffer) UpdateMaxLatency(maxLatency time.Duration) {
 func (b *Buffer) Push(pkt *rtp.Packet) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-
+	fmt.Println("PUSH", len(pkt.Payload))
 	b.packetsTotal++
 	var start, end, padding bool
 	if len(pkt.Payload) == 0 {

--- a/pkg/jitter/buffer.go
+++ b/pkg/jitter/buffer.go
@@ -109,6 +109,9 @@ func (b *Buffer) Push(pkt *rtp.Packet) {
 			b.prevSN = pkt.SequenceNumber - 1
 			b.minTS = pkt.Timestamp - b.maxLate
 			p.reset = true
+		} else {
+			// drop the buffer
+			return
 		}
 	} else if beforePrev && !outsidePrevRange {
 		// drop if packet comes before previously pushed packet

--- a/pkg/jitter/buffer.go
+++ b/pkg/jitter/buffer.go
@@ -101,8 +101,10 @@ func (b *Buffer) Push(pkt *rtp.Packet) {
 	outsidePrevRange := outsideRange(pkt.SequenceNumber, b.prevSN)
 
 	if !b.initialized {
+		fmt.Println("NOT INIT", p.start, b.head)
 		if p.start && (b.head == nil || before16(pkt.SequenceNumber, b.head.packet.SequenceNumber)) {
 			// initialize on the first start packet
+			fmt.Println("INITIALIZED")
 			b.initialized = true
 			b.prevSN = pkt.SequenceNumber - 1
 			b.minTS = pkt.Timestamp - b.maxLate

--- a/pkg/jitter/buffer.go
+++ b/pkg/jitter/buffer.go
@@ -15,6 +15,7 @@
 package jitter
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -91,6 +92,7 @@ func (b *Buffer) Push(pkt *rtp.Packet) {
 	} else {
 		start = b.depacketizer.IsPartitionHead(pkt.Payload)
 		end = b.depacketizer.IsPartitionTail(pkt.Marker, pkt.Payload)
+		fmt.Println("PARTITION", start, end)
 	}
 
 	p := b.newPacket(start, end, padding, pkt)
@@ -277,11 +279,13 @@ func (b *Buffer) pop() []*rtp.Packet {
 
 	b.drop()
 	if b.head == nil || !b.head.start {
+		fmt.Println("No start")
 		return nil
 	}
 
 	end := b.getEnd()
 	if end == nil {
+		fmt.Println("No end")
 		return nil
 	}
 
@@ -368,6 +372,7 @@ func (b *Buffer) getEnd() *packet {
 		if c.packet.SequenceNumber != prevSN+1 &&
 			// or a reset which is about to reach its time limit
 			(!prevComplete || !c.reset || !before32(c.packet.Timestamp-b.maxSampleSize, b.minTS)) {
+			fmt.Println("PREV", prevSN, c.packet.SequenceNumber)
 			break
 		}
 		if prevComplete {
@@ -380,6 +385,7 @@ func (b *Buffer) getEnd() *packet {
 		prevSN = c.packet.SequenceNumber
 	}
 
+	fmt.Println("END", end)
 	return end
 }
 


### PR DESCRIPTION
This drops buffers that are sent to the jitter buffer before the first partition start