### PR TITLE
Ensure adjusted PTS is always moving forward.

### DIFF
--- a/pkg/synchronizer/track.go
+++ b/pkg/synchronizer/track.go
@@ -335,6 +335,20 @@ func (t *TrackSynchronizer) getPTSWithoutRebase(pkt jitter.ExtPacket) (time.Dura
 	}
 
 	adjusted := pts + t.currentPTSOffset
+	if adjusted < t.lastPTSAdjusted {
+		// always move it forward
+		t.logger.Infow(
+			"propelling PTS forward",
+			"currentTS", ts,
+			"PTS", pts,
+			"estimatedPTS", estimatedPTS,
+			"ptsOffset", pts-estimatedPTS,
+			"adjustedPTS", adjusted,
+			"adjustedPTSOffset", adjusted-t.lastPTSAdjusted,
+			"state", t,
+		)
+		adjusted = t.lastPTSAdjusted + time.Millisecond
+	}
 
 	// if past end time, return EOF
 	if t.maxPTS > 0 && (adjusted > t.maxPTS) {


### PR DESCRIPTION
As adjusted is calculated after applying offset, it is possible that it could go backwards in some edge cases. Ensure it is always moving forward.