### PR TITLE
Added WithDTLSEllipticCurves ConnectOption for FIPS

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -350,6 +350,7 @@ func (e *RTCEngine) createPublisherPCLocked(configuration webrtc.Configuration) 
 		IncludeDefaultInterceptors: e.connParams.IncludeDefaultInterceptors,
 		OnRTTUpdate:                e.setRTT,
 		IsSender:                   true,
+		DTLSEllipticCurves:         e.connParams.DTLSEllipticCurves,
 	}); err != nil {
 		return err
 	}
@@ -435,6 +436,7 @@ func (e *RTCEngine) createSubscriberPCLocked(configuration webrtc.Configuration)
 		RetransmitBufferSize:       e.connParams.RetransmitBufferSize,
 		Interceptors:               e.connParams.Interceptors,
 		IncludeDefaultInterceptors: e.connParams.IncludeDefaultInterceptors,
+		DTLSEllipticCurves:         e.connParams.DTLSEllipticCurves,
 	}); err != nil {
 		return err
 	}

--- a/room.go
+++ b/room.go
@@ -40,6 +40,8 @@ import (
 	"github.com/livekit/protocol/auth"
 	protoCodecs "github.com/livekit/protocol/codecs"
 	"github.com/livekit/protocol/livekit"
+
+	dtlsElliptic "github.com/pion/dtls/v3/pkg/crypto/elliptic"
 )
 
 var (
@@ -192,6 +194,15 @@ func WithCodecs(codecs []livekit.Codec) ConnectOption {
 			pCodecs = append(pCodecs, protoCodecs.ToWebrtcCodecParameters(&codecs[i]))
 		}
 		p.Codecs = pCodecs
+	}
+}
+
+// WithDTLSEllipticCurves configures the DTLS elliptic curves used for key exchange.
+// Use this on FIPS 140-enabled systems to specify NIST-approved curves (e.g. P-256, P-384)
+// instead of the default X25519.
+func WithDTLSEllipticCurves(curves ...dtlsElliptic.Curve) ConnectOption {
+	return func(p *signalling.ConnectParams) {
+		p.DTLSEllipticCurves = curves
 	}
 }
 

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -22,6 +22,7 @@ import (
 	"github.com/livekit/mediatransportutil/pkg/pacer"
 	"github.com/livekit/protocol/livekit"
 	protoLogger "github.com/livekit/protocol/logger"
+	dtlsElliptic "github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/interceptor"
 	"github.com/pion/webrtc/v4"
 	"google.golang.org/protobuf/proto"
@@ -88,6 +89,8 @@ type ConnectParams struct {
 	IncludeDefaultInterceptors bool
 
 	ICETransportPolicy webrtc.ICETransportPolicy
+
+	DTLSEllipticCurves []dtlsElliptic.Curve // FIPS 140: override default DTLS curves
 
 	// internal use
 	Codecs []webrtc.RTPCodecParameters

--- a/transport.go
+++ b/transport.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/bep/debounce"
 	"github.com/pion/dtls/v3"
+	dtlsElliptic "github.com/pion/dtls/v3/pkg/crypto/elliptic"
 	"github.com/pion/interceptor"
 	"github.com/pion/interceptor/pkg/nack"
 	"github.com/pion/interceptor/pkg/twcc"
@@ -79,6 +80,7 @@ type PCTransportParams struct {
 	IncludeDefaultInterceptors bool
 	OnRTTUpdate                func(rtt uint32)
 	IsSender                   bool
+	DTLSEllipticCurves         []dtlsElliptic.Curve
 }
 
 func (t *PCTransport) registerDefaultInterceptors(params PCTransportParams, i *interceptor.Registry) error {
@@ -208,6 +210,9 @@ func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
 
 	se := webrtc.SettingEngine{}
 	se.SetSRTPProtectionProfiles(dtls.SRTP_AEAD_AES_128_GCM, dtls.SRTP_AES128_CM_HMAC_SHA1_80)
+	if len(params.DTLSEllipticCurves) > 0 {
+		se.SetDTLSEllipticCurves(params.DTLSEllipticCurves...)
+	}
 	se.SetDTLSRetransmissionInterval(dtlsRetransmissionInterval)
 	se.SetICETimeouts(iceDisconnectedTimeout, iceFailedTimeout, iceKeepaliveInterval)
 	lf := pionlogger.NewLoggerFactory(logger)


### PR DESCRIPTION
Resolves #866 

Adds `WithDTLSEllipticCurves` ConnectOption so callers can configure the DTLS elliptic curves used for WebRTC key exchange. This is needed on FIPS 140-enabled systems where Go's crypto stack rejects X25519 (the pion default) since it's not NIST-approved.

Usage:
```go
room, err := lksdk.ConnectToRoomWithToken(url, token, callback,
    lksdk.WithDTLSEllipticCurves(dtlsElliptic.P256, dtlsElliptic.P384),
)
```
When no curves are specified, behavior is unchanged (pion defaults apply).

