### PR TITLE
bump up the Rpc connection timeout to 7s, and clamp response timeout to min 1s

### DIFF
--- a/localparticipant.go
+++ b/localparticipant.go
@@ -566,7 +566,7 @@ func (p *LocalParticipant) HandleIncomingRpcResponse(requestId string, payload *
 // PerformRpc initiates an RPC call to a remote participant.
 // Returns the response payload or an error if the call fails or times out.
 func (p *LocalParticipant) PerformRpc(params PerformRpcParams) (*string, error) {
-	responseTimeout := 10000 * time.Millisecond
+	responseTimeout := 15000 * time.Millisecond
 	if params.ResponseTimeout != nil {
 		responseTimeout = *params.ResponseTimeout
 	}
@@ -574,7 +574,8 @@ func (p *LocalParticipant) PerformRpc(params PerformRpcParams) (*string, error) 
 	resultChan := make(chan *string, 1)
 	errorChan := make(chan error, 1)
 
-	maxRoundTripLatency := 2000 * time.Millisecond
+	maxRoundTripLatency := 7000 * time.Millisecond
+	minEffectiveResponseTimeout := 1 * time.Second
 
 	go func() {
 		if byteLength(params.Payload) > MaxPayloadBytes {
@@ -587,9 +588,16 @@ func (p *LocalParticipant) PerformRpc(params PerformRpcParams) (*string, error) 
 			return
 		}
 
+		effectiveResponseTimeout := responseTimeout - maxRoundTripLatency
+		if effectiveResponseTimeout < minEffectiveResponseTimeout {
+			effectiveResponseTimeout = minEffectiveResponseTimeout
+		}
 		id := uuid.New().String()
-		p.engine.publishRpcRequest(params.DestinationIdentity, id, params.Method, params.Payload, responseTimeout-maxRoundTripLatency)
+		p.engine.publishRpcRequest(params.DestinationIdentity, id, params.Method, params.Payload, effectiveResponseTimeout)
 
+		// Client-side timers:
+		// - responseTimer: total time client is willing to wait for a response.
+		// - ackTimer: time allowed for initial ACK/round-trip.
 		responseTimer := time.AfterFunc(responseTimeout, func() {
 			p.rpcPendingResponses.Delete(id)
 

--- a/rpc.go
+++ b/rpc.go
@@ -58,7 +58,10 @@ type PerformRpcParams struct {
 	Method string
 	// The method payload
 	Payload string
-	// Timeout for receiving a response after initial connection. Default: 10000ms
+	// Timeout for receiving a response after the initial connection (in milliseconds).
+	// If a value less than 8000 ms is provided, it will be automatically clamped to 8000 ms
+	// to ensure sufficient time for round-trip latency buffering.
+	// Default: 15000 ms.
 	ResponseTimeout *time.Duration
 }
 


### PR DESCRIPTION
We recently discovered that RPC message acknowledgments can experience several seconds of latency in certain scenarios. To address this, the client team has increased the connection timeout to 7 seconds, clamped the response timeout to a minimum of 1 second, and set the default RPC timeout to 15 seconds.

