### PR TITLE
Use packet receive time to calculate PTS.

### DIFF
--- a/pkg/synchronizer/track_test.go
+++ b/pkg/synchronizer/track_test.go
@@ -53,7 +53,6 @@ func newTSForTests(tc *testing.T, clockRate uint32, kind webrtc.RTPCodecType) *T
 	}
 	// set a stable startTime well in the past to make time.Since(startTime) > 0
 	t.startTime = time.Now().Add(-150 * time.Millisecond)
-	t.initTime = t.startTime
 	// pick an arbitrary RTP base
 	t.startRTP = 1000
 	return t
@@ -144,7 +143,7 @@ func TestGetPTSWithRebase_PropelsForward(t *testing.T) {
 	ts1 := ts.startRTP + rtp500ms
 	adj1, err := ts.getPTSWithRebase(jitter.ExtPacket{
 		Packet:     &rtp.Packet{Header: rtp.Header{Timestamp: ts1}},
-		ReceivedAt: time.Time{}, // not used for estimatedPTS here
+		ReceivedAt: mono.Now(),
 	})
 	require.NoError(t, err)
 	require.InDelta(t, 500*time.Millisecond, adj1, float64(20*time.Millisecond))
@@ -159,7 +158,7 @@ func TestGetPTSWithRebase_PropelsForward(t *testing.T) {
 
 	adj2, err := ts.getPTSWithRebase(jitter.ExtPacket{
 		Packet:     &rtp.Packet{Header: rtp.Header{Timestamp: ts2}},
-		ReceivedAt: time.Time{},
+		ReceivedAt: mono.Now(),
 	})
 	require.NoError(t, err)
 	require.Equal(t, want, adj2)


### PR DESCRIPTION
The pipeline clock is anchored to when the first track of the synchronizer group is innitialised. And all packets should have PTS with reference to that. That clock is set to when the first packet of any track in the synchronizer group is read off the wire (non-padding packet). So, (packet_receive_time - pipeline_start_time) should be used to get the correct PTS.

A burst of packets is an interesting case.
- smooth flow of packets
- 3 seconds of gap
- a burst of three seconds packets

In this case, the following will happen
- old packet drop threshold will kick in and drop some of those packets.
- estimated PTS will be higher by upto (3 seconds - old_packet_treshold) for the burst. But, they should still be acceptable and pushed with proper PTS, i. e. PTS calculated using RTP timestamp diff should be correct.

Have to ensure that different thresholds do not render the pipeline drop tracks.