### PR TITLE
TEL-522: JoinWithToken accepts a context to be cancelled or timed out early

### DIFF
--- a/room.go
+++ b/room.go
@@ -111,6 +111,15 @@ func WithConnectTimeout(timeout time.Duration) ConnectOption {
 	}
 }
 
+// WithContext sets a context for the JoinWithToken call.
+// When provided, the region discovery retry loop and backoff sleeps will
+// respect context cancellation/deadline.
+func WithContext(ctx context.Context) ConnectOption {
+	return func(p *signalling.ConnectParams) {
+		p.Context = ctx
+	}
+}
+
 // WithAutoSubscribe sets whether the participant should automatically subscribe to tracks.
 // Default is true.
 func WithAutoSubscribe(val bool) ConnectOption {
@@ -367,6 +376,10 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 		opt(params)
 	}
 
+	if params.Context != nil {
+		ctx = params.Context
+	}
+
 	if params.Logger != nil {
 		r.SetLogger(params.Logger)
 	}
@@ -378,6 +391,9 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 			r.log.Errorw("failed to get best url", err)
 		} else {
 			for tries := uint(0); !isSuccess; tries++ {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				bestURL, err := r.regionURLProvider.PopBestURL(cloudHostname, token)
 				if err != nil {
 					r.log.Errorw("failed to get best url", err)
@@ -396,7 +412,11 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 						"retrying in", d,
 						"url", bestURL,
 					)
-					time.Sleep(d)
+					select {
+					case <-time.After(d):
+					case <-ctx.Done():
+						return ctx.Err()
+					}
 					continue
 				}
 			}

--- a/room.go
+++ b/room.go
@@ -111,15 +111,6 @@ func WithConnectTimeout(timeout time.Duration) ConnectOption {
 	}
 }
 
-// WithContext sets a context for the JoinWithToken call.
-// When provided, the region discovery retry loop and backoff sleeps will
-// respect context cancellation/deadline.
-func WithContext(ctx context.Context) ConnectOption {
-	return func(p *signalling.ConnectParams) {
-		p.Context = ctx
-	}
-}
-
 // WithAutoSubscribe sets whether the participant should automatically subscribe to tracks.
 // Default is true.
 func WithAutoSubscribe(val bool) ConnectOption {
@@ -336,8 +327,13 @@ func (r *Room) PrepareConnection(url, token string) error {
 	return r.regionURLProvider.RefreshRegionSettings(cloudHostname, token)
 }
 
-// Join - joins the room as with default permissions
+// Join - joins the room with default permissions
 func (r *Room) Join(url string, info ConnectInfo, opts ...ConnectOption) error {
+	return r.JoinWithContext(context.Background(), url, info, opts...)
+}
+
+// JoinWithContext - like Join, but accepts a context for cancellation/deadline.
+func (r *Room) JoinWithContext(ctx context.Context, url string, info ConnectInfo, opts ...ConnectOption) error {
 	var params signalling.ConnectParams
 	for _, opt := range opts {
 		opt(&params)
@@ -361,23 +357,22 @@ func (r *Room) Join(url string, info ConnectInfo, opts ...ConnectOption) error {
 		return err
 	}
 
-	return r.JoinWithToken(url, token, opts...)
+	return r.JoinWithContextAndToken(ctx, url, token, opts...)
 }
 
 // JoinWithToken - customize participant options by generating your own token
 func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
-	ctx := context.TODO()
+	return r.JoinWithContextAndToken(context.Background(), url, token, opts...)
+}
 
+// JoinWithContextAndToken - like JoinWithToken, but accepts a context for cancellation/deadline.
+func (r *Room) JoinWithContextAndToken(ctx context.Context, url, token string, opts ...ConnectOption) error {
 	params := &signalling.ConnectParams{
 		AutoSubscribe:  true,
 		ConnectTimeout: 3 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(params)
-	}
-
-	if params.Context != nil {
-		ctx = params.Context
 	}
 
 	if params.Logger != nil {

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -92,11 +92,6 @@ type ConnectParams struct {
 
 	DTLSEllipticCurves []dtlsElliptic.Curve // FIPS 140: override default DTLS curves
 
-	// Context optionally provides a context for the JoinWithToken call.
-	// When set, the region discovery retry loop and backoff sleeps will
-	// respect context cancellation/deadline. Default is context.TODO().
-	Context context.Context
-
 	// internal use
 	Codecs []webrtc.RTPCodecParameters
 

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -92,6 +92,11 @@ type ConnectParams struct {
 
 	DTLSEllipticCurves []dtlsElliptic.Curve // FIPS 140: override default DTLS curves
 
+	// Context optionally provides a context for the JoinWithToken call.
+	// When set, the region discovery retry loop and backoff sleeps will
+	// respect context cancellation/deadline. Default is context.TODO().
+	Context context.Context
+
 	// internal use
 	Codecs []webrtc.RTPCodecParameters
 


### PR DESCRIPTION
Even though `CreateSIPParticipant` timed out much earlier and agent left, `JoinWithToken` continued to retry and eventually succeeded and the sip participant joined a room with no agent in it. We should stop retrying if `CreateSIPParticipant` already timed out hence the passed in context.