### PR TITLE
cloudagents client interface to support build logs

### DIFF
--- a/pkg/cloudagents/build.go
+++ b/pkg/cloudagents/build.go
@@ -20,9 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	bkclient "github.com/moby/buildkit/client"
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (c *Client) build(ctx context.Context, id string) error {
+func (c *Client) build(ctx context.Context, id string, writer io.Writer) error {
 	params := url.Values{}
 	params.Add("agent_id", id)
 	fullUrl := fmt.Sprintf("%s/build?%s", c.agentsURL, params.Encode())
@@ -50,7 +50,7 @@ func (c *Client) build(ctx context.Context, id string) error {
 	ch := make(chan *bkclient.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		display, err := progressui.NewDisplay(os.Stderr, "auto")
+		display, err := progressui.NewDisplay(writer, "plain")
 		if err != nil {
 			return err
 		}

--- a/pkg/cloudagents/logs.go
+++ b/pkg/cloudagents/logs.go
@@ -26,8 +26,8 @@ import (
 )
 
 type APIError struct {
-	Message string             `json:"msg"`
-	Meta    *map[string]string `json:"meta,omitempty"`
+	Message string            `json:"msg"`
+	Meta    map[string]string `json:"meta,omitempty"`
 }
 
 // StreamLogs streams the logs for the given agent.


### PR DESCRIPTION
Address few additional comments for cloudagents client
* fix agentsURL override
* support build logs streaming

Comment on progressui from the [other PR](https://github.com/livekit/server-sdk-go/pull/775#discussion_r2453008297):

> We need to support streaming during the build.
> 
> The buildkit library uses an internal go channel to return build logs, but returning this raw channel directly to caller exposes internal concurrency details and makes channel lifecycle management difficult. It is ambiguous who is responsible for closing the channel, consuming messages, or handling potential blocking operations.
>
> A better approach is to use io.Writer interface which allows the function to manage concurrency internally while providing a cleaner API.
>
> The progressui package name can be misleading. It is essentially a concurrent writer with a ticker and optional formatting configuration. It can also be used to stream raw JSON data if needed. While we could implement our own ticker to read from the internal channel, using the progressui package is more maintainable solution.
