### PR TITLE
Get to the point of establishing publishing peer connection and opening signalling data channel.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -173,6 +173,7 @@ func NewRTCEngine(
 ) *RTCEngine {
 	e := &RTCEngine{
 		log:                      logger,
+		signallingVersion:        signallingVersion,
 		engineHandler:            engineHandler,
 		cbGetLocalParticipantSID: getLocalParticipantSID,
 		trackPublishedListeners:  make(map[string]chan *livekit.TrackPublishedResponse),

--- a/engine.go
+++ b/engine.go
@@ -1221,7 +1221,6 @@ func (e *RTCEngine) OnReconnectResponse(res *livekit.ReconnectResponse) error {
 }
 
 func (e *RTCEngine) OnAnswer(sd webrtc.SessionDescription, answerId uint32) {
-	e.log.Debugw("RAJA onAnswer", "sd", sd) // REMOVE
 	if e.closed.Load() {
 		e.log.Debugw("ignoring SDP answer after closed")
 		return

--- a/room.go
+++ b/room.go
@@ -39,6 +39,14 @@ import (
 )
 
 var (
+	signallingVersion signalling.SignallingVersion = signalling.SignallingVersionV1
+)
+
+func WithSignallingVersion(v signalling.SignallingVersion) {
+	signallingVersion = v
+}
+
+var (
 	_ engineHandler = (*Room)(nil)
 )
 
@@ -204,7 +212,7 @@ func NewRoom(callback *RoomCallback) *Room {
 	}
 	r.callback.Merge(callback)
 
-	r.engine = NewRTCEngine(r, r.getLocalParticipantSID)
+	r.engine = NewRTCEngine(signallingVersion, r, r.getLocalParticipantSID)
 	r.LocalParticipant = newLocalParticipant(r.engine, r.callback, r.serverInfo)
 	return r
 }

--- a/signalling/errors.go
+++ b/signalling/errors.go
@@ -24,5 +24,6 @@ var (
 	ErrInvalidMessageType     = errors.New("invalid message type")
 	ErrInvalidParameter       = errors.New("invalid parameter")
 	ErrCannotDialSignal       = errors.New("could not dial signal connection")
-	ErrEmptyResponse          = errors.New("empty response")
+	ErrTransportNotStarted    = errors.New("transport not started")
+	ErrTransportChannelFull   = errors.New("transport channel is full")
 )

--- a/signalling/errors.go
+++ b/signalling/errors.go
@@ -24,6 +24,6 @@ var (
 	ErrInvalidMessageType     = errors.New("invalid message type")
 	ErrInvalidParameter       = errors.New("invalid parameter")
 	ErrCannotDialSignal       = errors.New("could not dial signal connection")
-	ErrTransportNotStarted    = errors.New("transport not started")
-	ErrTransportChannelFull   = errors.New("transport channel is full")
+	ErrMessageQueueNotStarted = errors.New("message queue not started")
+	ErrMessageQueueFull       = errors.New("message queue is full")
 )

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -27,6 +27,32 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type SignallingVersion int
+
+const (
+	SignallingVersionUnused SignallingVersion = iota
+	SignallingVersionV1                       // v1
+	SignallingVersionV2                       // v2
+)
+
+func (s SignallingVersion) String() string {
+	switch s {
+	case SignallingVersionUnused:
+		return "UNUSED"
+
+	case SignallingVersionV1:
+		return "V1"
+
+	case SignallingVersionV2:
+		return "V2"
+
+	default:
+		return fmt.Sprintf("UNKNOWN: %d", s)
+	}
+}
+
+// ---------------------------
+
 type joinMethod int
 
 const (
@@ -120,6 +146,8 @@ type ConnectParams struct {
 	Interceptors []interceptor.Factory
 
 	ICETransportPolicy webrtc.ICETransportPolicy
+
+	IsSignallingV2 bool
 }
 
 type SignalTransport interface {
@@ -153,6 +181,9 @@ type SignalHandler interface {
 	SetLogger(l protoLogger.Logger)
 
 	HandleMessage(msg proto.Message) error
+	HandleEncodedMessage(data []byte) error
+
+	PruneStaleReassemblies()
 }
 
 type SignalProcessor interface {

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -146,8 +146,6 @@ type ConnectParams struct {
 	Interceptors []interceptor.Factory
 
 	ICETransportPolicy webrtc.ICETransportPolicy
-
-	IsSignallingV2 bool
 }
 
 type SignalTransport interface {

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -150,6 +150,7 @@ type ConnectParams struct {
 
 type SignalTransport interface {
 	SetLogger(l protoLogger.Logger)
+	SetAsyncTransport(asyncTransport SignalTransport)
 
 	Start()
 	IsStarted() bool

--- a/signalling/messagequeue.go
+++ b/signalling/messagequeue.go
@@ -1,0 +1,107 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalling
+
+import (
+	"math/rand"
+	"sync"
+
+	"github.com/livekit/protocol/logger"
+	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
+)
+
+type messageQueueParams struct {
+	Logger        logger.Logger
+	HandleMessage func(msg proto.Message)
+}
+
+type messageQueue struct {
+	params messageQueueParams
+
+	lock             sync.RWMutex
+	isStarted        bool
+	msgChan          chan proto.Message
+	workerGeneration atomic.Uint32
+}
+
+func newMessageQueue(params messageQueueParams) *messageQueue {
+	m := &messageQueue{
+		params: params,
+	}
+	m.workerGeneration.Store(uint32(rand.Intn(1<<8) + 1))
+	return m
+}
+
+func (m *messageQueue) SetLogger(l logger.Logger) {
+	m.params.Logger = l
+}
+
+func (m *messageQueue) Start() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.isStarted {
+		return
+	}
+	m.isStarted = true
+
+	m.msgChan = make(chan proto.Message, 100)
+	go m.worker(m.workerGeneration.Inc())
+}
+
+func (m *messageQueue) IsStarted() bool {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.isStarted
+}
+
+func (m *messageQueue) Close() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.isStarted = false
+	m.workerGeneration.Inc()
+	close(m.msgChan)
+}
+
+func (m *messageQueue) Enqueue(msg proto.Message) error {
+	if msg == nil {
+		return nil
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	if !m.isStarted {
+		return ErrMessageQueueNotStarted
+	}
+
+	select {
+	case m.msgChan <- msg:
+		return nil
+	default:
+		return ErrMessageQueueFull
+	}
+}
+
+func (m *messageQueue) worker(gen uint32) {
+	for gen == m.workerGeneration.Load() {
+		msg := <-m.msgChan
+		if msg != nil {
+			m.params.HandleMessage(msg)
+		}
+	}
+}

--- a/signalling/signalhandler.go
+++ b/signalling/signalhandler.go
@@ -119,3 +119,12 @@ func (s *signalhandler) HandleMessage(msg proto.Message) error {
 
 	return nil
 }
+
+func (s *signalhandler) HandleEncodedMessage(data []byte) error {
+	signalResponse := &livekit.SignalResponse{}
+	if err := proto.Unmarshal(data, signalResponse); err != nil {
+		return err
+	}
+
+	return s.HandleMessage(signalResponse)
+}

--- a/signalling/signalhandlerunimplemented.go
+++ b/signalling/signalhandlerunimplemented.go
@@ -29,3 +29,9 @@ func (s *signalhandlerUnimplemented) SetLogger(l logger.Logger) {}
 func (s *signalhandlerUnimplemented) HandleMessage(msg proto.Message) error {
 	return nil
 }
+
+func (s *signalhandlerUnimplemented) HandleEncodedMessage(data []byte) error {
+	return nil
+}
+
+func (s *signalhandlerUnimplemented) PruneStaleReassemblies() {}

--- a/signalling/signalhandlerv2.go
+++ b/signalling/signalhandlerv2.go
@@ -113,6 +113,7 @@ func (s *signalhandlerv2) HandleMessage(msg proto.Message) error {
 				)
 			}
 
+			s.params.Logger.Infow("RAJA messageId", "messageId", sequencer.MessageId, "lprmi", sequencer.LastProcessedRemoteMessageId) // REMOVE
 			s.lastProcessedRemoteMessageId.Store(sequencer.MessageId)
 			s.params.Signalling.AckMessageId(sequencer.LastProcessedRemoteMessageId)
 			s.params.Signalling.SetLastProcessedRemoteMessageId(sequencer.MessageId)

--- a/signalling/signalhandlerv2.go
+++ b/signalling/signalhandlerv2.go
@@ -106,14 +106,19 @@ func (s *signalhandlerv2) HandleMessage(msg proto.Message) error {
 			case *livekit.Signalv2ServerMessage_SubscriberSdp:
 				s.params.Processor.OnOffer(protosignalling.FromProtoSessionDescription(payload.SubscriberSdp))
 
+			case *livekit.Signalv2ServerMessage_RoomUpdate:
+				s.params.Processor.OnRoomUpdate(payload.RoomUpdate.Room)
+
+			case *livekit.Signalv2ServerMessage_ParticipantUpdate:
+				s.params.Processor.OnParticipantUpdate(payload.ParticipantUpdate.Participants)
+
 			default:
 				s.params.Logger.Warnw(
 					"unhandled message", nil,
-					"mesageType", fmt.Sprintf("%T", serverMessage),
+					"mesageType", fmt.Sprintf("%T", serverMessage.GetMessage()),
 				)
 			}
 
-			s.params.Logger.Infow("RAJA messageId", "messageId", sequencer.MessageId, "lprmi", sequencer.LastProcessedRemoteMessageId) // REMOVE
 			s.lastProcessedRemoteMessageId.Store(sequencer.MessageId)
 			s.params.Signalling.AckMessageId(sequencer.LastProcessedRemoteMessageId)
 			s.params.Signalling.SetLastProcessedRemoteMessageId(sequencer.MessageId)

--- a/signalling/signalhandlerv2.go
+++ b/signalling/signalhandlerv2.go
@@ -134,3 +134,16 @@ func (s *signalhandlerv2) HandleMessage(msg proto.Message) error {
 
 	return nil
 }
+
+func (s *signalhandlerv2) HandleEncodedMessage(data []byte) error {
+	wireMessage := &livekit.Signalv2WireMessage{}
+	if err := proto.Unmarshal(data, wireMessage); err != nil {
+		return err
+	}
+
+	return s.HandleMessage(wireMessage)
+}
+
+func (s *signalhandlerv2) PruneStaleReassemblies() {
+	s.signalReassembler.Prune()
+}

--- a/signalling/signaltransport_datachannel.go
+++ b/signalling/signaltransport_datachannel.go
@@ -1,0 +1,126 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalling
+
+import (
+	"math/rand"
+	"sync"
+
+	"github.com/livekit/protocol/logger"
+	"github.com/pion/webrtc/v4"
+	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ SignalTransport = (*signalTransportDataChannel)(nil)
+
+type SignalTransportDataChannelParams struct {
+	Logger        logger.Logger
+	DataChannel   *webrtc.DataChannel
+	SignalHandler SignalHandler
+}
+
+type signalTransportDataChannel struct {
+	signalTransportUnimplemented
+
+	params SignalTransportDataChannelParams
+
+	lock             sync.RWMutex
+	isStarted        bool
+	msgChan          chan proto.Message
+	workerGeneration atomic.Uint32
+}
+
+func NewSignalTransportDataChannel(params SignalTransportDataChannelParams) SignalTransport {
+	s := &signalTransportDataChannel{
+		params:  params,
+		msgChan: make(chan proto.Message, 100),
+	}
+	s.workerGeneration.Store(uint32(rand.Intn(1<<8) + 1))
+	s.params.DataChannel.OnMessage(func(dataMsg webrtc.DataChannelMessage) {
+		s.params.SignalHandler.HandleEncodedMessage(dataMsg.Data)
+	})
+	return s
+}
+
+func (s *signalTransportDataChannel) SetLogger(l logger.Logger) {
+	s.params.Logger = l
+}
+
+func (s *signalTransportDataChannel) Start() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.isStarted {
+		return
+	}
+	s.isStarted = true
+
+	go s.worker(s.workerGeneration.Inc())
+}
+
+func (s *signalTransportDataChannel) IsStarted() bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.isStarted
+}
+
+func (s *signalTransportDataChannel) Close() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.isStarted = false
+	s.workerGeneration.Inc()
+	close(s.msgChan)
+}
+
+func (s *signalTransportDataChannel) SendMessage(msg proto.Message) error {
+	if msg == nil {
+		return nil
+	}
+
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if !s.isStarted {
+		return ErrTransportNotStarted
+	}
+
+	select {
+	case s.msgChan <- msg:
+		return nil
+	default:
+		// channel is full
+		return ErrTransportChannelFull
+	}
+}
+
+func (s *signalTransportDataChannel) worker(gen uint32) {
+	for gen == s.workerGeneration.Load() {
+		msg := <-s.msgChan
+		if msg != nil {
+			protoMsg, err := proto.Marshal(msg)
+			if err != nil {
+				s.params.Logger.Errorw("could not marshal proto message", err)
+				continue
+			}
+
+			if err := s.params.DataChannel.Send(protoMsg); err != nil {
+				s.params.Logger.Errorw("could not send proto message", err)
+				continue
+			}
+		}
+	}
+}

--- a/signalling/signaltransport_http.go
+++ b/signalling/signaltransport_http.go
@@ -223,8 +223,6 @@ func (s *signalTransportHttp) sendHttpRequest(
 	req.Header = NewHTTPHeaderWithToken(token)
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
-	s.params.Logger.Debugw("RAJA request", "wireMessage", wireMessage) // REMOVE
-
 	startedAt := time.Now()
 	hresp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -253,7 +251,6 @@ func (s *signalTransportHttp) sendHttpRequest(
 	if err := proto.Unmarshal(body, respWireMessage); err != nil {
 		return nil, err
 	}
-	s.params.Logger.Debugw("RAJA response", "respWireMessage", respWireMessage) // REMOVE
 
 	return respWireMessage, nil
 }

--- a/signalling/signaltransport_http.go
+++ b/signalling/signaltransport_http.go
@@ -201,6 +201,8 @@ func (s *signalTransportHttp) sendHttpRequest(
 	req.Header = NewHTTPHeaderWithToken(token)
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
+	s.params.Logger.Debugw("RAJA request", "wireMessage", wireMessage) // REMOVE
+
 	startedAt := time.Now()
 	hresp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -229,6 +231,7 @@ func (s *signalTransportHttp) sendHttpRequest(
 	if err := proto.Unmarshal(body, respWireMessage); err != nil {
 		return nil, err
 	}
+	s.params.Logger.Debugw("RAJA response", "respWireMessage", respWireMessage) // REMOVE
 
 	return respWireMessage, nil
 }

--- a/signalling/signaltransport_hybrid.go
+++ b/signalling/signaltransport_hybrid.go
@@ -57,6 +57,18 @@ func (s *signalTransportHybrid) SetLogger(l logger.Logger) {
 	s.syncTransport.SetLogger(l)
 }
 
+func (s *signalTransportHybrid) Start() {
+	s.syncTransport.Start()
+}
+
+func (s *signalTransportHybrid) IsStarted() bool {
+	return s.syncTransport.IsStarted()
+}
+
+func (s *signalTransportHybrid) Close() {
+	s.syncTransport.Close()
+}
+
 func (s *signalTransportHybrid) Join(
 	ctx context.Context,
 	url string,

--- a/signalling/signaltransport_unimplemented.go
+++ b/signalling/signaltransport_unimplemented.go
@@ -27,6 +27,8 @@ type signalTransportUnimplemented struct{}
 
 func (s *signalTransportUnimplemented) SetLogger(l protoLogger.Logger) {}
 
+func (s *signalTransportUnimplemented) SetAsyncTransport(asyncTransport SignalTransport) {}
+
 func (s *signalTransportUnimplemented) Start() {}
 
 func (s *signalTransportUnimplemented) IsStarted() bool {


### PR DESCRIPTION
- Adding a signalling version option to avoid changing code.

Need to do
- establishing signalling data channel should be driven by signal transport and not signalling version. For now, it is based on signalling version.
- have to configure publisher PC at start up and use it in `ConnectRequest`. That requires more wrangling of code which I will do later.