### PR TITLE
[Minor] logging fixes

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -486,6 +486,7 @@ func (e *RTCEngine) createSubscriberPCLocked(configuration webrtc.Configuration)
 		} else if c.Label() == lossyDataChannelName {
 			e.lossyDCSub = c
 		} else {
+			e.log.Warnw("received unknown data channel label, ignoring", nil, "label", c.Label())
 			return
 		}
 		c.OnMessage(e.handleDataPacket)
@@ -626,6 +627,7 @@ func (e *RTCEngine) UnregisterTrackPublishedListener(cid string) {
 func (e *RTCEngine) handleDataPacket(msg webrtc.DataChannelMessage) {
 	packet, err := e.readDataPacket(msg)
 	if err != nil {
+		e.log.Warnw("failed to parse data packet", err, "isString", msg.IsString)
 		return
 	}
 	identity := packet.ParticipantIdentity
@@ -733,10 +735,10 @@ func (e *RTCEngine) handleDisconnect(fullReconnect bool) {
 				}
 			}
 
-			delay := time.Duration(reconnectCount*reconnectCount) * initialReconnectInterval
-			if delay > maxReconnectInterval {
-				break
-			}
+			// Quadratic backoff: delay grows as reconnectCount² × initialReconnectInterval.
+			// Clamped to maxReconnectInterval so a future increase to maxReconnectCount
+			// cannot produce unbounded delays or skip the final OnDisconnected call.
+			delay := min(time.Duration(reconnectCount*reconnectCount)*initialReconnectInterval, maxReconnectInterval)
 			if reconnectCount < maxReconnectCount-1 {
 				time.Sleep(delay)
 			}

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -747,7 +747,7 @@ func (p *LocalParticipant) updateSubscriptionPermissionLocked() {
 	}
 
 	if err := p.engine.SendSubscriptionPermission(p.subscriptionPermission); err != nil {
-		logger.Errorw(
+		p.log.Errorw(
 			"could not send subscription permission", err,
 			"participant", p.identity,
 			"participantID", p.sid,

--- a/remoteparticipant.go
+++ b/remoteparticipant.go
@@ -112,6 +112,7 @@ func (p *RemoteParticipant) addSubscribedMediaTrack(
 				}
 				time.Sleep(50 * time.Millisecond)
 			}
+			p.engine.log.Warnw("timed out waiting for track publication metadata", nil, "trackSID", trackSID, "participant", p.Identity())
 			p.Callback.OnTrackSubscriptionFailed(trackSID, p)
 			p.roomCallback.OnTrackSubscriptionFailed(trackSID, p)
 		}()

--- a/room.go
+++ b/room.go
@@ -871,6 +871,7 @@ func (r *Room) OnDisconnected(reason DisconnectionReason) {
 }
 
 func (r *Room) OnRestarting() {
+	r.log.Infow("room connection restarting")
 	r.setConnectionState(ConnectionStateReconnecting)
 	r.callback.OnReconnecting()
 
@@ -898,11 +899,13 @@ func (r *Room) OnRestarted(
 }
 
 func (r *Room) OnResuming() {
+	r.log.Infow("room connection resuming")
 	r.setConnectionState(ConnectionStateReconnecting)
 	r.callback.OnReconnecting()
 }
 
 func (r *Room) OnResumed() {
+	r.log.Infow("room connection resumed")
 	r.setConnectionState(ConnectionStateConnected)
 	r.callback.OnReconnected()
 	r.sendSyncState()


### PR DESCRIPTION
### Why

Several silent failure paths made it a bit harder to debug and understand the reason while debugging

### Changes
- `engine.go` — reconnect backoff: Replaced the dead break (delay > maxReconnectInterval) with a min() clamp. With quadratic growth and maxReconnectCount=10, the break was unreachable (max delay is 24.3s vs 60s cap). If maxReconnectCount were ever increased, the break would exit the loop early and skip the OnDisconnected call, leaving the room in a zombie state.
- `engine.go` — data packet parse error: Was silently returning on error. Now logs Warnw with the error
- `engine.go` — unknown DataChannel label: Was silently returning. Now logs Warnw with the label 
- room.go — reconnect state transitions: OnRestarting, OnResuming, and OnResumed now log Infow at the room level, making the reconnect lifecycle traceable without relying solely on engine-level logs.
- `remoteparticipant.go` — track subscription timeout: The 5s metadata wait goroutine now logs Warnw with trackSID
- `localparticipant.go` — wrong logger instance: updateSubscriptionPermissionLocked was using the global logger instead of p.log

### Testing
go build . passes cleanly