### PR TITLE
Beginnings of HTTP signal transport.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -61,5 +61,5 @@ func (b authBase) withAuth(ctx context.Context, opt authOption, options ...authO
 		return nil, err
 	}
 
-	return twirp.WithHTTPRequestHeaders(ctx, signalling.NewHeaderWithToken(token))
+	return twirp.WithHTTPRequestHeaders(ctx, signalling.NewHTTPHeaderWithToken(token))
 }

--- a/engine.go
+++ b/engine.go
@@ -1311,7 +1311,6 @@ func (e *RTCEngine) OnConnectResponse(res *livekit.ConnectResponse) error {
 		}
 	}
 
-	// SIGNALLING-V2-TODO: send subscriber answer
 	if res.SubscriberSdp != nil {
 		e.OnOffer(protosignalling.FromProtoSessionDescription(res.SubscriberSdp))
 	}

--- a/engine.go
+++ b/engine.go
@@ -172,19 +172,20 @@ func NewRTCEngine(engineHandler engineHandler, getLocalParticipantSID func() str
 		reliableMsgSeq:           1,
 	}
 	// SIGNALLING-V2-TODO: have to instantiate objects based on signal version & transport
-	e.signalling = signalling.NewSignallingv2(signalling.Signallingv2Params{
+	e.signalling = signalling.NewSignalling(signalling.SignallingParams{
 		Logger: e.log,
 	})
-	e.signalHandler = signalling.NewSignalHandlerv2(signalling.SignalHandlerv2Params{
+	e.signalHandler = signalling.NewSignalHandler(signalling.SignalHandlerParams{
 		Logger:    e.log,
 		Processor: e,
 	})
-	e.signalTransport = signalling.NewSignalTransportHybrid(signalling.SignalTransportHybridParams{
-		Logger:        e.log,
-		Version:       Version,
-		Protocol:      PROTOCOL,
-		Signalling:    e.signalling,
-		SignalHandler: e.signalHandler,
+	e.signalTransport = signalling.NewSignalTransportWebSocket(signalling.SignalTransportWebSocketParams{
+		Logger:                 e.log,
+		Version:                Version,
+		Protocol:               PROTOCOL,
+		Signalling:             e.signalling,
+		SignalTransportHandler: e,
+		SignalHandler:          e.signalHandler,
 	})
 
 	e.onClose = []func(){}

--- a/engine.go
+++ b/engine.go
@@ -17,7 +17,8 @@ package lksdk
 import (
 	"context"
 	"errors"
-	"fmt"
+	"io"
+	"net/http"
 	"sync"
 	"time"
 
@@ -54,7 +55,13 @@ type engineHandler interface {
 	OnResuming()
 	OnResumed()
 	OnTranscription(*livekit.Transcription)
-	OnSignalClientConnected(*livekit.JoinResponse)
+	OnRoomJoined(
+		room *livekit.Room,
+		participant *livekit.ParticipantInfo,
+		otherParticipants []*livekit.ParticipantInfo,
+		serverInfo *livekit.ServerInfo,
+		sifTrailer []byte,
+	)
 	OnRpcRequest(callerIdentity, requestId, method, payload string, responseTimeout time.Duration, version uint32)
 	OnRpcAck(requestId string)
 	OnRpcResponse(requestId string, payload *string, error *RpcError)
@@ -165,19 +172,19 @@ func NewRTCEngine(engineHandler engineHandler, getLocalParticipantSID func() str
 		reliableMsgSeq:           1,
 	}
 	// SIGNALLING-V2-TODO: have to instantiate objects based on signal version & transport
-	e.signalling = signalling.NewSignalling(signalling.SignallingParams{
+	e.signalling = signalling.NewSignallingv2(signalling.Signallingv2Params{
 		Logger: e.log,
 	})
-	e.signalHandler = signalling.NewSignalHandler(signalling.SignalHandlerParams{
+	e.signalHandler = signalling.NewSignalHandlerv2(signalling.SignalHandlerv2Params{
 		Logger:    e.log,
 		Processor: e,
 	})
-	e.signalTransport = signalling.NewSignalTransportWebSocket(signalling.SignalTransportWebSocketParams{
-		Logger:                 e.log,
-		Version:                Version,
-		Protocol:               PROTOCOL,
-		SignalTransportHandler: e,
-		SignalHandler:          e.signalHandler,
+	e.signalTransport = signalling.NewSignalTransportHybrid(signalling.SignalTransportHybridParams{
+		Logger:        e.log,
+		Version:       Version,
+		Protocol:      PROTOCOL,
+		Signalling:    e.signalling,
+		SignalHandler: e.signalHandler,
 	})
 
 	e.onClose = []func(){}
@@ -203,49 +210,24 @@ func (e *RTCEngine) JoinContext(
 	url string,
 	token string,
 	connectParams *signalling.ConnectParams,
-) (proto.Message, error) {
-	msg, err := e.signalTransport.Join(ctx, url, token, *connectParams)
-	if err != nil {
-		return nil, err
-	}
-
-	res, ok := msg.(*livekit.JoinResponse)
-	if !ok {
-		e.log.Warnw(
-			"unknown message type", nil,
-			"messageType", fmt.Sprintf("%T", msg),
-		)
-		return nil, ErrInvalidMessageType
-	}
-
+) (bool, error) {
 	e.url = url
 	e.token.Store(token)
 	e.connParams = connectParams
 
-	err = e.configure(res.IceServers, res.ClientConfiguration, proto.Bool(res.SubscriberPrimary))
+	err := e.signalTransport.Join(ctx, url, token, *connectParams)
 	if err != nil {
-		e.log.Warnw("could not configure", err)
-		return nil, err
-	}
-
-	e.engineHandler.OnSignalClientConnected(res)
-
-	e.signalTransport.Start()
-
-	// send offer
-	if !res.SubscriberPrimary || res.FastPublish {
-		if publisher, ok := e.Publisher(); ok {
-			publisher.Negotiate()
-		} else {
-			e.log.Warnw("no publisher peer connection", ErrNoPeerConnection)
+		if verr := e.validate(ctx, url, token, connectParams, ""); verr != nil {
+			return false, verr
 		}
+		return false, err
 	}
 
 	if err = e.waitUntilConnected(); err != nil {
-		return nil, err
+		return false, err
 	}
 	e.hasConnected.Store(true)
-	return res, err
+	return true, err
 }
 
 func (e *RTCEngine) OnClose(onClose func()) {
@@ -364,7 +346,7 @@ func (e *RTCEngine) configure(
 	if subscriberPrimary != nil {
 		e.subscriberPrimary = *subscriberPrimary
 	}
-	e.subscriber.OnRemoteDescriptionSettled(e.createPublisherAnswerAndSend)
+	e.subscriber.OnRemoteDescriptionSettled(e.createSubscriberPCAnswerAndSend)
 
 	e.publisher.pc.OnICECandidate(func(candidate *webrtc.ICECandidate) {
 		if candidate == nil {
@@ -692,34 +674,25 @@ func (e *RTCEngine) handleDisconnect(fullReconnect bool) {
 }
 
 func (e *RTCEngine) resumeConnection() error {
-	msg, err := e.signalTransport.Reconnect(
+	err := e.signalTransport.Reconnect(
 		e.url,
 		e.token.Load(),
 		*e.connParams,
 		e.cbGetLocalParticipantSID(),
 	)
 	if err != nil {
+		if verr := e.validate(
+			context.TODO(),
+			e.url,
+			e.token.Load(),
+			e.connParams,
+			e.cbGetLocalParticipantSID(),
+		); verr != nil {
+			return verr
+		}
 		return err
 	}
 
-	if msg != nil {
-		reconnect, ok := msg.(*livekit.ReconnectResponse)
-		if ok {
-			configuration := e.makeRTCConfiguration(reconnect.IceServers, reconnect.ClientConfiguration)
-			e.pclock.Lock()
-			if err = e.publisher.SetConfiguration(configuration); err != nil {
-				logger.Errorw("could not set rtc configuration for publisher", err)
-				e.pclock.Unlock()
-				return err
-			}
-			if err = e.subscriber.SetConfiguration(configuration); err != nil {
-				logger.Errorw("could not set rtc configuration for subscriber", err)
-				e.pclock.Unlock()
-				return err
-			}
-			e.pclock.Unlock()
-		}
-	}
 	e.signalTransport.Start()
 
 	// send offer if publisher enabled
@@ -750,34 +723,11 @@ func (e *RTCEngine) restartConnection() error {
 	}
 	e.signalTransport.Close()
 
-	msg, err := e.JoinContext(context.TODO(), e.url, e.token.Load(), e.connParams)
-	if err != nil {
-		return err
-	}
-
-	res, ok := msg.(*livekit.SignalResponse)
-	if !ok {
-		e.log.Warnw(
-			"unknown message type", nil,
-			"messageType", fmt.Sprintf("%T", msg),
-		)
-		return ErrInvalidMessageType
-	}
-
-	joinResponse := res.GetJoin()
-	if joinResponse == nil {
-		e.log.Warnw(
-			"unknown message type", nil,
-			"messageType", fmt.Sprintf("%T", res),
-		)
-		return ErrInvalidMessageType
-	}
-
-	e.engineHandler.OnRestarted(joinResponse.Room, joinResponse.Participant, joinResponse.OtherParticipants)
-	return nil
+	_, err := e.JoinContext(context.TODO(), e.url, e.token.Load(), e.connParams)
+	return err
 }
 
-func (e *RTCEngine) createPublisherAnswerAndSend() error {
+func (e *RTCEngine) createSubscriberPCAnswerAndSend() error {
 	answer, err := e.subscriber.pc.CreateAnswer(nil)
 	if err != nil {
 		e.log.Errorw("could not create answer", err)
@@ -1096,21 +1046,82 @@ func (e *RTCEngine) Simulate(scenario SimulateScenario) {
 	}
 }
 
+func (e *RTCEngine) validate(
+	ctx context.Context,
+	urlPrefix string,
+	token string,
+	connectParams *signalling.ConnectParams,
+	participantSID string,
+) error {
+	req, err := e.signalling.HTTPRequestForValidate(
+		ctx,
+		Version,
+		PROTOCOL,
+		urlPrefix,
+		token,
+		connectParams,
+		participantSID,
+	)
+	if err != nil {
+		return err
+	}
+
+	hresp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		e.log.Errorw("error getting validation", err, "httpResponse", hresp)
+		return signalling.ErrCannotDialSignal
+	}
+
+	if hresp.StatusCode == http.StatusOK {
+		// no specific errors to return if validate succeeds
+		e.log.Infow("validate succeeded")
+		return nil
+	}
+
+	var errString string
+	switch hresp.StatusCode {
+	case http.StatusUnauthorized:
+		errString = "unauthorized: "
+	case http.StatusNotFound:
+		errString = "not found: "
+	case http.StatusServiceUnavailable:
+		errString = "unavailable: "
+	}
+	body, err := io.ReadAll(hresp.Body)
+	if err == nil {
+		errString += string(body)
+		e.log.Errorw("validation error", errors.New(errString), "httpResponse", hresp)
+	}
+	return errors.New(errString)
+}
+
 // signalling.SignalTransportHandler implementation
 func (e *RTCEngine) OnTransportClose() {
 	e.handleDisconnect(false)
 }
 
 // signalling.SignalProcessor implementation
-func (e *RTCEngine) OnJoinResponse(res *livekit.JoinResponse) {
-	/* SIGNALLING-V2-TODO: make this async
+func (e *RTCEngine) OnJoinResponse(res *livekit.JoinResponse) error {
+	isRestarting := false
+	if e.reconnecting.Load() && e.requiresFullReconnect.Load() {
+		isRestarting = true
+	}
+
+	e.signalTransport.SetParticipantResource(e.url, res.GetParticipant().Sid, e.token.Load())
+
 	err := e.configure(res.IceServers, res.ClientConfiguration, proto.Bool(res.SubscriberPrimary))
 	if err != nil {
 		e.log.Warnw("could not configure", err)
-		return
+		return err
 	}
 
-	e.engineHandler.OnSignalClientConnected(res)
+	e.engineHandler.OnRoomJoined(
+		res.Room,
+		res.Participant,
+		res.OtherParticipants,
+		res.ServerInfo,
+		res.SifTrailer,
+	)
 
 	e.signalTransport.Start()
 
@@ -1122,7 +1133,30 @@ func (e *RTCEngine) OnJoinResponse(res *livekit.JoinResponse) {
 			e.log.Warnw("no publisher peer connection", ErrNoPeerConnection)
 		}
 	}
-	*/
+
+	if isRestarting {
+		e.engineHandler.OnRestarted(res.Room, res.Participant, res.OtherParticipants)
+	}
+	return nil
+}
+
+func (e *RTCEngine) OnReconnectResponse(res *livekit.ReconnectResponse) error {
+	configuration := e.makeRTCConfiguration(res.IceServers, res.ClientConfiguration)
+
+	e.pclock.Lock()
+	defer e.pclock.Unlock()
+
+	if err := e.publisher.SetConfiguration(configuration); err != nil {
+		e.log.Errorw("could not set rtc configuration for publisher", err)
+		return err
+	}
+
+	if err := e.subscriber.SetConfiguration(configuration); err != nil {
+		e.log.Errorw("could not set rtc configuration for subscriber", err)
+		return err
+	}
+
+	return nil
 }
 
 func (e *RTCEngine) OnAnswer(sd webrtc.SessionDescription, answerId uint32) {
@@ -1212,6 +1246,7 @@ func (e *RTCEngine) OnTrackRemoteMuted(request *livekit.MuteTrackRequest) {
 
 func (e *RTCEngine) OnTokenRefresh(refreshToken string) {
 	e.token.Store(refreshToken)
+	e.signalTransport.UpdateParticipantToken(refreshToken)
 }
 
 func (e *RTCEngine) OnLeave(leave *livekit.LeaveRequest) {
@@ -1239,4 +1274,50 @@ func (e *RTCEngine) OnLocalTrackSubscribed(trackSubscribed *livekit.TrackSubscri
 
 func (e *RTCEngine) OnSubscribedQualityUpdate(subscribedQualityUpdate *livekit.SubscribedQualityUpdate) {
 	e.engineHandler.OnSubscribedQualityUpdate(subscribedQualityUpdate)
+}
+
+func (e *RTCEngine) OnConnectResponse(res *livekit.ConnectResponse) error {
+	isRestarting := false
+	if e.reconnecting.Load() && e.requiresFullReconnect.Load() {
+		isRestarting = true
+	}
+
+	e.log.Debugw("RAJA got connect response", "res", protoLogger.Proto(res)) // REMOVE
+	e.signalTransport.SetParticipantResource(e.url, res.GetParticipant().Sid, e.token.Load())
+
+	err := e.configure(res.IceServers, res.ClientConfiguration, proto.Bool(true))
+	if err != nil {
+		e.log.Warnw("could not configure", err)
+		return err
+	}
+
+	e.engineHandler.OnRoomJoined(
+		res.Room,
+		res.Participant,
+		res.OtherParticipants,
+		res.ServerInfo,
+		res.SifTrailer,
+	)
+
+	e.signalTransport.Start()
+
+	// SIGNALLING-V2-TODO: should send publisher offer in connect request itself
+	// send offer
+	if res.FastPublish {
+		if publisher, ok := e.Publisher(); ok {
+			publisher.Negotiate()
+		} else {
+			e.log.Warnw("no publisher peer connection", ErrNoPeerConnection)
+		}
+	}
+
+	// SIGNALLING-V2-TODO: send subscriber answer
+	if res.SubscriberSdp != nil {
+		e.OnOffer(protosignalling.FromProtoSessionDescription(res.SubscriberSdp))
+	}
+
+	if isRestarting {
+		e.engineHandler.OnRestarted(res.Room, res.Participant, res.OtherParticipants)
+	}
+	return nil
 }

--- a/engine.go
+++ b/engine.go
@@ -1071,6 +1071,7 @@ func (e *RTCEngine) validate(
 		e.log.Errorw("error getting validation", err, "httpResponse", hresp)
 		return signalling.ErrCannotDialSignal
 	}
+	defer hresp.Body.Close()
 
 	if hresp.StatusCode == http.StatusOK {
 		// no specific errors to return if validate succeeds
@@ -1282,7 +1283,6 @@ func (e *RTCEngine) OnConnectResponse(res *livekit.ConnectResponse) error {
 		isRestarting = true
 	}
 
-	e.log.Debugw("RAJA got connect response", "res", protoLogger.Proto(res)) // REMOVE
 	e.signalTransport.SetParticipantResource(e.url, res.GetParticipant().Sid, e.token.Load())
 
 	err := e.configure(res.IceServers, res.ClientConfiguration, proto.Bool(true))

--- a/room.go
+++ b/room.go
@@ -297,13 +297,13 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 		opt(params)
 	}
 
-	var joinRes proto.Message
+	isSuccess := false
 	cloudHostname, _ := parseCloudURL(url)
 	if !params.DisableRegionDiscovery && cloudHostname != "" {
 		if err := r.regionURLProvider.RefreshRegionSettings(cloudHostname, token); err != nil {
 			logger.Errorw("failed to get best url", err)
 		} else {
-			for tries := uint(0); joinRes == nil; tries++ {
+			for tries := uint(0); !isSuccess; tries++ {
 				bestURL, err := r.regionURLProvider.PopBestURL(cloudHostname, token)
 				if err != nil {
 					logger.Errorw("failed to get best url", err)
@@ -318,7 +318,7 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 				// - Too short, risk frequently timing out on a request that would have
 				//   succeeded.
 				callCtx, cancelCallCtx := context.WithTimeout(ctx, 4*time.Second)
-				joinRes, err = r.engine.JoinContext(callCtx, bestURL, token, params)
+				isSuccess, err = r.engine.JoinContext(callCtx, bestURL, token, params)
 				cancelCallCtx()
 				if err != nil {
 					// try the next URL with exponential backoff
@@ -335,7 +335,7 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 		}
 	}
 
-	if joinRes == nil {
+	if !isSuccess {
 		if _, err := r.engine.JoinContext(ctx, url, token, params); err != nil {
 			return err
 		}
@@ -690,22 +690,28 @@ func (r *Room) OnMediaTrack(track *webrtc.TrackRemote, receiver *webrtc.RTPRecei
 	r.runParticipantDefers(livekit.ParticipantID(participantID), rp)
 }
 
-func (r *Room) OnSignalClientConnected(joinRes *livekit.JoinResponse) {
+func (r *Room) OnRoomJoined(
+	room *livekit.Room,
+	participant *livekit.ParticipantInfo,
+	otherParticipants []*livekit.ParticipantInfo,
+	serverInfo *livekit.ServerInfo,
+	sifTrailer []byte,
+) {
 	r.lock.Lock()
-	r.name = joinRes.Room.Name
-	r.metadata = joinRes.Room.Metadata
-	r.serverInfo = joinRes.ServerInfo
+	r.name = room.Name
+	r.metadata = room.Metadata
+	r.serverInfo = serverInfo
 	r.connectionState = ConnectionStateConnected
-	r.sifTrailer = make([]byte, len(joinRes.SifTrailer))
-	copy(r.sifTrailer, joinRes.SifTrailer)
+	r.sifTrailer = make([]byte, len(sifTrailer))
+	copy(r.sifTrailer, sifTrailer)
 	r.lock.Unlock()
 
-	r.setSid(joinRes.Room.Sid, false)
+	r.setSid(room.Sid, false)
 
-	r.LocalParticipant.updateInfo(joinRes.Participant)
+	r.LocalParticipant.updateInfo(participant)
 	r.LocalParticipant.updateSubscriptionPermission()
 
-	for _, pi := range joinRes.OtherParticipants {
+	for _, pi := range otherParticipants {
 		r.addRemoteParticipant(pi, true)
 		r.clearParticipantDefers(livekit.ParticipantID(pi.Sid), pi)
 		// no need to run participant defers here, since we are connected for the first time

--- a/signalling/errors.go
+++ b/signalling/errors.go
@@ -17,10 +17,11 @@ package signalling
 import "errors"
 
 var (
+	ErrUnsupportedProtocol = errors.New("unsupported protocol")
 	ErrUnimplemented       = errors.New("unimplemented")
 	ErrURLNotProvided      = errors.New("URL was not provided")
 	ErrInvalidMessageType  = errors.New("invalid message type")
 	ErrInvalidParameter    = errors.New("invalid parameter")
 	ErrCannotDialSignal    = errors.New("could not dial signal connection")
-	ErrCannotConnectSignal = errors.New("could not establish signal connection")
+	ErrEmptyResponse       = errors.New("empty response")
 )

--- a/signalling/errors.go
+++ b/signalling/errors.go
@@ -17,11 +17,12 @@ package signalling
 import "errors"
 
 var (
-	ErrUnsupportedProtocol = errors.New("unsupported protocol")
-	ErrUnimplemented       = errors.New("unimplemented")
-	ErrURLNotProvided      = errors.New("URL was not provided")
-	ErrInvalidMessageType  = errors.New("invalid message type")
-	ErrInvalidParameter    = errors.New("invalid parameter")
-	ErrCannotDialSignal    = errors.New("could not dial signal connection")
-	ErrEmptyResponse       = errors.New("empty response")
+	ErrUnsupportedSignalling  = errors.New("unsupported signalling protocol")
+	ErrUnsupportedContentType = errors.New("unsupported content type")
+	ErrUnimplemented          = errors.New("unimplemented")
+	ErrURLNotProvided         = errors.New("URL was not provided")
+	ErrInvalidMessageType     = errors.New("invalid message type")
+	ErrInvalidParameter       = errors.New("invalid parameter")
+	ErrCannotDialSignal       = errors.New("could not dial signal connection")
+	ErrEmptyResponse          = errors.New("empty response")
 )

--- a/signalling/signalhandler.go
+++ b/signalling/signalhandler.go
@@ -60,6 +60,9 @@ func (s *signalhandler) HandleMessage(msg proto.Message) error {
 	case *livekit.SignalResponse_Join:
 		s.params.Processor.OnJoinResponse(payload.Join)
 
+	case *livekit.SignalResponse_Reconnect:
+		s.params.Processor.OnReconnectResponse(payload.Reconnect)
+
 	case *livekit.SignalResponse_Answer:
 		s.params.Processor.OnAnswer(protosignalling.FromProtoSessionDescription(payload.Answer))
 

--- a/signalling/signallingunimplemented.go
+++ b/signalling/signallingunimplemented.go
@@ -15,6 +15,9 @@
 package signalling
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"google.golang.org/protobuf/proto"
@@ -26,6 +29,52 @@ type signallingUnimplemented struct {
 }
 
 func (s *signallingUnimplemented) SetLogger(l logger.Logger) {}
+
+func (s *signallingUnimplemented) Path() string {
+	return ""
+}
+
+func (s *signallingUnimplemented) ParticipantPath(participantSid string) string {
+	return ""
+}
+
+func (s *signallingUnimplemented) ValidatePath() string {
+	return ""
+}
+
+func (s *signallingUnimplemented) JoinMethod() joinMethod {
+	return joinMethodUnused
+}
+
+func (s *signallingUnimplemented) ConnectQueryParams(
+	version string,
+	protocol int,
+	connectParams *ConnectParams,
+	participantSID string,
+) (string, error) {
+	return "", ErrUnimplemented
+}
+
+func (s *signallingUnimplemented) ConnectRequest(
+	version string,
+	protocol int,
+	connectParams *ConnectParams,
+	participantSID string,
+) (*livekit.ConnectRequest, error) {
+	return nil, ErrUnimplemented
+}
+
+func (s *signallingUnimplemented) HTTPRequestForValidate(
+	ctx context.Context,
+	version string,
+	protocol int,
+	urlPrefix string,
+	token string,
+	connectParams *ConnectParams,
+	participantSID string,
+) (*http.Request, error) {
+	return nil, ErrUnimplemented
+}
 
 func (s *signallingUnimplemented) SignalLeaveRequest(leave *livekit.LeaveRequest) proto.Message {
 	return nil
@@ -78,4 +127,8 @@ func (s *signallingUnimplemented) SignalUpdateParticipantMetadata(metadata *live
 func (u *signallingUnimplemented) AckMessageId(ackMessageId uint32) {}
 
 func (u *signallingUnimplemented) SetLastProcessedRemoteMessageId(lastProcessedRemoteMessageId uint32) {
+}
+
+func (s *signallingUnimplemented) SignalConnectRequest(connectRequest *livekit.ConnectRequest) proto.Message {
+	return nil
 }

--- a/signalling/signallingv2.go
+++ b/signalling/signallingv2.go
@@ -53,7 +53,7 @@ func (s *signallingv2) Path() string {
 }
 
 func (s *signallingv2) ParticipantPath(participantSid string) string {
-	return "/rtc/v2" + participantSid
+	return "/rtc/v2/" + participantSid
 }
 
 func (s *signallingv2) ValidatePath() string {

--- a/signalling/signallingv2.go
+++ b/signalling/signallingv2.go
@@ -14,7 +14,17 @@
 
 package signalling
 
-import "github.com/livekit/protocol/logger"
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/url"
+	"runtime"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+	"google.golang.org/protobuf/proto"
+)
 
 var _ Signalling = (*signallingv2)(nil)
 
@@ -31,5 +41,146 @@ type signallingv2 struct {
 func NewSignallingv2(params Signallingv2Params) Signalling {
 	return &signallingv2{
 		params: params,
+	}
+}
+
+func (s *signallingv2) SetLogger(l logger.Logger) {
+	s.params.Logger = l
+}
+
+func (s *signallingv2) Path() string {
+	return "/rtc/v2"
+}
+
+func (s *signallingv2) ParticipantPath(participantSid string) string {
+	return "/rtc/v2" + participantSid
+}
+
+func (s *signallingv2) ValidatePath() string {
+	return "/rtc/v2/validate"
+}
+
+func (s *signallingv2) JoinMethod() joinMethod {
+	return joinMethodConnectRequest
+}
+
+func (s *signallingv2) ConnectRequest(
+	version string,
+	protocol int,
+	connectParams *ConnectParams,
+	participantSID string,
+) (*livekit.ConnectRequest, error) {
+	clientInfo := &livekit.ClientInfo{
+		Version:  version,
+		Protocol: int32(protocol),
+		Os:       runtime.GOOS,
+		Sdk:      livekit.ClientInfo_GO,
+	}
+
+	connectionSettings := &livekit.ConnectionSettings{}
+	if connectParams.AutoSubscribe {
+		connectionSettings.AutoSubscribe = true
+	}
+
+	return &livekit.ConnectRequest{
+		ClientInfo:            clientInfo,
+		ConnectionSettings:    connectionSettings,
+		ParticipantAttributes: connectParams.Attributes,
+	}, nil
+}
+
+func (s *signallingv2) HTTPRequestForValidate(
+	ctx context.Context,
+	version string,
+	protocol int,
+	urlPrefix string,
+	token string,
+	connectParams *ConnectParams,
+	participantSID string,
+) (*http.Request, error) {
+	if urlPrefix == "" {
+		return nil, ErrURLNotProvided
+	}
+
+	connectRequest, err := s.ConnectRequest(
+		version,
+		protocol,
+		connectParams,
+		participantSID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	wireMessage := s.SignalConnectRequest(connectRequest)
+	protoMsg, err := proto.Marshal(wireMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(ToHttpURL(urlPrefix) + s.ValidatePath())
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), bytes.NewBuffer(protoMsg))
+	if err != nil {
+		s.params.Logger.Errorw("error creating validate request", err)
+		return nil, err
+	}
+	req.Header = NewHTTPHeaderWithToken(token)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	return req, nil
+}
+
+func (s *signallingv2) AckMessageId(ackMessageId uint32) {
+	// SIGNALLING-V2-TODO s.signalCache.Clear(ackMessageId)
+}
+
+func (s *signallingv2) SetLastProcessedRemoteMessageId(lastProcessedRemoteMessageId uint32) {
+	// SIGNALLING-V2-TODO s.signalCache.SetLastProcessedRemoteMessageId(lastProcessedRemoteMessageId)
+}
+
+func (s *signallingv2) SignalConnectRequest(connectRequest *livekit.ConnectRequest) proto.Message {
+	clientMessage := &livekit.Signalv2ClientMessage{
+		Message: &livekit.Signalv2ClientMessage_ConnectRequest{
+			ConnectRequest: connectRequest,
+		},
+	}
+	return s.cacheAndReturnEnvelope(clientMessage)
+}
+
+func (s *signallingv2) SignalSdpOffer(offer *livekit.SessionDescription) proto.Message {
+	clientMessage := &livekit.Signalv2ClientMessage{
+		Message: &livekit.Signalv2ClientMessage_PublisherSdp{
+			PublisherSdp: offer,
+		},
+	}
+	return s.cacheAndReturnEnvelope(clientMessage)
+}
+
+func (s *signallingv2) SignalSdpAnswer(answer *livekit.SessionDescription) proto.Message {
+	clientMessage := &livekit.Signalv2ClientMessage{
+		Message: &livekit.Signalv2ClientMessage_SubscriberSdp{
+			SubscriberSdp: answer,
+		},
+	}
+	return s.cacheAndReturnEnvelope(clientMessage)
+}
+
+func (s *signallingv2) cacheAndReturnEnvelope(cm *livekit.Signalv2ClientMessage) proto.Message {
+	/* SIGNALLING-V2-TODO
+	sm = s.signalCache.Add(sm)
+	if sm == nil {
+		return nil
+	}
+	*/
+
+	return &livekit.Signalv2WireMessage{
+		Message: &livekit.Signalv2WireMessage_Envelope{
+			Envelope: &livekit.Envelope{
+				ClientMessages: []*livekit.Signalv2ClientMessage{cm},
+			},
+		},
 	}
 }

--- a/signalling/signaltransport_http.go
+++ b/signalling/signaltransport_http.go
@@ -1,0 +1,229 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalling
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ SignalTransport = (*signalTransportHttp)(nil)
+
+type SignalTransportHttpParams struct {
+	Logger        logger.Logger
+	Version       string
+	Protocol      int
+	Signalling    Signalling
+	SignalHandler SignalHandler
+}
+
+type signalTransportHttp struct {
+	signalTransportUnimplemented
+
+	params SignalTransportHttpParams
+
+	lock           sync.Mutex
+	url            string
+	participantSid string
+	token          string
+}
+
+func NewSignalTransportHttp(params SignalTransportHttpParams) SignalTransport {
+	return &signalTransportHttp{
+		params: params,
+	}
+}
+
+func (s *signalTransportHttp) SetLogger(l logger.Logger) {
+	s.params.Logger = l
+}
+
+func (s *signalTransportHttp) Join(
+	ctx context.Context,
+	url string,
+	token string,
+	connectParams ConnectParams,
+) error {
+	msg, err := s.connect(ctx, url, token, connectParams, "")
+	if err != nil {
+		s.params.Logger.Warnw("RAJA connect error", err) // REMOVE
+		return err
+	}
+
+	s.params.Logger.Debugw("RAJA connect response", "response", logger.Proto(msg)) // REMOVE
+	return s.params.SignalHandler.HandleMessage(msg)
+}
+
+// SIGNALLING-V2-TODO: fix this comment after reconnect=1 is finalised for signalling v2
+// Reconnect sends a new connection request to the server, passing in reconnect=1
+// when successful, it'll return a ReconnectResponse;
+// older versions of the server will not send back a ReconnectResponse
+func (s *signalTransportHttp) Reconnect(
+	url string,
+	token string,
+	connectParams ConnectParams,
+	participantSID string,
+) error {
+	connectParams.Reconnect = true
+	msg, err := s.connect(context.TODO(), url, token, connectParams, participantSID)
+	if err != nil {
+		return err
+	}
+
+	return s.params.SignalHandler.HandleMessage(msg)
+}
+
+func (s *signalTransportHttp) SetParticipantResource(url string, participantSid string, token string) {
+	s.lock.Lock()
+	s.url = url
+	s.participantSid = participantSid
+	s.token = token
+	s.lock.Unlock()
+}
+
+func (s *signalTransportHttp) UpdateParticipantToken(token string) {
+	s.lock.Lock()
+	s.token = token
+	s.lock.Unlock()
+}
+
+// SIGNALLING-V2-TODO: have to write in messageId order
+// SIGNALLING-V2-TODO: have to return error
+func (s *signalTransportHttp) SendMessage(msg proto.Message) error {
+	if msg == nil {
+		return nil
+	}
+
+	go func() {
+		s.lock.Lock()
+		url := s.url + s.params.Signalling.ParticipantPath(s.participantSid)
+		token := s.token
+		s.lock.Unlock()
+
+		respWireMessage, err := s.sendHttpRequest(
+			url,
+			http.MethodPatch,
+			token,
+			msg,
+		)
+		if err != nil {
+			return
+		}
+
+		s.params.SignalHandler.HandleMessage(respWireMessage)
+	}()
+	return nil
+}
+
+func (s *signalTransportHttp) connect(
+	ctx context.Context,
+	urlPrefix string,
+	token string,
+	connectParams ConnectParams,
+	participantSID string,
+) (proto.Message, error) {
+	if joinMethod := s.params.Signalling.JoinMethod(); joinMethod != joinMethodConnectRequest {
+		// SIGNALLING-V2-TODO: add HTTP support for v1 signalling
+		return nil, ErrUnsupportedProtocol
+	}
+
+	if urlPrefix == "" {
+		return nil, ErrURLNotProvided
+	}
+	urlPrefix = ToHttpURL(urlPrefix)
+
+	connectRequest, err := s.params.Signalling.ConnectRequest(
+		s.params.Version,
+		s.params.Protocol,
+		&connectParams,
+		participantSID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	wireMessage := s.params.Signalling.SignalConnectRequest(connectRequest)
+	return s.sendHttpRequest(
+		urlPrefix+s.params.Signalling.Path(),
+		http.MethodPost,
+		token,
+		wireMessage,
+	)
+}
+
+func (s *signalTransportHttp) sendHttpRequest(
+	location string,
+	method string,
+	token string,
+	wireMessage proto.Message,
+) (*livekit.Signalv2WireMessage, error) {
+	protoMsg, err := proto.Marshal(wireMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse(location)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, u.String(), bytes.NewBuffer(protoMsg))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header = NewHTTPHeaderWithToken(token)
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	startedAt := time.Now()
+	hresp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.params.Logger.Errorw("http request failed", err, "httpResponse", hresp)
+		return nil, err
+	}
+	defer hresp.Body.Close()
+	s.params.Logger.Infow("http response received", "elapsed", time.Since(startedAt))
+	s.params.Logger.Infow("http response received", "elapsed", time.Since(startedAt), "status", hresp.StatusCode) // REMOVE
+
+	s.params.Logger.Debugw("rAJA resp", "hresp", hresp) // REMOVE
+	body, err := io.ReadAll(hresp.Body)
+	if err != nil {
+		s.params.Logger.Warnw("could not read body", err) // REMOVE
+		return nil, err
+	}
+
+	if hresp.StatusCode != http.StatusOK {
+		s.params.Logger.Warnw("status bad", errors.New(string(body))) // REMOVE
+		return nil, errors.New(string(body))
+	}
+
+	respWireMessage := &livekit.Signalv2WireMessage{}
+	if err := proto.Unmarshal(body, respWireMessage); err != nil {
+		s.params.Logger.Warnw("could not unmarshal", err) // REMOVE
+		return nil, err
+	}
+
+	return respWireMessage, nil
+}

--- a/signalling/signaltransport_http.go
+++ b/signalling/signaltransport_http.go
@@ -115,6 +115,12 @@ func (s *signalTransportHttp) SendMessage(msg proto.Message) error {
 		return nil
 	}
 
+	// SIGNALLING-V2-TODO: see note above about ordering and returning error,
+	// using a goroutine as message handlers can trigger a message send
+	// (example: SDP offer handler sending an answer). In sync transport,
+	// that could lead to a chain where the function making the original
+	// request has not returned.
+	// Potentially need to create a queue, but that makes it async. Needs more thinking.
 	go func() {
 		s.lock.Lock()
 		url := s.url + s.params.Signalling.ParticipantPath(s.participantSid)

--- a/signalling/signaltransport_hybrid.go
+++ b/signalling/signaltransport_hybrid.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/livekit/protocol/logger"
+	"google.golang.org/protobuf/proto"
 )
 
 var _ SignalTransport = (*signalTransportHybrid)(nil)
@@ -72,4 +73,16 @@ func (s *signalTransportHybrid) Reconnect(
 	participantSID string,
 ) error {
 	return s.syncTransport.Reconnect(url, token, connectParams, participantSID)
+}
+
+func (s *signalTransportHybrid) SetParticipantResource(url string, participantSid string, token string) {
+	s.syncTransport.SetParticipantResource(url, participantSid, token)
+}
+
+func (s *signalTransportHybrid) UpdateParticipantToken(token string) {
+	s.syncTransport.UpdateParticipantToken(token)
+}
+
+func (s *signalTransportHybrid) SendMessage(msg proto.Message) error {
+	return s.syncTransport.SendMessage(msg)
 }

--- a/signalling/signaltransport_hybrid.go
+++ b/signalling/signaltransport_hybrid.go
@@ -1,0 +1,75 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalling
+
+import (
+	"context"
+
+	"github.com/livekit/protocol/logger"
+)
+
+var _ SignalTransport = (*signalTransportHybrid)(nil)
+
+type SignalTransportHybridParams struct {
+	Logger        logger.Logger
+	Version       string
+	Protocol      int
+	Signalling    Signalling
+	SignalHandler SignalHandler
+}
+
+type signalTransportHybrid struct {
+	signalTransportUnimplemented
+
+	params SignalTransportHybridParams
+
+	syncTransport SignalTransport
+}
+
+func NewSignalTransportHybrid(params SignalTransportHybridParams) SignalTransport {
+	return &signalTransportHybrid{
+		params: params,
+		syncTransport: NewSignalTransportHttp(SignalTransportHttpParams{
+			Logger:        params.Logger,
+			Version:       params.Version,
+			Protocol:      params.Protocol,
+			Signalling:    params.Signalling,
+			SignalHandler: params.SignalHandler,
+		}),
+	}
+}
+
+func (s *signalTransportHybrid) SetLogger(l logger.Logger) {
+	s.params.Logger = l
+	s.syncTransport.SetLogger(l)
+}
+
+func (s *signalTransportHybrid) Join(
+	ctx context.Context,
+	url string,
+	token string,
+	connectParams ConnectParams,
+) error {
+	return s.syncTransport.Join(ctx, url, token, connectParams)
+}
+
+func (s *signalTransportHybrid) Reconnect(
+	url string,
+	token string,
+	connectParams ConnectParams,
+	participantSID string,
+) error {
+	return s.syncTransport.Reconnect(url, token, connectParams, participantSID)
+}

--- a/signalling/signaltransport_unimplemented.go
+++ b/signalling/signaltransport_unimplemented.go
@@ -40,18 +40,23 @@ func (s *signalTransportUnimplemented) Join(
 	url string,
 	token string,
 	connectParams ConnectParams,
-) (proto.Message, error) {
-	return nil, ErrUnimplemented
+) error {
+	return ErrUnimplemented
 }
 
 func (s *signalTransportUnimplemented) Reconnect(
-	urlPrefix string,
+	url string,
 	token string,
 	connectParams ConnectParams,
 	participantSID string,
-) (proto.Message, error) {
-	return nil, ErrUnimplemented
+) error {
+	return ErrUnimplemented
 }
+
+func (s *signalTransportUnimplemented) SetParticipantResource(url string, participantSid string, token string) {
+}
+
+func (s *signalTransportUnimplemented) UpdateParticipantToken(token string) {}
 
 func (s *signalTransportUnimplemented) SendMessage(msg proto.Message) error {
 	return nil

--- a/signalling/signaltransport_websocket.go
+++ b/signalling/signaltransport_websocket.go
@@ -174,7 +174,7 @@ func (s *signalTransportWebSocket) connect(
 ) (proto.Message, error) {
 	if joinMethod := s.params.Signalling.JoinMethod(); joinMethod != joinMethodQueryParams {
 		// SIGNALLING-V2-TODO: add WebSocket support for v2 signalling
-		return nil, ErrUnsupportedProtocol
+		return nil, ErrUnsupportedSignalling
 	}
 
 	if urlPrefix == "" {

--- a/signalling/signaltransport_websocket.go
+++ b/signalling/signaltransport_websocket.go
@@ -16,14 +16,10 @@ package signalling
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -42,6 +38,7 @@ type SignalTransportWebSocketParams struct {
 	Logger                 logger.Logger
 	Version                string
 	Protocol               int
+	Signalling             Signalling
 	SignalTransportHandler SignalTransportHandler
 	SignalHandler          SignalHandler
 }
@@ -51,12 +48,10 @@ type signalTransportWebSocket struct {
 
 	params SignalTransportWebSocketParams
 
-	conn      atomic.Pointer[websocket.Conn]
-	lock      sync.Mutex
-	isStarted atomic.Bool
-	// SIGNALLING-V2-TODO: this should be signalling version agnostic,
-	// in v2 messages could be replayed, so this caching may not be necessary
-	pendingResponse *livekit.SignalResponse
+	conn            atomic.Pointer[websocket.Conn]
+	lock            sync.Mutex
+	isStarted       atomic.Bool
+	pendingResponse proto.Message // only for old servers which do not send ReconnectResponse
 	readerClosedCh  chan struct{}
 }
 
@@ -96,45 +91,31 @@ func (s *signalTransportWebSocket) Close() {
 
 func (s *signalTransportWebSocket) Join(
 	ctx context.Context,
-	urlPrefix string,
+	url string,
 	token string,
 	connectParams ConnectParams,
-) (proto.Message, error) {
-	msg, err := s.connect(ctx, urlPrefix, token, connectParams, "")
+) error {
+	msg, err := s.connect(ctx, url, token, connectParams, "")
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	res, ok := msg.(*livekit.SignalResponse)
-	if !ok {
-		s.params.Logger.Warnw(
-			"unknown message type", nil,
-			"messageType", fmt.Sprintf("%T", msg),
-		)
-		return nil, ErrInvalidMessageType
-	}
-
-	join := res.GetJoin()
-	if join == nil {
-		return nil, fmt.Errorf("unexpected response: %v", res.Message)
-	}
-
-	return join, nil
+	return s.params.SignalHandler.HandleMessage(msg)
 }
 
 // Reconnect starts a new WebSocket connection to the server, passing in reconnect=1
 // when successful, it'll return a ReconnectResponse;
 // older versions of the server will not send back a ReconnectResponse
 func (s *signalTransportWebSocket) Reconnect(
-	urlPrefix string,
+	url string,
 	token string,
 	connectParams ConnectParams,
 	participantSID string,
-) (proto.Message, error) {
+) error {
 	connectParams.Reconnect = true
-	msg, err := s.connect(context.TODO(), urlPrefix, token, connectParams, participantSID)
+	msg, err := s.connect(context.TODO(), url, token, connectParams, participantSID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	res, ok := msg.(*livekit.SignalResponse)
@@ -143,29 +124,29 @@ func (s *signalTransportWebSocket) Reconnect(
 			"unknown message type", nil,
 			"messageType", fmt.Sprintf("%T", msg),
 		)
-		return nil, ErrInvalidMessageType
+		return ErrInvalidMessageType
 	}
+	s.params.Logger.Debugw("reconnect received response", "response", res.String())
 
 	s.lock.Lock()
 	s.pendingResponse = nil
-	s.params.Logger.Debugw("reconnect received response", "response", res.String())
 	if res != nil {
 		switch payload := res.Message.(type) {
 		case *livekit.SignalResponse_Reconnect:
 			s.lock.Unlock()
-			return payload.Reconnect, nil
+			return s.params.SignalHandler.HandleMessage(msg)
 
 		case *livekit.SignalResponse_Leave:
 			s.lock.Unlock()
 			s.params.SignalHandler.HandleMessage(msg)
-			return nil, fmt.Errorf("reconnect received left, reason: %s", payload.Leave.GetReason())
+			return fmt.Errorf("reconnect received left, reason: %s", payload.Leave.GetReason())
 		}
 
 		s.pendingResponse = res
 	}
 	s.lock.Unlock()
 
-	return nil, nil
+	return nil
 }
 
 func (s *signalTransportWebSocket) SendMessage(msg proto.Message) error {
@@ -188,42 +169,35 @@ func (s *signalTransportWebSocket) connect(
 	ctx context.Context,
 	urlPrefix string,
 	token string,
-	params ConnectParams,
+	connectParams ConnectParams,
 	participantSID string,
 ) (proto.Message, error) {
+	if joinMethod := s.params.Signalling.JoinMethod(); joinMethod != joinMethodQueryParams {
+		// SIGNALLING-V2-TODO: add WebSocket support for v2 signalling
+		return nil, ErrUnsupportedProtocol
+	}
+
 	if urlPrefix == "" {
 		return nil, ErrURLNotProvided
 	}
 	urlPrefix = ToWebsocketURL(urlPrefix)
-	urlSuffix := fmt.Sprintf("/rtc?protocol=%d&version=%s", s.params.Protocol, s.params.Version)
 
-	if params.AutoSubscribe {
-		urlSuffix += "&auto_subscribe=1"
-	} else {
-		urlSuffix += "&auto_subscribe=0"
-	}
-	if params.Reconnect {
-		urlSuffix += "&reconnect=1"
-		if participantSID != "" {
-			urlSuffix += fmt.Sprintf("&sid=%s", participantSID)
-		}
-	}
-	if len(params.Attributes) != 0 {
-		data, err := json.Marshal(params.Attributes)
-		if err != nil {
-			return nil, ErrInvalidParameter
-		}
-		str := base64.URLEncoding.EncodeToString(data)
-		urlSuffix += "&attributes=" + str
-	}
-	urlSuffix += getStatsParamString()
-
-	u, err := url.Parse(urlPrefix + urlSuffix)
+	queryParams, err := s.params.Signalling.ConnectQueryParams(
+		s.params.Version,
+		s.params.Protocol,
+		&connectParams,
+		participantSID,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	header := NewHeaderWithToken(token)
+	u, err := url.Parse(urlPrefix + s.params.Signalling.Path() + fmt.Sprintf("?%s", queryParams))
+	if err != nil {
+		return nil, err
+	}
+
+	header := NewHTTPHeaderWithToken(token)
 	startedAt := time.Now()
 	conn, hresp, err := websocket.DefaultDialer.DialContext(ctx, u.String(), header)
 	if err != nil {
@@ -240,40 +214,10 @@ func (s *signalTransportWebSocket) connect(
 			// DNS issue, abort
 			return nil, ErrCannotDialSignal
 		}
-		// use validate endpoint to get the actual error
-		validateSuffix := strings.Replace(urlSuffix, "/rtc", "/rtc/validate", 1)
 
-		validateReq, err1 := http.NewRequestWithContext(ctx, http.MethodGet, ToHttpURL(urlPrefix)+validateSuffix, nil)
-		if err1 != nil {
-			s.params.Logger.Errorw("error creating validate request", err1)
-			return nil, ErrCannotDialSignal
-		}
-		validateReq.Header = header
-		hresp, err := http.DefaultClient.Do(validateReq)
-		if err != nil {
-			s.params.Logger.Errorw("error getting validation", err, "httpResponse", hresp)
-			return nil, ErrCannotDialSignal
-		} else if hresp.StatusCode == http.StatusOK {
-			// no specific errors to return if validate succeeds
-			s.params.Logger.Infow("validate succeeded")
-			return nil, ErrCannotConnectSignal
-		} else {
-			var errString string
-			switch hresp.StatusCode {
-			case http.StatusUnauthorized:
-				errString = "unauthorized: "
-			case http.StatusNotFound:
-				errString = "not found: "
-			case http.StatusServiceUnavailable:
-				errString = "unavailable: "
-			}
-			body, err := io.ReadAll(hresp.Body)
-			if err == nil {
-				errString += string(body)
-			}
-			return nil, errors.New(errString)
-		}
+		return nil, err
 	}
+
 	s.Close() // close previous conn, if any
 	s.conn.Store(conn)
 
@@ -299,8 +243,7 @@ func (s *signalTransportWebSocket) readWorker(readerClosedCh chan struct{}) {
 		s.params.SignalTransportHandler.OnTransportClose()
 	}()
 
-	// SIGNALLING-V2-TODO: make this signalling version agnostic
-	var pendingResponse *livekit.SignalResponse
+	var pendingResponse proto.Message
 	s.lock.Lock()
 	pendingResponse = s.pendingResponse
 	s.pendingResponse = nil
@@ -351,11 +294,6 @@ func (s *signalTransportWebSocket) readResponse() (proto.Message, error) {
 }
 
 // ----------------------------------
-
-func getStatsParamString() string {
-	params := "&sdk=go&os=" + runtime.GOOS
-	return params
-}
 
 func isIgnoredWebsocketError(err error) bool {
 	if err == nil ||

--- a/signalling/utils.go
+++ b/signalling/utils.go
@@ -33,7 +33,7 @@ func ToWebsocketURL(url string) string {
 	return url
 }
 
-func NewHeaderWithToken(token string) http.Header {
+func NewHTTPHeaderWithToken(token string) http.Header {
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+token)
 	return header


### PR DESCRIPTION
Another pit stop along the way as this is getting big(ish).

Main bits
- Signal transport HTTP
- Signal transport hybrid - instantiates http only now
- Handle `/validate` end points in a more common way
- Use a join method for transport + signalling combination
  - not supporting v2 via WebSocket OR v1 via HTTP, can add later if need be
