### PR TITLE
PublishTrack: populate SimulcastCodecs with primary codec for video tracks (fixes H.265 single-stream forwarding)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -563,3 +563,84 @@ func TestSimulcastCodec(t *testing.T) {
 	}
 
 }
+
+// TestPublishTrackSingleStreamCodecMime verifies that a single-stream
+// (no backup codec) PublishTrack populates AddTrackRequest.SimulcastCodecs
+// with the primary codec's MimeType, so trackPublicationBase.MimeType()
+// returns a non-empty value and setPublishingCodecsQuality classifies the
+// subscribed codec as primary instead of falling into the backup branch.
+//
+// Regression test for: single-stream H.265 publishes negotiated SDP cleanly
+// but the subscriber's track stayed muted with zero RTP forwarded, because
+// the publisher SDK was emitting "subscriber requested backup codec but no
+// track found" for every subscribed codec.
+func TestPublishTrackSingleStreamCodecMime(t *testing.T) {
+	cases := []struct {
+		name  string
+		codec webrtc.RTPCodecCapability
+	}{
+		{
+			name: "h264",
+			codec: webrtc.RTPCodecCapability{
+				MimeType:  webrtc.MimeTypeH264,
+				ClockRate: 90000,
+			},
+		},
+		{
+			name: "h265",
+			codec: webrtc.RTPCodecCapability{
+				MimeType:  webrtc.MimeTypeH265,
+				ClockRate: 90000,
+			},
+		},
+		{
+			name: "vp8",
+			codec: webrtc.RTPCodecCapability{
+				MimeType:  webrtc.MimeTypeVP8,
+				ClockRate: 90000,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pub, err := createAgent(t.Name(), nil, "publisher")
+			require.NoError(t, err)
+			defer pub.Disconnect()
+
+			trackPub := pubNullTrack(t, pub, "single_codec", c.codec)
+			t.Log("published single-stream track:", trackPub.SID(), "codec:", trackPub.MimeType())
+
+			// Wait briefly for the server's TrackPublishedResponse to populate info.
+			require.Eventually(t, func() bool {
+				return trackPub.MimeType() != ""
+			}, 5*time.Second, 50*time.Millisecond, "MimeType should be populated from server response")
+
+			require.Equal(t, c.codec.MimeType, trackPub.MimeType(),
+				"single-stream %s publish should report its codec MimeType (regression for H.265 single-stream)", c.name)
+
+			subscribed := make(chan struct{}, 1)
+			sub, err := createAgent(t.Name(), &RoomCallback{
+				ParticipantCallback: ParticipantCallback{
+					OnTrackSubscribed: func(track *webrtc.TrackRemote, publication *RemoteTrackPublication, rp *RemoteParticipant) {
+						t.Log("subscribed:", track.Codec().MimeType, publication.SID())
+						require.Equal(t, publication.SID(), trackPub.SID())
+						require.Equal(t, c.codec.MimeType, track.Codec().MimeType)
+						select {
+						case subscribed <- struct{}{}:
+						default:
+						}
+					},
+				},
+			}, "subscriber")
+			require.NoError(t, err)
+			defer sub.Disconnect()
+
+			select {
+			case <-subscribed:
+			case <-time.After(10 * time.Second):
+				t.Fatalf("subscriber never received %s track — SFU likely never started forwarding RTP", c.name)
+			}
+		})
+	}
+}

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -173,6 +173,19 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 		} else {
 			p.log.Warnw("backup codec publication with encryption is not supported, ignoring backup codec", nil)
 		}
+	} else if kind == TrackKindVideo && primaryCodec.MimeType != "" {
+		// TrackPublishedResponse does not include a top-level TrackInfo.MimeType,
+		// but the server echoes AddTrackRequest.SimulcastCodecs into
+		// TrackInfo.Codecs. Populate the primary codec here so MimeType()
+		// (publication.go:78-105) returns a non-empty value, which lets
+		// setPublishingCodecsQuality (publication.go:485-528) correctly
+		// classify subscribed video codecs as primary rather than backup.
+		req.SimulcastCodecs = []*livekit.SimulcastCodec{
+			{
+				Codec: primaryCodec.MimeType,
+				Cid:   track.ID(),
+			},
+		}
 	}
 	if err := p.engine.SendAddTrack(req); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

