### PR TITLE
Fix start time adjustment logging

### DIFF
--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -608,6 +608,7 @@ func (t *TrackSynchronizer) updatePropagationDelay(asr *augmentedSenderReport) i
 func (t *TrackSynchronizer) maybeAdjustStartTime(asr *augmentedSenderReport) int64 {
 	nowNano := mono.UnixNano()
 	startTimeNano := t.startTime.UnixNano()
+	t.logger.Debugw("startTime", "startTime", t.startTime, "nano", startTimeNano) // REMOVE
 	if time.Duration(nowNano-startTimeNano) > cStartTimeAdjustWindow || asr.receivedAtAdjusted == 0 {
 		return 0
 	}
@@ -670,7 +671,7 @@ func (t *TrackSynchronizer) maybeAdjustStartTime(asr *augmentedSenderReport) int
 		}
 	}
 
-	return startTimeNano - adjustedStartTimeNano
+	return requestedAdjustment
 }
 
 func (t *TrackSynchronizer) acceptable(d time.Duration) bool {

--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -697,6 +697,9 @@ func (t *TrackSynchronizer) isPacketTooOld(packetTime time.Time) bool {
 	return t.oldPacketThreshold != 0 && mono.Now().Sub(packetTime) > t.oldPacketThreshold
 }
 
+// avoid applying small changes to start time as it will cause subsequent PTSes
+// to have micro jumps potentially causing audible distortion,
+// the bet is more infrequent larger jumps  is better than more frequent smaller jumps
 func (t *TrackSynchronizer) applyQuantizedStartTimeAdvance(deltaTotal time.Duration) time.Duration {
 	// include any prior residual
 	deltaTotal += t.startTimeAdjustResidual

--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -90,6 +90,7 @@ type TrackSynchronizer struct {
 
 	propagationDelayEstimator *OWDEstimator
 	totalStartTimeAdjustment  time.Duration
+	startTimeAdjustResidual   time.Duration
 
 	// packet stats
 	numEmitted           uint32
@@ -662,8 +663,8 @@ func (t *TrackSynchronizer) maybeAdjustStartTime(asr *augmentedSenderReport) int
 				getLoggingFields()...,
 			)
 		} else {
-			t.startTime = time.Unix(0, adjustedStartTimeNano)
-			t.logger.Infow("adjusting start time", getLoggingFields()...)
+			applied := t.applyQuantizedStartTimeAdvance(time.Duration(requestedAdjustment))
+			t.logger.Infow("adjusting start time", append(getLoggingFields(), "appliedAdjustment", applied)...)
 		}
 	}
 
@@ -696,6 +697,25 @@ func (t *TrackSynchronizer) isPacketTooOld(packetTime time.Time) bool {
 	return t.oldPacketThreshold != 0 && mono.Now().Sub(packetTime) > t.oldPacketThreshold
 }
 
+func (t *TrackSynchronizer) applyQuantizedStartTimeAdvance(deltaTotal time.Duration) time.Duration {
+	// include any prior residual
+	deltaTotal += t.startTimeAdjustResidual
+
+	quanta := deltaTotal / t.maxDriftAdjustment
+	residual := deltaTotal % t.maxDriftAdjustment
+
+	if quanta > 0 {
+		applied := quanta * t.maxDriftAdjustment
+		t.startTime = t.startTime.Add(-applied)
+		t.totalStartTimeAdjustment += applied
+		t.startTimeAdjustResidual = residual
+		return applied
+	}
+
+	t.startTimeAdjustResidual = deltaTotal
+	return 0
+}
+
 func (t *TrackSynchronizer) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	if t == nil {
 		return nil
@@ -719,6 +739,7 @@ func (t *TrackSynchronizer) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddTime("nextPTSAdjustmentAt", t.nextPTSAdjustmentAt)
 	e.AddObject("propagationDelayEstimator", t.propagationDelayEstimator)
 	e.AddDuration("totalStartTimeAdjustment", t.totalStartTimeAdjustment)
+	e.AddDuration("startTimeAdjustResidual", t.startTimeAdjustResidual)
 	e.AddUint32("numEmitted", t.numEmitted)
 	e.AddUint32("numDroppedOld", t.numDroppedOld)
 	e.AddUint32("numDroppedOutOfOrder", t.numDroppedOutOfOrder)

--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -608,7 +608,6 @@ func (t *TrackSynchronizer) updatePropagationDelay(asr *augmentedSenderReport) i
 func (t *TrackSynchronizer) maybeAdjustStartTime(asr *augmentedSenderReport) int64 {
 	nowNano := mono.UnixNano()
 	startTimeNano := t.startTime.UnixNano()
-	t.logger.Debugw("startTime", "startTime", t.startTime, "nano", startTimeNano) // REMOVE
 	if time.Duration(nowNano-startTimeNano) > cStartTimeAdjustWindow || asr.receivedAtAdjusted == 0 {
 		return 0
 	}
@@ -644,10 +643,8 @@ func (t *TrackSynchronizer) maybeAdjustStartTime(asr *augmentedSenderReport) int
 	getLoggingFields := func() []interface{} {
 		return []interface{}{
 			"nowTime", time.Unix(0, now),
-			"before", t.startTime,
+			"before", time.Unix(0, startTimeNano),
 			"after", time.Unix(0, adjustedStartTimeNano),
-			"startTimeNano", startTimeNano,
-			"adjustedStartTimeNano", adjustedStartTimeNano,
 			"requestedAdjustment", time.Duration(requestedAdjustment),
 			"nowTS", nowTS,
 			"timeSinceReceive", timeSinceReceive,


### PR DESCRIPTION
As it was logged, the before time was logged after adjustment, so it looked like the adjustment calculation was incorrect.

Adding more comments around quantising start time adjustment.