### PR TITLE
Fixing offset calculation

### DIFF
--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -164,14 +164,14 @@ func (t *TrackSynchronizer) onSenderReport(pkt *rtcp.SenderReport) {
 
 	offset := mediatransportutil.NtpTime(pkt.NTPTime).Time().Sub(t.startTime.Add(pts))
 	if t.onSR != nil {
-		t.onSR(offset - t.desiredPTSOffset)
+		t.onSR(offset)
 	}
 
 	if !t.acceptable(offset) {
 		return
 	}
 
-	t.desiredPTSOffset = offset
+	t.desiredPTSOffset += offset
 	t.lastSR = pkt.RTPTime
 }
 


### PR DESCRIPTION
Sender reports shouldn't overwrite the desired offset but update it. Also signal the correct diff in onSR callbacks.