### PR TITLE
Adding burst estimator based start gate for initializing track synchronizer

### DIFF
--- a/pkg/synchronizer/start_gate.go
+++ b/pkg/synchronizer/start_gate.go
@@ -1,0 +1,161 @@
+package synchronizer
+
+import (
+	"time"
+
+	"github.com/livekit/media-sdk/jitter"
+	"github.com/pion/webrtc/v4"
+)
+
+// startGate is a lightweight buffer that decides when a track should be
+// considered "live". Callers push packets into the gate until it returns a
+// slice of packets that can be used to initialize downstream synchronisation.
+// The second return value exposes how many packets were discarded while the
+// gate was waiting for stability, and the third return value indicates whether
+// the gate has finished its job.
+type startGate interface {
+	Push(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int, bool)
+}
+
+// burstEstimatorGate implements startGate using the burst-estimation logic.
+// It buffers packets until their arrival cadence matches
+// the RTP timestamp spacing well enough to assume we are caught up with the
+// realtime stream. The gate can be configured with different tolerances for
+// audio and video since video keyframes may span hundreds of packets.
+type burstEstimatorGate struct {
+	clockRate   uint32
+	maxSkew     time.Duration
+	minArrival  time.Duration
+	scoreTarget int
+
+	score       int
+	lastTS      uint32
+	lastArrival time.Time
+	hasLast     bool
+	done        bool
+	buffer      []jitter.ExtPacket
+	maxBuffer   int
+}
+
+func newStartGate(clockRate uint32, kind webrtc.RTPCodecType) startGate {
+	be := &burstEstimatorGate{
+		clockRate:   clockRate,
+		maxSkew:     20 * time.Millisecond,
+		minArrival:  2 * time.Millisecond,
+		scoreTarget: 5,
+		maxBuffer:   1000, // high bitrate key frames can span hundreds of packets
+	}
+
+	if kind == webrtc.RTPCodecTypeAudio {
+		be.maxSkew = 8 * time.Millisecond
+		be.maxBuffer = 200
+	}
+
+	return be
+}
+
+// Push feeds one packet into the gate. Once pacing stabilizes it returns the
+// buffered packets that should be used to initialize the track synchronizer,
+// along with the number of packets dropped while waiting and a done flag.
+func (b *burstEstimatorGate) Push(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int, bool) {
+	if b.done {
+		return nil, 0, true
+	}
+
+	if len(pkt.Payload) == 0 {
+		return nil, 0, false
+	}
+
+	if !b.hasLast {
+		b.lastTS = pkt.Timestamp
+		b.lastArrival = pkt.ReceivedAt
+		b.hasLast = true
+		b.buffer = append(b.buffer[:0], pkt)
+		return nil, 0, false
+	}
+
+	signedTsDelta := int32(pkt.Timestamp - b.lastTS)
+	arrivalDelta := pkt.ReceivedAt.Sub(b.lastArrival)
+
+	if signedTsDelta < 0 {
+		// ignore out-of-order packets while continuing to wait for stability
+		return nil, 0, false
+	}
+
+	if signedTsDelta == 0 {
+		// multiple packets with the same timestamp (e.g. key frame)
+		b.buffer = append(b.buffer, pkt)
+		if dropped := b.enforceWindow(); dropped > 0 {
+			return nil, dropped, false
+		}
+		return nil, 0, false
+	}
+
+	b.lastTS = pkt.Timestamp
+	b.lastArrival = pkt.ReceivedAt
+
+	tsDuration := b.timestampToDuration(uint32(signedTsDelta))
+	if tsDuration <= 0 {
+		dropped := len(b.buffer)
+		b.buffer = b.buffer[:0]
+		b.score = 0
+		b.buffer = append(b.buffer, pkt)
+		return nil, dropped, false
+	}
+
+	if arrivalDelta < b.minArrival {
+		dropped := len(b.buffer)
+		b.buffer = b.buffer[:0]
+		b.score = 0
+		b.buffer = append(b.buffer, pkt)
+		return nil, dropped, false
+	}
+
+	skew := arrivalDelta - tsDuration
+	if skew < 0 {
+		skew = -skew
+	}
+
+	if skew > b.maxSkew {
+		dropped := len(b.buffer)
+		b.buffer = b.buffer[:0]
+		b.score = 0
+		b.buffer = append(b.buffer, pkt)
+		return nil, dropped, false
+	}
+
+	b.buffer = append(b.buffer, pkt)
+	if dropped := b.enforceWindow(); dropped > 0 {
+		return nil, dropped, false
+	}
+
+	if b.score < b.scoreTarget {
+		b.score++
+	}
+	if b.score >= b.scoreTarget {
+		b.done = true
+		ready := b.buffer
+		b.buffer = nil
+		return ready, 0, true
+	}
+
+	return nil, 0, false
+}
+
+func (b *burstEstimatorGate) timestampToDuration(delta uint32) time.Duration {
+	if b.clockRate == 0 {
+		return 0
+	}
+	return time.Duration(int64(delta) * int64(time.Second) / int64(b.clockRate))
+}
+
+func (b *burstEstimatorGate) enforceWindow() int {
+	if b.maxBuffer == 0 || len(b.buffer) <= b.maxBuffer {
+		return 0
+	}
+	dropped := len(b.buffer) - b.maxBuffer
+	copy(b.buffer, b.buffer[dropped:])
+	b.buffer = b.buffer[:len(b.buffer)-dropped]
+	b.score = 0
+	return dropped
+}

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -39,6 +39,7 @@ type SynchronizerConfig struct {
 	PreJitterBufferReceiveTimeEnabled bool
 	RTCPSenderReportRebaseEnabled     bool
 	OldPacketThreshold                time.Duration
+	EnableStartGate                   bool
 
 	OnStarted func()
 }
