### PR TITLE
Rename H26xFormat to H26xStreamingFormat and avcc -> RTP.

### DIFF
--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -45,15 +45,15 @@ type H26xStreamingFormat int
 
 const (
 	H26xStreamingFormatAnnexB H26xStreamingFormat = iota
-	H26xStreamingFormatRTP
+	H26xStreamingFormatLengthPrefixed
 )
 
 func (f H26xStreamingFormat) String() string {
 	switch f {
 	case H26xStreamingFormatAnnexB:
 		return "AnnexB"
-	case H26xStreamingFormatRTP:
-		return "RTP"
+	case H26xStreamingFormatLengthPrefixed:
+		return "LengthPrefixed"
 	default:
 		return fmt.Sprintf("Unknown: %d", f)
 	}
@@ -276,8 +276,8 @@ func (p *ReaderSampleProvider) NextSample(ctx context.Context) (media.Sample, er
 			err         error
 		)
 		switch p.h26xStreamingFormat {
-		case H26xStreamingFormatRTP:
-			nalUnitType, nalUnitData, err = nextNALH264AVCC(p.reader)
+		case H26xStreamingFormatLengthPrefixed:
+			nalUnitType, nalUnitData, err = nextNALH264LengthPrefixed(p.reader)
 			if err != nil {
 				return sample, err
 			}
@@ -379,8 +379,8 @@ func (p *ReaderSampleProvider) NextSample(ctx context.Context) (media.Sample, er
 
 // --------------------------------------------------
 
-// minimal AVCC reader (length-prefixed NAL)
-func nextNALH264AVCC(r io.Reader) (h264reader.NalUnitType, []byte, error) {
+// minimal length-prefixed NAL reeader
+func nextNALH264LengthPrefixed(r io.Reader) (h264reader.NalUnitType, []byte, error) {
 	var hdr [4]byte
 	if _, err := io.ReadFull(r, hdr[:]); err != nil {
 		return 0, nil, err

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package lksdk
 
-const Version = "2.12.5"
+const Version = "2.12.6"


### PR DESCRIPTION
AVCC is really a format for containers like mp4. And in that format, SPS/PPS is stored in a different section in the container. Technically, they are out-of-band from the stream.

NVidia drivers call the length prefixed output mode as RTP_MODE_OUTPUT (https://developer.nvidia.com/docs/drive/drive-os/archives/6.0.3/linux/sdk/api_reference/group__x__h264__encoder__api.html#ggae87dcbde3f31e145bce800e59530f88eae974e3646f6b7daeb3d32f4e610190c1).

So, rename AVCC -> RTP