### PR TITLE
Use build log stream auto format by default

### DIFF
--- a/pkg/cloudagents/build.go
+++ b/pkg/cloudagents/build.go
@@ -47,7 +47,7 @@ func (c *Client) build(ctx context.Context, id string, writer io.Writer) error {
 		return fmt.Errorf("failed to build agent: %s", resp.Status)
 	}
 
-	displayMode := progressui.PlainMode
+	displayMode := progressui.AutoMode
 	if c.jsonLogStream {
 		displayMode = progressui.RawJSONMode
 	}

--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package lksdk
 
-const Version = "2.12.6"
+const Version = "2.12.7"


### PR DESCRIPTION
Using 'auto' format allows the build logs to roll up in TTY