@@ -105,6 +106,13 @@ func WithRTCPSenderReportRebaseEnabled() SynchronizerOption {
 func WithOldPacketThreshold(oldPacketThreshold time.Duration) SynchronizerOption {
 	return func(config *SynchronizerConfig) {
 		config.OldPacketThreshold = oldPacketThreshold
+	}
+}
+
+// WithStartGate enabled will buffer incoming packets until pacing stabilizes before initializing tracks
+func WithStartGate() SynchronizerOption {
+	return func(config *SynchronizerConfig) {
+		config.EnableStartGate = true
 	}
 }
 

--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -56,6 +56,7 @@ type TrackSynchronizer struct {
 	track  TrackRemote
 	logger logger.Logger
 	*rtpConverter
+	startGate startGate
 
 	// config
 	maxTsDiff                         time.Duration // maximum acceptable difference between RTP packets
@@ -94,6 +95,7 @@ type TrackSynchronizer struct {
 	propagationDelayEstimator *OWDEstimator
 	totalStartTimeAdjustment  time.Duration
 	startTimeAdjustResidual   time.Duration
+	initialized               bool
 
 	stats stats
 }
@@ -115,6 +117,10 @@ func newTrackSynchronizer(s *Synchronizer, track TrackRemote) *TrackSynchronizer
 		propagationDelayEstimator:         NewOWDEstimator(OWDEstimatorParamsDefault),
 	}
 
+	if s.config.EnableStartGate {
+		t.startGate = newStartGate(track.Codec().ClockRate, track.Kind())
+	}
+
 	return t
 }
 
@@ -125,19 +131,51 @@ func (t *TrackSynchronizer) OnSenderReport(f func(drift time.Duration)) {
 	t.onSR = f
 }
 
+// PrimeForStart buffers incoming packets until pacing stabilizes, initializing the
+// track synchronizer automatically once a suitable sequence has been observed.
+// It returns the packets that should be forwarded, the number of packets
+// dropped while waiting, and a boolean indicating whether the track is ready to
+// process samples. After the gate finishes, there is no need to call the API again.
+func (t *TrackSynchronizer) PrimeForStart(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int, bool) {
+	if t.initialized || t.startGate == nil {
+		if !t.initialized {
+			t.Initialize(pkt.Packet)
+		}
+		return []jitter.ExtPacket{pkt}, 0, true
+	}
+
+	ready, dropped, done := t.startGate.Push(pkt)
+	if !done {
+		return nil, dropped, false
+	}
+
+	if len(ready) == 0 {
+		ready = append(ready, pkt)
+	}
+
+	if !t.initialized {
+		t.Initialize(ready[0].Packet)
+	}
+
+	return ready, dropped, true
+}
+
 // Initialize should be called as soon as the first packet is received
 func (t *TrackSynchronizer) Initialize(pkt *rtp.Packet) {
 	now := mono.Now()
 	t.Lock()
 	synchronizer := t.sync
 	t.Unlock()
-	if synchronizer == nil {
-		return
+	startedAt := now.UnixNano()
+	if synchronizer != nil {
+		startedAt = synchronizer.getOrSetStartedAt(now.UnixNano())
 	}
-	startedAt := synchronizer.getOrSetStartedAt(now.UnixNano())
 
 	t.Lock()
 	defer t.Unlock()
+	if t.initialized {
+		return
+	}
 
 	t.currentPTSOffset = time.Duration(now.UnixNano() - startedAt)
 	t.desiredPTSOffset = t.currentPTSOffset
@@ -147,6 +185,7 @@ func (t *TrackSynchronizer) Initialize(pkt *rtp.Packet) {
 	t.startRTP = pkt.Timestamp
 	t.lastPTS = 0
 	t.lastPTSAdjusted = t.currentPTSOffset
+	t.initialized = true
 	t.logger.Infow(
 		"initialized track synchronizer",
 		"state", t,


### PR DESCRIPTION
RTP packets arriving at a receiver site might come in a burst because of reconnect sending older packets through a NACK + retransmission. Anchoring track start time during phases of bursts would result in setting wrong start time for the track and breaking inter-track synchronization. Adding burst esitmator gate before init which will check between packets RTP and reception time and would allow init only when pace stabilizes (no burst is ongoing).