### PR TITLE
chore(release): bump to v2.14.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package lksdk
 
-const Version = "2.13.3"
+const Version = "2.14.0"


### PR DESCRIPTION
Bumping to `v2.14.0` to match changes in CLI to support non-interactive terminals: https://github.com/livekit/livekit-cli/pull/776