### PR TITLE
Revive track that constantly falls behind the current timeline

### DIFF
--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -26,6 +26,7 @@ const (
 	DefaultMaxDriftAdjustment           = 5 * time.Millisecond
 	DefaultDriftAdjustmentWindowPercent = 0.0 // 0 -> disables throttling
 	DefaultOldPacketThreshold           = 500 * time.Millisecond
+	DefaultFallingBehindThreshold       = 10 * time.Second
 )
 
 type SynchronizerOption func(*SynchronizerConfig)
@@ -39,6 +40,7 @@ type SynchronizerConfig struct {
 	PreJitterBufferReceiveTimeEnabled bool
 	RTCPSenderReportRebaseEnabled     bool
 	OldPacketThreshold                time.Duration
+	FallingBehindThreshold            time.Duration
 	EnableStartGate                   bool
 
 	OnStarted func()
@@ -109,6 +111,14 @@ func WithOldPacketThreshold(oldPacketThreshold time.Duration) SynchronizerOption
 	}
 }
 
+// WithFallingBehindThreshold sets the threshold at which a track is considered falling behind
+// at which point the track will be pulled forward
+func WithFallingBehindThreshold(fallingBehindThreshold time.Duration) SynchronizerOption {
+	return func(config *SynchronizerConfig) {
+		config.FallingBehindThreshold = fallingBehindThreshold
+	}
+}
+
 // WithStartGate enabled will buffer incoming packets until pacing stabilizes before initializing tracks
 func WithStartGate() SynchronizerOption {
 	return func(config *SynchronizerConfig) {
@@ -143,6 +153,7 @@ func NewSynchronizer(onStarted func()) *Synchronizer {
 		MaxDriftAdjustment:           DefaultMaxDriftAdjustment,
 		DriftAdjustmentWindowPercent: DefaultDriftAdjustmentWindowPercent,
 		OldPacketThreshold:           DefaultOldPacketThreshold,
+		FallingBehindThreshold:       DefaultFallingBehindThreshold,
 		OnStarted:                    onStarted,
 	}
 
@@ -161,6 +172,7 @@ func NewSynchronizerWithOptions(opts ...SynchronizerOption) *Synchronizer {
 		MaxDriftAdjustment:           DefaultMaxDriftAdjustment,
 		DriftAdjustmentWindowPercent: DefaultDriftAdjustmentWindowPercent,
 		OldPacketThreshold:           DefaultOldPacketThreshold,
+		FallingBehindThreshold:       DefaultFallingBehindThreshold,
 		OnStarted:                    nil,
 	}
 


### PR DESCRIPTION
We have seen cases where a track RTP packets timestamps could fall behind live mixer thereshold but still be in the acceptable range. Lowering acceptable range is avoided here to be able to avoid time rebase for the cases where a track only temporarly falls behind and then catches up - we would still like to avoid rebasing in that case so that we don't introduce syncrhonization problems (few missed packets at the cost of preserved sync).
The idea of this change is that if a track is constantly behind for some time - it's better to pull it forward in time and prevent it from being completely lost (at the cost of skewed synchronizaiton)