### PR TITLE
Log track synchronizer state more.

### DIFF
--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -415,7 +415,7 @@ func (t *TrackSynchronizer) onSenderReportWithoutRebase(pkt *rtcp.SenderReport) 
 		SenderReport: pkt,
 		receivedAt:   mono.UnixNano(),
 	}
-	if (t.lastSR.RTPTime != 0 && (pkt.RTPTime-t.lastSR.RTPTime) > (1<<31)) || pkt.RTPTime == t.lastSR.RTPTime {
+	if t.lastSR != nil && ((t.lastSR.RTPTime != 0 && (pkt.RTPTime-t.lastSR.RTPTime) > (1<<31)) || pkt.RTPTime == t.lastSR.RTPTime) {
 		t.logger.Debugw(
 			"dropping duplicate or out-of-order sender report",
 			"receivedSR", wrappedAugmentedSenderReportLogger{augmented},
@@ -484,7 +484,7 @@ func (t *TrackSynchronizer) onSenderReportWithRebase(pkt *rtcp.SenderReport) {
 		return
 	}
 
-	if (t.lastSR.RTPTime != 0 && (pkt.RTPTime-t.lastSR.RTPTime) > (1<<31)) || pkt.RTPTime == t.lastSR.RTPTime {
+	if t.lastSR != nil && ((t.lastSR.RTPTime != 0 && (pkt.RTPTime-t.lastSR.RTPTime) > (1<<31)) || pkt.RTPTime == t.lastSR.RTPTime) {
 		t.logger.Debugw(
 			"dropping duplicate or out-of-order sender report",
 			"receivedSR", wrappedAugmentedSenderReportLogger{augmented},


### PR DESCRIPTION
Adding a bunch of logging to have the synchronizer state in all the logs and also more places logged when packets are dropped/ignored.

NOTE for reviewers: looks like a lot of change, but no functional change, all of this is logging a bunch more and also using structured logging on the whole structure so that the state can be logged easily and while logging the full context is always available.