### PR TITLE
Keep chunks in deque.

### DIFF
--- a/examples/audiotrack/main.go
+++ b/examples/audiotrack/main.go
@@ -138,7 +138,7 @@ func handleSubscribe(track *webrtc.TrackRemote, targetChannels int) (*lkmedia.PC
 		panic(err)
 	}
 
-	webmWriter := webm.NewPCM16Writer(fileWriter, lkmedia.DefaultOpusSampleRate, targetChannels, lkmedia.DefaultOpusSampleDuration)
+	webmWriter := webm.NewPCM16Writer(fileWriter, lkmedia.DefaultOpusSampleRate, targetChannels, lkmedia.DefaultOpusFrameDuration)
 	pcmTrack, err := lkmedia.NewPCMRemoteTrack(track, webmWriter)
 	if err != nil {
 		panic(err)

--- a/examples/audiotrack/main.go
+++ b/examples/audiotrack/main.go
@@ -138,7 +138,7 @@ func handleSubscribe(track *webrtc.TrackRemote, targetChannels int) (*lkmedia.PC
 		panic(err)
 	}
 
-	webmWriter := webm.NewPCM16Writer(fileWriter, lkmedia.DefaultOpusSampleRate, targetChannels, lkmedia.DefaultOpusFrameDuration)
+	webmWriter := webm.NewPCM16Writer(fileWriter, lkmedia.DefaultOpusSampleRate, targetChannels, lkmedia.DefaultOpusSampleDuration)
 	pcmTrack, err := lkmedia.NewPCMRemoteTrack(track, webmWriter)
 	if err != nil {
 		panic(err)

--- a/pkg/media/audiotrack.go
+++ b/pkg/media/audiotrack.go
@@ -124,7 +124,7 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 	return t, nil
 }
 
-func (t *PCMLocalTrack) pushChunksToBuffer(chunk media.PCM16Sample) {
+func (t *PCMLocalTrack) pushChunkToBuffer(chunk media.PCM16Sample) {
 	if len(chunk) != 0 {
 		chunkCopy := make(media.PCM16Sample, len(chunk))
 		copy(chunkCopy, chunk)
@@ -184,13 +184,13 @@ func (t *PCMLocalTrack) getNumSamplesInChunkBuffer() int {
 	return numSamples
 }
 
-func (t *PCMLocalTrack) WriteSample(sample media.PCM16Sample) error {
+func (t *PCMLocalTrack) WriteSample(chunk media.PCM16Sample) error {
 	if t.closed.Load() {
 		return errors.New("track is closed")
 	}
 
 	t.mu.Lock()
-	t.pushChunksToBuffer(sample)
+	t.pushChunkToBuffer(chunk)
 	t.cond.Broadcast()
 	t.mu.Unlock()
 	return nil

--- a/pkg/media/audiotrack.go
+++ b/pkg/media/audiotrack.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	DefaultOpusSampleRate    = 48000
-	DefaultOpusFrameDuration = 20 * time.Millisecond
-	defaultPCMFrameDuration  = 10 * time.Millisecond
+	DefaultOpusSampleRate     = 48000
+	DefaultOpusSampleDuration = 20 * time.Millisecond
+	defaultPCMFrameDuration   = 10 * time.Millisecond
 )
 
 type PCMLocalTrackParams struct {

--- a/pkg/media/audiotrack.go
+++ b/pkg/media/audiotrack.go
@@ -126,7 +126,9 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 
 func (t *PCMLocalTrack) pushChunksToBuffer(chunk media.PCM16Sample) {
 	if len(chunk) != 0 {
-		t.chunkBuffer.PushBack(chunk)
+		chunkCopy := make(media.PCM16Sample, len(chunk))
+		copy(chunkCopy, chunk)
+		t.chunkBuffer.PushBack(chunkCopy)
 	}
 }
 

--- a/pkg/media/audiotrack.go
+++ b/pkg/media/audiotrack.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	DefaultOpusSampleRate     = 48000
-	DefaultOpusSampleDuration = 20 * time.Millisecond
-	defaultPCMSampleDuration  = 10000 * time.Microsecond
+	DefaultOpusSampleRate    = 48000
+	DefaultOpusFrameDuration = 20 * time.Millisecond
+	defaultPCMFrameDuration  = 10 * time.Millisecond
 )
 
 type PCMLocalTrackParams struct {
@@ -46,12 +46,12 @@ type PCMLocalTrack struct {
 	sourceSampleRate     int
 	frameDuration        time.Duration
 	sourceChannels       int
-	chunksPerSample      int
+	samplesPerFrame      int
 	writeSilenceOnNoData bool
 
 	// int16 to support a LE/BE PCM16 chunk that has a high byte and low byte
 	// TODO(anunaym14): switch out deque for a ring buffer
-	chunkBuffer *deque.Deque[int16]
+	chunkBuffer *deque.Deque[media.PCM16Sample]
 
 	mu   sync.Mutex
 	cond *sync.Cond
@@ -87,7 +87,7 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 	}
 
 	// opusWriter writes opus samples to the track
-	opusWriter := media.FromSampleWriter[opus.Sample](track, DefaultOpusSampleRate, defaultPCMSampleDuration)
+	opusWriter := media.FromSampleWriter[opus.Sample](track, DefaultOpusSampleRate, defaultPCMFrameDuration)
 	// pcmWriter encodes opus samples from PCM16 samples and writes them to opusWriter
 	pcmWriter, err := opus.Encode(opusWriter, sourceChannels, logger)
 	if err != nil {
@@ -111,10 +111,10 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 		pcmWriter:              pcmWriter,
 		resampledPCMWriter:     resampledPCMWriter,
 		sourceSampleRate:       sourceSampleRate,
-		frameDuration:          defaultPCMSampleDuration,
+		frameDuration:          defaultPCMFrameDuration,
 		sourceChannels:         sourceChannels,
-		chunkBuffer:            new(deque.Deque[int16]),
-		chunksPerSample:        (sourceSampleRate * sourceChannels * int(defaultPCMSampleDuration/time.Nanosecond)) / 1e9,
+		chunkBuffer:            new(deque.Deque[media.PCM16Sample]),
+		samplesPerFrame:        (sourceSampleRate * sourceChannels * int(defaultPCMFrameDuration/time.Nanosecond)) / 1e9,
 		writeSilenceOnNoData:   params.WriteSilenceOnNoData,
 	}
 
@@ -124,21 +124,21 @@ func NewPCMLocalTrack(sourceSampleRate int, sourceChannels int, logger protoLogg
 	return t, nil
 }
 
-func (t *PCMLocalTrack) pushChunksToBuffer(sample media.PCM16Sample) {
-	for _, chunk := range sample {
+func (t *PCMLocalTrack) pushChunksToBuffer(chunk media.PCM16Sample) {
+	if len(chunk) != 0 {
 		t.chunkBuffer.PushBack(chunk)
 	}
 }
 
-func (t *PCMLocalTrack) waitUntilBufferHasChunks(count int) bool {
+func (t *PCMLocalTrack) waitUntilBufferHasSamples(count int) bool {
 	var didWait bool
 
-	if t.closed.Load() && t.chunkBuffer.Len() > 0 {
+	if t.closed.Load() && t.getNumSamplesInChunkBuffer() > 0 {
 		// write whatever is left, with silence as filler
 		return false
 	}
 
-	for t.chunkBuffer.Len() < count && !t.closed.Load() {
+	for t.getNumSamplesInChunkBuffer() < count && !t.closed.Load() {
 		t.emptyBufMu.Lock()
 		t.emptyBufCond.Broadcast()
 		t.emptyBufMu.Unlock()
@@ -150,30 +150,36 @@ func (t *PCMLocalTrack) waitUntilBufferHasChunks(count int) bool {
 	return didWait
 }
 
-func (t *PCMLocalTrack) getChunksFromBuffer() (media.PCM16Sample, bool) {
-	chunks := make(media.PCM16Sample, t.chunksPerSample)
+func (t *PCMLocalTrack) getFrameFromChunkBuffer() (media.PCM16Sample, bool) {
+	frame := make(media.PCM16Sample, 0, t.samplesPerFrame)
 
 	var didWait = false
 	if !t.writeSilenceOnNoData {
-		didWait = t.waitUntilBufferHasChunks(t.chunksPerSample)
+		didWait = t.waitUntilBufferHasSamples(t.samplesPerFrame)
 	}
 
-	if t.closed.Load() && t.chunkBuffer.Len() == 0 {
+	if t.closed.Load() && t.getNumSamplesInChunkBuffer() == 0 {
 		return nil, false
 	}
 
-	for i := 0; i < t.chunksPerSample; i++ {
-		if t.chunkBuffer.Len() == 0 {
-			// this will zero-init at index i, which will be a silent chunk.
-			// if writeSilenceOnNoData is false, this condition will only be true
-			// when the track is closed and the buffer does not have enough chunks.
-			continue
-		} else {
-			chunks[i] = t.chunkBuffer.PopFront()
+	for len(frame) < t.samplesPerFrame && t.chunkBuffer.Len() != 0 {
+		chunk := t.chunkBuffer.PopFront()
+		remaining := min(t.samplesPerFrame-len(frame), len(chunk))
+		frame = append(frame, chunk[:remaining]...)
+		if remaining < len(chunk) {
+			t.chunkBuffer.PushFront(chunk[remaining:])
 		}
 	}
 
-	return chunks, didWait
+	return frame, didWait
+}
+
+func (t *PCMLocalTrack) getNumSamplesInChunkBuffer() int {
+	numSamples := 0
+	for i := 0; i < t.chunkBuffer.Len(); i++ {
+		numSamples += len(t.chunkBuffer.At(i))
+	}
+	return numSamples
 }
 
 func (t *PCMLocalTrack) WriteSample(sample media.PCM16Sample) error {
@@ -193,16 +199,16 @@ func (t *PCMLocalTrack) processSamples() {
 	defer ticker.Stop()
 
 	for {
-		if t.closed.Load() && t.chunkBuffer.Len() == 0 {
+		if t.closed.Load() && t.getNumSamplesInChunkBuffer() == 0 {
 			break
 		}
 
 		t.mu.Lock()
-		sample, didWait := t.getChunksFromBuffer()
-		if sample != nil {
-			// sample is only nil when the track is closed, so we don't need to
+		frame, didWait := t.getFrameFromChunkBuffer()
+		if frame != nil {
+			// frame is only nil when the track is closed, so we don't need to
 			// adjust ticker for this case.
-			t.resampledPCMWriter.WriteSample(sample)
+			t.resampledPCMWriter.WriteSample(frame)
 			if didWait {
 				ticker.Reset(t.frameDuration)
 			}
@@ -222,14 +228,12 @@ func (t *PCMLocalTrack) WaitForPlayout() {
 	t.emptyBufMu.Lock()
 	defer t.emptyBufMu.Unlock()
 
-	if t.writeSilenceOnNoData {
-		for t.chunkBuffer.Len() > 0 {
-			t.emptyBufCond.Wait()
-		}
-	} else {
-		for t.chunkBuffer.Len() > t.chunksPerSample {
-			t.emptyBufCond.Wait()
-		}
+	samplesThreshold := 0
+	if !t.writeSilenceOnNoData {
+		samplesThreshold = t.samplesPerFrame
+	}
+	for t.getNumSamplesInChunkBuffer() > samplesThreshold {
+		t.emptyBufCond.Wait()
 	}
 }
 


### PR DESCRIPTION
Re-jiggering a bit of this. Using more standard definitions

sample: a single qunatised digital audio sample (a single point in time)
frame: a collection of samples with some well-defined duration - 10 ms used here for Opus encode (side note: I wish the writer API was called WriteFrame instead of WriteSample)
chunk: a collection of samples of variable duration - like what is submitted on PCM side, could be 1 second long, could be 100 ms long, etc.
Change the deque to store chunks as is and when processing construct 10 ms frames. Don't think there is a need to convert to samples while storing in deque. Should keep the deque size smaller.