### PR TITLE
after parsing H264 SEI NAL, discard to avoid breaking certain decoders

### DIFF
--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -379,7 +379,6 @@ func (p *ReaderSampleProvider) NextSample(ctx context.Context) (media.Sample, er
 				p.pendingUserTimestampUs = 0
 			}
 			sample.Data = appendUserTimestampTrailer(sample.Data, ts)
-
 		}
 
 		sample.Duration = defaultH264FrameDuration


### PR DESCRIPTION
- when SEI parsing is enabled, we should always discard the SEI NAL as it still breaks some decoders.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SEI metadata is no longer emitted as standalone samples; SEI content is always cleared and used only to source timestamps to prevent invalid/empty samples and potential decoder issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->