### PR TITLE
rename OnDisconnect to OnDisconnected to match parent method

### DIFF
--- a/room.go
+++ b/room.go
@@ -724,7 +724,7 @@ func (r *Room) OnRoomJoined(
 	}
 }
 
-func (r *Room) OnDisconnect(reason DisconnectionReason) {
+func (r *Room) OnDisconnected(reason DisconnectionReason) {
 	r.callback.OnDisconnected()
 	r.callback.OnDisconnectedWithReason(reason)
 


### PR DESCRIPTION
Renamed Room method from OnDisconnect to OnDisconnected  
- Parent class (nullEngineHandler) defines OnDisconnected  
- Ensures method naming consistency and correct override