### PR TITLE
fix(remote_participant): disconnect reason

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -161,18 +161,17 @@ func GetDisconnectionReason(reason livekit.DisconnectReason) DisconnectionReason
 }
 
 type RoomCallback struct {
-	OnDisconnected                      func()
-	OnDisconnectedWithReason            func(reason DisconnectionReason)
-	OnParticipantConnected              func(*RemoteParticipant)
-	OnParticipantDisconnected           func(*RemoteParticipant)
-	OnParticipantDisconnectedWithReason func(*RemoteParticipant, livekit.DisconnectReason)
-	OnActiveSpeakersChanged             func([]Participant)
-	OnRoomMetadataChanged               func(metadata string)
-	OnRecordingStatusChanged            func(isRecording bool)
-	OnRoomMoved                         func(roomName string, token string)
-	OnReconnecting                      func()
-	OnReconnected                       func()
-	OnLocalTrackSubscribed              func(publication *LocalTrackPublication, lp *LocalParticipant)
+	OnDisconnected            func()
+	OnDisconnectedWithReason  func(reason DisconnectionReason)
+	OnParticipantConnected    func(*RemoteParticipant)
+	OnParticipantDisconnected func(*RemoteParticipant)
+	OnActiveSpeakersChanged   func([]Participant)
+	OnRoomMetadataChanged     func(metadata string)
+	OnRecordingStatusChanged  func(isRecording bool)
+	OnRoomMoved               func(roomName string, token string)
+	OnReconnecting            func()
+	OnReconnected             func()
+	OnLocalTrackSubscribed    func(publication *LocalTrackPublication, lp *LocalParticipant)
 
 	// participant events are sent to the room as well
 	ParticipantCallback
@@ -184,18 +183,17 @@ func NewRoomCallback() *RoomCallback {
 	return &RoomCallback{
 		ParticipantCallback: *pc,
 
-		OnDisconnected:                      func() {},
-		OnDisconnectedWithReason:            func(reason DisconnectionReason) {},
-		OnParticipantConnected:              func(participant *RemoteParticipant) {},
-		OnParticipantDisconnected:           func(participant *RemoteParticipant) {},
-		OnParticipantDisconnectedWithReason: func(participant *RemoteParticipant, reason livekit.DisconnectReason) {},
-		OnActiveSpeakersChanged:             func(participants []Participant) {},
-		OnRoomMetadataChanged:               func(metadata string) {},
-		OnRecordingStatusChanged:            func(isRecording bool) {},
-		OnRoomMoved:                         func(roomName string, token string) {},
-		OnReconnecting:                      func() {},
-		OnReconnected:                       func() {},
-		OnLocalTrackSubscribed:              func(publication *LocalTrackPublication, lp *LocalParticipant) {},
+		OnDisconnected:            func() {},
+		OnDisconnectedWithReason:  func(reason DisconnectionReason) {},
+		OnParticipantConnected:    func(participant *RemoteParticipant) {},
+		OnParticipantDisconnected: func(participant *RemoteParticipant) {},
+		OnActiveSpeakersChanged:   func(participants []Participant) {},
+		OnRoomMetadataChanged:     func(metadata string) {},
+		OnRecordingStatusChanged:  func(isRecording bool) {},
+		OnRoomMoved:               func(roomName string, token string) {},
+		OnReconnecting:            func() {},
+		OnReconnected:             func() {},
+		OnLocalTrackSubscribed:    func(publication *LocalTrackPublication, lp *LocalParticipant) {},
 	}
 }
 
@@ -216,9 +214,6 @@ func (cb *RoomCallback) Merge(other *RoomCallback) {
 	}
 	if other.OnParticipantDisconnected != nil {
 		cb.OnParticipantDisconnected = other.OnParticipantDisconnected
-	}
-	if other.OnParticipantDisconnectedWithReason != nil {
-		cb.OnParticipantDisconnectedWithReason = other.OnParticipantDisconnectedWithReason
 	}
 	if other.OnActiveSpeakersChanged != nil {
 		cb.OnActiveSpeakersChanged = other.OnActiveSpeakersChanged

--- a/room.go
+++ b/room.go
@@ -923,7 +923,6 @@ func (r *Room) OnParticipantDisconnect(rp *RemoteParticipant, reason livekit.Dis
 
 	rp.info.DisconnectReason = reason
 	go r.callback.OnParticipantDisconnected(rp)
-	go r.callback.OnParticipantDisconnectedWithReason(rp, reason)
 }
 
 func (r *Room) OnSpeakersChanged(speakerUpdates []*livekit.SpeakerInfo) {
@@ -1005,7 +1004,7 @@ func (r *Room) OnRoomMoved(moved *livekit.RoomMovedResponse) {
 	r.OnRoomUpdate(moved.Room)
 
 	for _, rp := range r.GetRemoteParticipants() {
-		r.OnParticipantDisconnect(rp, livekit.DisconnectReason_ROOM_CLOSED)
+		r.OnParticipantDisconnect(rp, livekit.DisconnectReason_MIGRATION)
 	}
 
 	go r.callback.OnRoomMoved(moved.Room.Name, moved.Token)


### PR DESCRIPTION
Tested with this example: https://gist.github.com/anunaym14/47f0ede23ec9ddfb0e782250fda8d279

```
 > go run main.go
2025-11-12T21:53:09.241+0530    INFO    disconnect-reason       disconnect_reason/main.go:23    participant disconnected without reason  {"identity": "go-sdk-1", "reason": "CLIENT_INITIATED"}
2025-11-12T21:53:09.241+0530    INFO    disconnect-reason       disconnect_reason/main.go:26    participant disconnected with reason     {"identity": "go-sdk-1", "reason": "CLIENT_INITIATED"}
```