`PublishTrack` for video tracks without an explicit backup codec was leaving `AddTrackRequest.SimulcastCodecs` empty. The server's `TrackPublishedResponse` therefore echoed back an empty `TrackInfo.MimeType` (the comment at `publication.go:78-105` describes this dependency), so `trackPublicationBase.MimeType()` returned `""` for every single-stream video publish.

`setPublishingCodecsQuality` (`publication.go:485-528`) then misclassified every subscribed codec as backup — `strings.HasSuffix("", "h265")` is always false — and emitted `"subscriber requested backup codec but no track found"` instead of running the primary-codec branch.

For H.264 the SFU still forwarded RTP via defaults, so the bug was invisible; for H.265 (and presumably other non-default codecs) the SFU never started forwarding, the subscriber's `track.muted` stayed `true`, and zero bytes were received even though SDP negotiation completed cleanly.

## Fix

Add a single `else if` branch in `PublishTrack` that populates `SimulcastCodecs[0]` with `{Codec: primaryCodec.MimeType, Cid: track.ID()}` when:

- there's no explicit backup codec (existing branch already handles that case at `localparticipant.go:159-176`)
- `kind == TrackKindVideo`
- `primaryCodec.MimeType != ""`

This mirrors what `PublishSimulcastTrack` already does at `localparticipant.go:311-328`. After the fix:

- `MimeType()` returns the actual codec MIME (`video/H265`, `video/VP8`, etc.)
- `setPublishingCodecsQuality` correctly takes the primary-codec branch
- The spurious `subscriber requested backup codec but no track found` warnings stop firing for normal single-stream publishes
- H.265 subscribers actually receive RTP

Audio is correctly excluded — audio codec updates dispatch through `handleSubscribedAudioCodecUpdate` / `setAudioCodecSubscribed`, not `setPublishingCodecsQuality`.

## Test

Adds `TestPublishTrackSingleStreamCodecMime` covering H.264, H.265, and VP8 single-stream `PublishTrack`. For each:

1. Asserts `trackPub.MimeType() == codec.MimeType` after publish
2. Subscribes from a second participant and asserts the track is received within 10s (regression: H.265 was previously stuck on `track.muted=true` and never delivered)

Test follows the existing `TestSimulcastCodec` pattern (same `createAgent` / `pubNullTrack` helpers, same Docker-server `mage test` runner). Compiles cleanly; functional verification requires the LiveKit server harness.

## Context / how this was found

Discovered while spiking LiveKit as a candidate SFU for low-latency robot teleop. The camera produces hardware H.265 (Rockchip `mpph265enc`); re-encoding is too slow for our latency budget. `lk room join --publish h265://host:port` (livekit-cli v2.16.2) negotiated SDP, fired `TrackSubscribed` in Chrome 147, but the receiver's track stayed muted and zero RTP arrived. Same pipeline with H.264 worked.

Initial issue reported against `livekit-cli`: livekit/livekit-cli#837. After tracing through the SDK with help from a code-review agent, the actual bug is here in `server-sdk-go`'s `PublishTrack` `AddTrackRequest` assembly — `livekit-cli` is just a caller that happens to hit it. Fixing it here also helps `publishFile` and any other `PublishTrack` caller.

I verified the build with `go build ./...`, `go vet ./...`, and `go test -c .` (test binary builds clean). I haven't run the integration test against a live LiveKit server in CI — happy to iterate on the test if maintainers want a different shape.

## Notes for reviewers

- The new branch only runs when `pubOptions.backupCodecTrack == nil` (existing branch handles the backup case) and `primaryCodec.MimeType != ""` (skips the case where the SDK can't infer a codec).
- No encryption guard, mirroring how `PublishSimulcastTrack` already populates `SimulcastCodecs` unconditionally — the existing E2EE guard in the backup-codec branch is specifically about `setBackupCodecTrack`, not about `SimulcastCodecs[0]` metadata.
- The change is metadata-only; no behavior change to RTP packetization, RID extension, or transceiver setup.
