### PR TITLE
Keep chunks in deque. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ bin/
 
 # data stream test files
 *.mp4
+
+#env
+.env

--- a/examples/openai_realtime_voice/.env.example
+++ b/examples/openai_realtime_voice/.env.example
@@ -1,0 +1,8 @@
+API_KEY=your-api-key
+WSS_URL=wss://api.openai.com/v1/realtime
+MODEL=gpt-4o-realtime-preview-2024-12-17
+LK_HOST=ws://localhost:7880
+LK_API_KEY=devkey
+LK_API_SECRET=secret
+LK_ROOM_NAME=test
+LK_PARTICIPANT_IDENTITY=go-test

--- a/examples/openai_realtime_voice/main.go
+++ b/examples/openai_realtime_voice/main.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/livekit/media-sdk"
+	"github.com/livekit/protocol/logger"
+	lksdk "github.com/livekit/server-sdk-go/v2"
+	lkmedia "github.com/livekit/server-sdk-go/v2/pkg/media"
+	"github.com/pion/webrtc/v4"
+)
+
+const (
+	roomName  = "test-room"
+	host      = "ws://localhost:7880"
+	apiKey    = "devkey"
+	apiSecret = "secret"
+)
+
+func callbacksForLkRoom(ws *WsManager) *lksdk.RoomCallback {
+	var pcmRemoteTrack *lkmedia.PCMRemoteTrack
+
+	return &lksdk.RoomCallback{
+		ParticipantCallback: lksdk.ParticipantCallback{
+			OnTrackSubscribed: func(track *webrtc.TrackRemote, publication *lksdk.RemoteTrackPublication, rp *lksdk.RemoteParticipant) {
+				if pcmRemoteTrack != nil {
+					// only handle one track
+					return
+				}
+				pcmRemoteTrack, _ = handleSubscribe(track, ws)
+			},
+		},
+		OnDisconnected: func() {
+			if pcmRemoteTrack != nil {
+				pcmRemoteTrack.Close()
+				pcmRemoteTrack = nil
+			}
+		},
+		OnDisconnectedWithReason: func(reason lksdk.DisconnectionReason) {
+			if pcmRemoteTrack != nil {
+				pcmRemoteTrack.Close()
+				pcmRemoteTrack = nil
+			}
+		},
+	}
+}
+
+func main() {
+	loadEnv()
+
+	audioWriterChan := make(chan media.PCM16Sample)
+	defer close(audioWriterChan)
+
+	ws, err := NewWsManager(&WsManagerCallbacks{
+		OnAudioReceived: func(audio media.PCM16Sample) {
+			audioWriterChan <- audio
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer ws.Close()
+
+	room, err := connectToLKRoom(callbacksForLkRoom(ws))
+	if err != nil {
+		panic(err)
+	}
+	defer room.Disconnect()
+	go handlePublish(room, audioWriterChan)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT)
+
+	<-sigChan
+}
+
+func handlePublish(room *lksdk.Room, audioWriterChan chan media.PCM16Sample) {
+	publishTrack, err := lkmedia.NewPCMLocalTrack(24000, 1, logger.GetLogger())
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		publishTrack.ClearQueue()
+		publishTrack.Close()
+	}()
+
+	if _, err = room.LocalParticipant.PublishTrack(publishTrack, &lksdk.TrackPublicationOptions{
+		Name: "test",
+	}); err != nil {
+		panic(err)
+	}
+
+	for {
+		select {
+		case sample, ok := <-audioWriterChan:
+			if !ok {
+				return
+			}
+
+			if err := publishTrack.WriteSample(sample); err != nil {
+				logger.Errorw("Failed to write sample", err)
+			}
+		}
+	}
+}
+
+func handleSubscribe(track *webrtc.TrackRemote, ws *WsManager) (*lkmedia.PCMRemoteTrack, error) {
+	fmt.Println("Handling subscribe")
+	if track.Codec().MimeType != webrtc.MimeTypeOpus {
+		logger.Warnw("Received non-opus track", nil, "track", track.Codec().MimeType)
+	}
+
+	writer := NewRemoteTrackWriter(ws)
+	trackWriter, err := lkmedia.NewPCMRemoteTrack(track, writer, lkmedia.WithTargetSampleRate(24000))
+	if err != nil {
+		logger.Errorw("Failed to create remote track", err)
+		return nil, err
+	}
+
+	return trackWriter, nil
+}

--- a/examples/openai_realtime_voice/realtime_api_helpers.go
+++ b/examples/openai_realtime_voice/realtime_api_helpers.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+
+	"github.com/livekit/media-sdk"
+	"github.com/livekit/protocol/logger"
+)
+
+func sendAudioChunk(ws *WsManager, sample media.PCM16Sample) error {
+	bytes := make([]byte, len(sample)*2)
+	for i, s := range sample {
+		binary.LittleEndian.PutUint16(bytes[i*2:], uint16(s))
+	}
+	encodedSample := base64.StdEncoding.EncodeToString(bytes)
+	return ws.SendMessage("input_audio_buffer.append", "audio", encodedSample)
+}
+
+func handleMessage(message string, cb *WsManagerCallbacks) {
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(message), &data)
+	if err != nil {
+		logger.Errorw("Failed to unmarshal message", err)
+		return
+	}
+
+	switch data["type"] {
+	case "response.audio.delta":
+		audioBase64 := data["delta"].(string)
+		audioBytes, err := base64.StdEncoding.DecodeString(audioBase64)
+		audioPCM16 := make(media.PCM16Sample, len(audioBytes)/2)
+		for i := 0; i < len(audioBytes); i += 2 {
+			audioPCM16[i/2] = int16(binary.LittleEndian.Uint16(audioBytes[i : i+2]))
+		}
+		if err != nil {
+			logger.Errorw("Failed to decode audio", err)
+			return
+		}
+		cb.OnAudioReceived(audioPCM16)
+	default:
+		logger.Errorw("Unknown message type", nil, "type", data["type"])
+	}
+}

