### PR TITLE
chore(release): bump to v2.15.0 for cli

### DIFF
--- a/version.go
+++ b/version.go
@@ -14,4 +14,4 @@
 
 package lksdk
 
-const Version = "2.14.0"
+const Version = "2.15.0"


### PR DESCRIPTION
Bumping to `v2.15.0` to match changes in CLI to support new `docs` command: https://github.com/livekit/livekit-cli/pull/774