### PR TITLE
feat: Add `DisableRed` option for audio publications

### DIFF
--- a/localparticipant.go
+++ b/localparticipant.go
@@ -88,6 +88,7 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 		Height:     uint32(opts.VideoHeight),
 		DisableDtx: opts.DisableDTX,
 		Stereo:     opts.Stereo,
+		DisableRed: opts.DisableRed,
 		Stream:     opts.Stream,
 		Encryption: opts.Encryption,
 	}

--- a/publication.go
+++ b/publication.go
@@ -436,6 +436,7 @@ type TrackPublicationOptions struct {
 	// Opus only
 	DisableDTX bool
 	Stereo     bool
+	DisableRed bool
 	// which stream the track belongs to, used to group tracks together.
 	// if not specified, server will infer it from track source to bundle camera/microphone, screenshare/audio together
 	Stream string


### PR DESCRIPTION
This PR introduces a `DisableRed` option to `TrackPublicationOptions`. This allows developers to disable Redundant Audio Data (RED) for an audio track upon publication.

While RED can improve audio resilience on networks with packet loss, it increases bandwidth usage. This option provides flexibility for scenarios where lower bandwidth is a priority.