### PR TITLE
Version 2.12.8

### DIFF
--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package lksdk
 
-const Version = "2.12.7"
+const Version = "2.12.8"


### PR DESCRIPTION
This is becoming a bit of a pain.
This is an empty tag so that we can use the same version in CLI. And if I do not release CLI fast enough (I already had a PR with 2.12.6 which is pending release awaiting a customer check), I will have to re-tag.