### PR TITLE
Adding media running time setter

### DIFF
--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -242,6 +242,14 @@ func (s *Synchronizer) GetStartedAt() int64 {
 	return s.startedAt
 }
 
+// SetMediaRunningTime updates the external media running time provider after the synchronizer has been created.
+// Passing a nil provider clears the configuration.
+func (s *Synchronizer) SetMediaRunningTime(mediaRunningTime func() (time.Duration, bool)) {
+	s.Lock()
+	s.config.MediaRunningTime = mediaRunningTime
+	s.Unlock()
+}
+
 func (s *Synchronizer) getOrSetStartedAt(now int64) int64 {
 	s.Lock()
 	defer s.Unlock()

--- a/pkg/synchronizer/track_test.go
+++ b/pkg/synchronizer/track_test.go
@@ -415,14 +415,12 @@ func TestNormalizePTSToMediaPipelineTimeline_CorrectsAfterLongLag(t *testing.T) 
 	ts.lastPTS = ptsIn
 	ts.lastPTSAdjusted = ptsIn
 	sampleTS := ts.toRTP(ptsIn)
-	initialStartRTP := ts.startRTP
 	ts.lastTimelyPacket = mono.Now().Add(-cMaxTimelyPacketAge - time.Second)
 
 	deadline, ok := ts.sync.getExternalMediaDeadline()
 	require.True(t, ok)
 
 	adjusted, ptsOut := ts.normalizePTSToMediaPipelineTimeline(ptsIn, sampleTS, mono.Now())
-	require.NotEqual(t, initialStartRTP, ts.startRTP, "expected track to rebase when lag persists")
 	expectedPTS := deadline + ts.maxMediaRunningTimeDelay - ts.currentPTSOffset
 	require.InDelta(t, float64(expectedPTS), float64(ptsOut), float64(3*time.Millisecond))
 	require.InDelta(t, float64(expectedPTS+ts.currentPTSOffset), float64(adjusted), float64(3*time.Millisecond))


### PR DESCRIPTION
Synchronizer API consumers might not be able to set the pipeline time provider when the object is created.
Adding a setter method so it could be updated when available.

Removing unused field inside track.go and also removing parts which update startRTP. It's used only for logging and it's nice to have original value there.