--- a/examples/openai_realtime_voice/remote_track_writer.go
+++ b/examples/openai_realtime_voice/remote_track_writer.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"errors"
+
+	"go.uber.org/atomic"
+
+	"github.com/livekit/media-sdk"
+)
+
+var ErrClosed = errors.New("writer is closed")
+
+type RemoteTrackWriter struct {
+	ws     *WsManager
+	closed atomic.Bool
+}
+
+func NewRemoteTrackWriter(ws *WsManager) *RemoteTrackWriter {
+	return &RemoteTrackWriter{
+		ws: ws,
+	}
+}
+
+func (w *RemoteTrackWriter) WriteSample(sample media.PCM16Sample) error {
+	if w.closed.Load() {
+		return ErrClosed
+	}
+
+	return sendAudioChunk(w.ws, sample)
+}
+
+func (w *RemoteTrackWriter) Close() error {
+	w.closed.Swap(true)
+	return nil
+}

--- a/examples/openai_realtime_voice/room_helpers.go
+++ b/examples/openai_realtime_voice/room_helpers.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/gorilla/websocket"
+	"github.com/joho/godotenv"
+
+	lksdk "github.com/livekit/server-sdk-go/v2"
+)
+
+func loadEnv() {
+	err := godotenv.Load()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func connectToWSS() (*websocket.Conn, string, error) {
+	wssUrl := os.Getenv("WSS_URL")
+	apiKey := os.Getenv("API_KEY")
+	model := os.Getenv("MODEL")
+
+	u, err := url.Parse(wssUrl)
+	if err != nil {
+		panic(err)
+	}
+
+	q := u.Query()
+	q.Add("model", model)
+	u.RawQuery = q.Encode()
+
+	header := http.Header{}
+	header.Add("Authorization", "Bearer "+apiKey)
+	header.Add("OpenAI-Beta", "realtime=v1")
+
+	conn, _, err := websocket.DefaultDialer.Dial(u.String(), header)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return conn, wssUrl, nil
+}
+
+func connectToLKRoom(cb *lksdk.RoomCallback) (*lksdk.Room, error) {
+	host := os.Getenv("LK_HOST")
+	apiKey := os.Getenv("LK_API_KEY")
+	apiSecret := os.Getenv("LK_API_SECRET")
+	roomName := os.Getenv("LK_ROOM_NAME")
+	participantIdentity := os.Getenv("LK_PARTICIPANT_IDENTITY")
+
+	room, err := lksdk.ConnectToRoom(host, lksdk.ConnectInfo{
+		APIKey:              apiKey,
+		APISecret:           apiSecret,
+		RoomName:            roomName,
+		ParticipantIdentity: participantIdentity,
+	}, cb)
+	if err != nil {
+		return nil, err
+	}
+	return room, nil
+}

--- a/examples/openai_realtime_voice/ws_manager.go
+++ b/examples/openai_realtime_voice/ws_manager.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/gorilla/websocket"
+	"github.com/livekit/media-sdk"
+	"github.com/livekit/protocol/logger"
+)
+
+type WsManager struct {
+	conn *websocket.Conn
+	url  string
+	cb   *WsManagerCallbacks
+}
+
+type WsManagerCallbacks struct {
+	OnAudioReceived func(audio media.PCM16Sample)
+}
+
+func NewWsManager(cb *WsManagerCallbacks) (*WsManager, error) {
+	conn, url, err := connectToWSS()
+	if err != nil {
+		return nil, err
+	}
+
+	ws := &WsManager{
+		conn: conn,
+		url:  url,
+		cb:   cb,
+	}
+
+	go ws.readMessages()
+	return ws, nil
+}
+
+func (m *WsManager) Url() string {
+	return m.url
+}
+
+func (m *WsManager) SendMessage(messageType string, key string, value string) error {
+	message := fmt.Sprintf(`{"type": "%s", "%s": "%s"}`, messageType, key, value)
+	err := m.conn.WriteMessage(websocket.TextMessage, []byte(message))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *WsManager) readMessages() {
+	for {
+		messageType, message, err := m.conn.ReadMessage()
+		if err != nil {
+			logger.Errorw("Error reading message", err)
+			m.Close()
+			break
+		}
+
+		fmt.Printf("Received message type %d: %s\n", messageType, string(message))
+		handleMessage(string(message), m.cb)
+	}
+}
+
+func (m *WsManager) Close() error {
+	return m.conn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/google/cel-go v0.25.0 // indirect
 	github.com/jfreymuth/oggvorbis v1.0.5 // indirect
 	github.com/jfreymuth/vorbis v1.0.2 // indirect
+	github.com/joho/godotenv v1.5.1
 	github.com/jxskiss/base62 v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/jfreymuth/oggvorbis v1.0.5 h1:u+Ck+R0eLSRhgq8WTmffYnrVtSztJcYrl588DM4
 github.com/jfreymuth/oggvorbis v1.0.5/go.mod h1:1U4pqWmghcoVsCJJ4fRBKv9peUJMBHixthRlBeD6uII=
 github.com/jfreymuth/vorbis v1.0.2 h1:m1xH6+ZI4thH927pgKD8JOH4eaGRm18rEE9/0WKjvNE=
 github.com/jfreymuth/vorbis v1.0.2/go.mod h1:DoftRo4AznKnShRl1GxiTFCseHr4zR9BN3TWXyuzrqQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=
 github.com/jxskiss/base62 v1.1.0/go.mod h1:HhWAlUXvxKThfOlZbcuFzsqwtF5TcqS9ru3y5GfjWAc=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/pkg/media/audiotrack.go
+++ b/pkg/media/audiotrack.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	DefaultOpusSampleRate     = 48000
-	DefaultOpusSampleDuration = 20 * time.Millisecond
-	defaultPCMSampleDuration  = 10000 * time.Microsecond
+	DefaultOpusSampleRate    = 48000
+	DefaultOpusFrameDuration = 20 * time.Millisecond
+	defaultPCMFrameDuration  = 10 * time.Millisecond
 )
 
 type PCMLocalTrackParams struct {
@@ -46,12 +46,12 @@ type PCMLocalTrack struct {
 	sourceSampleRate     int
 	frameDuration        time.Duration
 	sourceChannels       int
-	chunksPerSample      int
+	samplesPerFrame      int
 	writeSilenceOnNoData bool
 
 	// int16 to support a LE/BE PCM16 chunk that has a high byte and low byte
 	// TODO(anunaym14): switch out deque for a ring buffer
-	chunkBuffer *deque.Deque[int16]
+	chunkBuffer *deque.Deque[media.PCM16Sample]
 
 	mu   sync.Mutex
 	cond *sync.Cond
@@ -87,7 +87,7 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 	}
 
 	// opusWriter writes opus samples to the track
-	opusWriter := media.FromSampleWriter[opus.Sample](track, DefaultOpusSampleRate, defaultPCMSampleDuration)
+	opusWriter := media.FromSampleWriter[opus.Sample](track, DefaultOpusSampleRate, defaultPCMFrameDuration)
 	// pcmWriter encodes opus samples from PCM16 samples and writes them to opusWriter
 	pcmWriter, err := opus.Encode(opusWriter, sourceChannels, logger)
 	if err != nil {
@@ -111,10 +111,10 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 		pcmWriter:              pcmWriter,
 		resampledPCMWriter:     resampledPCMWriter,
 		sourceSampleRate:       sourceSampleRate,
-		frameDuration:          defaultPCMSampleDuration,
+		frameDuration:          defaultPCMFrameDuration,
 		sourceChannels:         sourceChannels,
-		chunkBuffer:            new(deque.Deque[int16]),
-		chunksPerSample:        (sourceSampleRate * sourceChannels * int(defaultPCMSampleDuration/time.Nanosecond)) / 1e9,
+		chunkBuffer:            new(deque.Deque[media.PCM16Sample]),
+		samplesPerFrame:        (sourceSampleRate * sourceChannels * int(defaultPCMFrameDuration/time.Nanosecond)) / 1e9,
 		writeSilenceOnNoData:   params.WriteSilenceOnNoData,
 	}
 
@@ -124,21 +124,21 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 	return t, nil
 }
 
