### PR TITLE
Fix: Correct error condition for handler registration methods

### DIFF
--- a/examples/rpc/main.go
+++ b/examples/rpc/main.go
@@ -198,7 +198,7 @@ func performDivide(room *lksdk.Room) {
 	logger.Infow(fmt.Sprintf("[Caller] The result is %v", result))
 }
 
-func registerReceiverMethods(rooms map[string]*lksdk.Room) {
+func registerReceiverMethods(rooms map[string]*lksdk.Room) error {
 	greeterRoom := rooms[greeter]
 	mathGeniusRoom := rooms[mathGenius]
 
@@ -213,7 +213,11 @@ func registerReceiverMethods(rooms map[string]*lksdk.Room) {
 
 		return <-resultChan, nil
 	}
-	greeterRoom.RegisterRpcMethod("arrival", arrivalHandler)
+	err := greeterRoom.RegisterRpcMethod("arrival", arrivalHandler)
+	if err != nil {
+		logger.Errorw("Failed to register arrival RPC method", err)
+		return err
+	}
 
 	squareRootHandler := func(data lksdk.RpcInvocationData) (string, error) {
 		resultChan := make(chan string)
@@ -242,7 +246,11 @@ func registerReceiverMethods(rooms map[string]*lksdk.Room) {
 
 		return <-resultChan, nil
 	}
-	mathGeniusRoom.RegisterRpcMethod("square-root", squareRootHandler)
+	err = mathGeniusRoom.RegisterRpcMethod("square-root", squareRootHandler)
+	if err != nil {
+		logger.Errorw("Failed to register square root RPC method", err)
+		return err
+	}
 
 	divideHandler := func(data lksdk.RpcInvocationData) (string, error) {
 		resultChan := make(chan string)
@@ -279,7 +287,12 @@ func registerReceiverMethods(rooms map[string]*lksdk.Room) {
 
 		return <-resultChan, nil
 	}
-	mathGeniusRoom.RegisterRpcMethod("divide", divideHandler)
+	err = mathGeniusRoom.RegisterRpcMethod("divide", divideHandler)
+	if err != nil {
+		logger.Errorw("Failed to register divide RPC method", err)
+		return err
+	}
+	return nil
 }
 
 func main() {
@@ -313,7 +326,11 @@ func main() {
 		logger.Infow("Participants disconnected. Example completed.")
 	}()
 
-	registerReceiverMethods(rooms)
+	err := registerReceiverMethods(rooms)
+	if err != nil {
+		logger.Errorw("failed to register RPC methods", err)
+		return
+	}
 
 	logger.Infow("participants connected to room, starting rpc demo", "roomName", roomName)
 

--- a/room.go
+++ b/room.go
@@ -619,7 +619,7 @@ func (r *Room) getLocalParticipantSID() string {
 // and they will be received on the caller's side with the message intact.
 // Other errors thrown in your handler will not be transmitted as-is, and will instead arrive to the caller as `1500` ("Application Error").
 func (r *Room) RegisterRpcMethod(method string, handler RpcHandlerFunc) error {
-	if _, ok := r.rpcHandlers.LoadOrStore(method, handler); !ok {
+	if _, loaded := r.rpcHandlers.LoadOrStore(method, handler); loaded {
 		return fmt.Errorf("rpc handler already registered for method: %s, unregisterRpcMethod before trying to register again", method)
 	}
 	return nil
@@ -635,7 +635,7 @@ func (r *Room) UnregisterRpcMethod(method string) {
 // It will be called when a text stream is received for the given topic.
 // The handler will be called with the stream reader and the participant identity that sent the stream.
 func (r *Room) RegisterTextStreamHandler(topic string, handler TextStreamHandler) error {
-	if _, ok := r.textStreamHandlers.LoadOrStore(topic, handler); !ok {
+	if _, loaded := r.textStreamHandlers.LoadOrStore(topic, handler); loaded {
 		return fmt.Errorf("text stream handler already registered for topic: %s", topic)
 	}
 	return nil
@@ -650,7 +650,7 @@ func (r *Room) UnregisterTextStreamHandler(topic string) {
 // It will be called when a byte stream is received for the given topic.
 // The handler will be called with the stream reader and the participant identity that sent the stream.
 func (r *Room) RegisterByteStreamHandler(topic string, handler ByteStreamHandler) error {
-	if _, ok := r.byteStreamHandlers.LoadOrStore(topic, handler); !ok {
+	if _, loaded := r.byteStreamHandlers.LoadOrStore(topic, handler); loaded {
 		return fmt.Errorf("byte stream handler already registered for topic: %s", topic)
 	}
 	return nil


### PR DESCRIPTION
This PR fixes the logic for error handling in the following methods:

- RegisterRpcMethod
- RegisterTextStreamHandler
- RegisterByteStreamHandler

Previously, these methods return an error even when the handler was not actually registered, due to incorrect error condition checks. The logic is now corrected so that an error is only returned if a handler for the given method or topic is already registered.