### PR TITLE
Add private link methods in AgentClient

### DIFF
--- a/agent_client.go
+++ b/agent_client.go
@@ -120,3 +120,27 @@ func (c *AgentClient) GetClientSettings(ctx context.Context, req *livekit.Client
 	}
 	return c.agentClient.GetClientSettings(ctx, req)
 }
+
+func (c *AgentClient) CreatePrivateLink(ctx context.Context, req *livekit.CreatePrivateLinkRequest) (*livekit.CreatePrivateLinkResponse, error) {
+	ctx, err := c.withAuth(ctx, withAgentGrant{Admin: true})
+	if err != nil {
+		return nil, err
+	}
+	return c.agentClient.CreatePrivateLink(ctx, req)
+}
+
+func (c *AgentClient) DestroyPrivateLink(ctx context.Context, req *livekit.DestroyPrivateLinkRequest) (*livekit.DestroyPrivateLinkResponse, error) {
+	ctx, err := c.withAuth(ctx, withAgentGrant{Admin: true})
+	if err != nil {
+		return nil, err
+	}
+	return c.agentClient.DestroyPrivateLink(ctx, req)
+}
+
+func (c *AgentClient) ListPrivateLinks(ctx context.Context, req *livekit.ListPrivateLinksRequest) (*livekit.ListPrivateLinksResponse, error) {
+	ctx, err := c.withAuth(ctx, withAgentGrant{Admin: true})
+	if err != nil {
+		return nil, err
+	}
+	return c.agentClient.ListPrivateLinks(ctx, req)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/media-sdk v0.0.0-20251106223430-dd8f5e0de2cf
 	github.com/livekit/mediatransportutil v0.0.0-20251128105421-19c7a7b81c22
-	github.com/livekit/protocol v1.44.1-0.20260120134243-0914cc74653e
+	github.com/livekit/protocol v1.44.1-0.20260211210831-af21b2260770
 	github.com/magefile/mage v1.15.0
 	github.com/pion/dtls/v3 v3.0.10
 	github.com/pion/interceptor v0.1.43

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/livekit/mediatransportutil v0.0.0-20251128105421-19c7a7b81c22 h1:dzCB
 github.com/livekit/mediatransportutil v0.0.0-20251128105421-19c7a7b81c22/go.mod h1:mSNtYzSf6iY9xM3UX42VEI+STHvMgHmrYzEHPcdhB8A=
 github.com/livekit/protocol v1.44.1-0.20260120134243-0914cc74653e h1:ClpOUpIDcIT/fKh66kOlO4b7fj47ApsITOwCOlvFrGc=
 github.com/livekit/protocol v1.44.1-0.20260120134243-0914cc74653e/go.mod h1:BLJHYHErQTu3+fnmfGrzN6CbHxNYiooFIIYGYxXxotw=
+github.com/livekit/protocol v1.44.1-0.20260211210831-af21b2260770 h1:iOG7eeQDc83HEeOgJ1E9uBr8zmCWjmi61qsADNQrC3I=
+github.com/livekit/protocol v1.44.1-0.20260211210831-af21b2260770/go.mod h1:BLJHYHErQTu3+fnmfGrzN6CbHxNYiooFIIYGYxXxotw=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=

--- a/pkg/cloudagents/client.go
+++ b/pkg/cloudagents/client.go
@@ -122,6 +122,21 @@ func (c *Client) DeployAgent(
 	return c.uploadAndBuild(ctx, agentID, resp.PresignedUrl, resp.PresignedPostRequest, source, excludeFiles, buildLogStreamWriter)
 }
 
+// CreatePrivateLink creates a new private link for cloud agents.
+func (c *Client) CreatePrivateLink(ctx context.Context, req *lkproto.CreatePrivateLinkRequest) (*lkproto.CreatePrivateLinkResponse, error) {
+	return c.AgentClient.CreatePrivateLink(ctx, req)
+}
+
+// DestroyPrivateLink deletes a private link by ID.
+func (c *Client) DestroyPrivateLink(ctx context.Context, req *lkproto.DestroyPrivateLinkRequest) (*lkproto.DestroyPrivateLinkResponse, error) {
+	return c.AgentClient.DestroyPrivateLink(ctx, req)
+}
+
+// ListPrivateLinks lists private links for the project.
+func (c *Client) ListPrivateLinks(ctx context.Context, req *lkproto.ListPrivateLinksRequest) (*lkproto.ListPrivateLinksResponse, error) {
+	return c.AgentClient.ListPrivateLinks(ctx, req)
+}
+
 // uploadAndBuild uploads the source and triggers remote build
 func (c *Client) uploadAndBuild(
 	ctx context.Context,


### PR DESCRIPTION
- Adds private link related methods (Create, List, Delete) to AgentClient so it can easily be used by CLI
- Bumped protocol version in go.mod