-func (t *PCMLocalTrack) pushChunksToBuffer(sample media.PCM16Sample) {
-	for _, chunk := range sample {
+func (t *PCMLocalTrack) pushChunksToBuffer(chunk media.PCM16Sample) {
+	if len(chunk) != 0 {
 		t.chunkBuffer.PushBack(chunk)
 	}
 }
 
-func (t *PCMLocalTrack) waitUntilBufferHasChunks(count int) bool {
+func (t *PCMLocalTrack) waitUntilBufferHasSamples(count int) bool {
 	var didWait bool
 
-	if t.closed.Load() && t.chunkBuffer.Len() > 0 {
+	if t.closed.Load() && t.getNumSamplesInChunkBuffer() > 0 {
 		// write whatever is left, with silence as filler
 		return false
 	}
 
-	for t.chunkBuffer.Len() < count && !t.closed.Load() {
+	for t.getNumSamplesInChunkBuffer() < count && !t.closed.Load() {
 		t.emptyBufMu.Lock()
 		t.emptyBufCond.Broadcast()
 		t.emptyBufMu.Unlock()
@@ -150,30 +150,36 @@ func (t *PCMLocalTrack) waitUntilBufferHasChunks(count int) bool {
 	return didWait
 }
 
-func (t *PCMLocalTrack) getChunksFromBuffer() (media.PCM16Sample, bool) {
-	chunks := make(media.PCM16Sample, t.chunksPerSample)
+func (t *PCMLocalTrack) getFrameFromChunkBuffer() (media.PCM16Sample, bool) {
+	frame := make(media.PCM16Sample, 0, t.samplesPerFrame)
 
 	var didWait = false
 	if !t.writeSilenceOnNoData {
-		didWait = t.waitUntilBufferHasChunks(t.chunksPerSample)
+		didWait = t.waitUntilBufferHasSamples(t.samplesPerFrame)
 	}
 
-	if t.closed.Load() && t.chunkBuffer.Len() == 0 {
+	if t.closed.Load() && t.getNumSamplesInChunkBuffer() == 0 {
 		return nil, false
 	}
 
-	for i := 0; i < t.chunksPerSample; i++ {
-		if t.chunkBuffer.Len() == 0 {
-			// this will zero-init at index i, which will be a silent chunk.
-			// if writeSilenceOnNoData is false, this condition will only be true
-			// when the track is closed and the buffer does not have enough chunks.
-			continue
-		} else {
-			chunks[i] = t.chunkBuffer.PopFront()
+	for len(frame) < t.samplesPerFrame && t.chunkBuffer.Len() != 0 {
+		chunk := t.chunkBuffer.PopFront()
+		remaining := min(t.samplesPerFrame-len(frame), len(chunk))
+		frame = append(frame, chunk[:remaining]...)
+		if remaining < len(chunk) {
+			t.chunkBuffer.PushFront(chunk[remaining:])
 		}
 	}
 
-	return chunks, didWait
+	return frame, didWait
+}
+
+func (t *PCMLocalTrack) getNumSamplesInChunkBuffer() int {
+	numSamples := 0
+	for i := 0; i < t.chunkBuffer.Len(); i++ {
+		numSamples += len(t.chunkBuffer.At(i))
+	}
+	return numSamples
 }
 
 func (t *PCMLocalTrack) WriteSample(sample media.PCM16Sample) error {
@@ -193,16 +199,16 @@ func (t *PCMLocalTrack) processSamples() {
 	defer ticker.Stop()
 
 	for {
-		if t.closed.Load() && t.chunkBuffer.Len() == 0 {
+		if t.closed.Load() && t.getNumSamplesInChunkBuffer() == 0 {
 			break
 		}
 
 		t.mu.Lock()
-		sample, didWait := t.getChunksFromBuffer()
-		if sample != nil {
-			// sample is only nil when the track is closed, so we don't need to
+		frame, didWait := t.getFrameFromChunkBuffer()
+		if frame != nil {
+			// frame is only nil when the track is closed, so we don't need to
 			// adjust ticker for this case.
-			t.resampledPCMWriter.WriteSample(sample)
+			t.resampledPCMWriter.WriteSample(frame)
 			if didWait {
 				ticker.Reset(t.frameDuration)
 			}
@@ -222,14 +228,12 @@ func (t *PCMLocalTrack) WaitForPlayout() {
 	t.emptyBufMu.Lock()
 	defer t.emptyBufMu.Unlock()
 
-	if t.writeSilenceOnNoData {
-		for t.chunkBuffer.Len() > 0 {
-			t.emptyBufCond.Wait()
-		}
-	} else {
-		for t.chunkBuffer.Len() > t.chunksPerSample {
-			t.emptyBufCond.Wait()
-		}
+	samplesThreshold := 0
+	if !t.writeSilenceOnNoData {
+		samplesThreshold = t.samplesPerFrame
+	}
+	for t.getNumSamplesInChunkBuffer() > samplesThreshold {
+		t.emptyBufCond.Wait()
 	}
 }
 


### PR DESCRIPTION
Re-jiggering a bit of this. Using more standard definitions
- sample: a single qunatised digital audio sample (a single point in
  time)
- frame: a collection of samples with some well-defined duration - 10 ms
  used here for Opus encode (side note: I wish the writer API was called
  WriteFrame instead of WriteSample)
- chunk: a collection of samples of variable duration - like what is
  submitted on PCM side, could be 1 second long, could be 100 ms long,
  etc.

Change the deque to store chunks as is and when processing construct 10
ms frames. Don't think there is a need to convert to samples while
storing in deque. Should keep the deque size smaller and also avoid a
copy.