### PR TITLE
Add WithDisableTURN connect option

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -824,6 +825,9 @@ func (e *RTCEngine) createSubscriberPCAnswerAndSend() error {
 }
 
 func (e *RTCEngine) makeRTCConfiguration(iceServers []*livekit.ICEServer, clientConfig *livekit.ClientConfiguration) webrtc.Configuration {
+	if e.connParams.DisableTURN {
+		iceServers = filterTURNServers(iceServers)
+	}
 	rtcICEServers := protosignalling.FromProtoIceServers(iceServers)
 	configuration := webrtc.Configuration{
 		ICEServers:         rtcICEServers,
@@ -834,6 +838,27 @@ func (e *RTCEngine) makeRTCConfiguration(iceServers []*livekit.ICEServer, client
 		configuration.ICETransportPolicy = webrtc.ICETransportPolicyRelay
 	}
 	return configuration
+}
+
+func filterTURNServers(iceServers []*livekit.ICEServer) []*livekit.ICEServer {
+	var filtered []*livekit.ICEServer
+	for _, server := range iceServers {
+		var urls []string
+		for _, u := range server.Urls {
+			lower := strings.ToLower(u)
+			if !strings.HasPrefix(lower, "turn:") && !strings.HasPrefix(lower, "turns:") {
+				urls = append(urls, u)
+			}
+		}
+		if len(urls) > 0 {
+			filtered = append(filtered, &livekit.ICEServer{
+				Urls:       urls,
+				Username:   server.Username,
+				Credential: server.Credential,
+			})
+		}
+	}
+	return filtered
 }
 
 func (e *RTCEngine) publishDataPacket(pck *livekit.DataPacket, kind livekit.DataPacket_Kind) error {

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,0 +1,104 @@
+package lksdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+func TestFilterTURNServers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []*livekit.ICEServer
+		expected []*livekit.ICEServer
+	}{
+		{
+			name: "removes turn and turns URLs, keeps stun",
+			input: []*livekit.ICEServer{
+				{
+					Urls: []string{
+						"turn:ip-10-0-0-1.host.livekit.cloud:3478?transport=udp",
+						"turns:oashburn1b.turn.livekit.cloud:443?transport=tcp",
+						"stun:stun.l.google.com:19302",
+					},
+					Username:   "user",
+					Credential: "pass",
+				},
+			},
+			expected: []*livekit.ICEServer{
+				{
+					Urls:       []string{"stun:stun.l.google.com:19302"},
+					Username:   "user",
+					Credential: "pass",
+				},
+			},
+		},
+		{
+			name: "case insensitive",
+			input: []*livekit.ICEServer{
+				{
+					Urls:       []string{"TURN:host:3478", "TURNS:host:443", "STUN:host:3478"},
+					Username:   "user",
+					Credential: "pass",
+				},
+			},
+			expected: []*livekit.ICEServer{
+				{
+					Urls:       []string{"STUN:host:3478"},
+					Username:   "user",
+					Credential: "pass",
+				},
+			},
+		},
+		{
+			name: "drops server entirely when all URLs are turn",
+			input: []*livekit.ICEServer{
+				{
+					Urls: []string{
+						"turn:host:3478",
+						"turns:host:443?transport=tcp",
+					},
+					Username:   "user",
+					Credential: "pass",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "multiple servers",
+			input: []*livekit.ICEServer{
+				{
+					Urls:       []string{"turn:host:3478"},
+					Username:   "user1",
+					Credential: "pass1",
+				},
+				{
+					Urls:       []string{"stun:stun.l.google.com:19302"},
+					Username:   "",
+					Credential: "",
+				},
+			},
+			expected: []*livekit.ICEServer{
+				{
+					Urls:       []string{"stun:stun.l.google.com:19302"},
+					Username:   "",
+					Credential: "",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterTURNServers(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/room.go
+++ b/room.go
@@ -157,6 +157,15 @@ func WithICETransportPolicy(iceTransportPolicy webrtc.ICETransportPolicy) Connec
 	}
 }
 
+// WithDisableTURN removes TURN/TURNS URLs from the ICE server configuration
+// provided by the SFU. Use this when the client is co-located with the SFU
+// and does not need relay candidates.
+func WithDisableTURN() ConnectOption {
+	return func(p *signalling.ConnectParams) {
+		p.DisableTURN = true
+	}
+}
+
 // WithDisableRegionDiscovery disables automatic region discovery for LiveKit Cloud.
 func WithDisableRegionDiscovery() ConnectOption {
 	return func(p *signalling.ConnectParams) {

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -90,6 +90,10 @@ type ConnectParams struct {
 
 	ICETransportPolicy webrtc.ICETransportPolicy
 
+	// DisableTURN removes TURN/TURNS URLs from the ICE server list provided by the SFU.
+	// Use this when the client is co-located with the SFU and does not need relay candidates.
+	DisableTURN bool
+
 	DTLSEllipticCurves []dtlsElliptic.Curve // FIPS 140: override default DTLS curves
 
 	// internal use


### PR DESCRIPTION
Adds a WithDisableTURN() connect option that filters turn:/turns: URLs from the ICE server list provided  by the SFU. This is useful for co-located services like egress and ingress that connect via host candidates and don't need relay. ICE servers with only TURN URLs are dropped entirely; mixed servers retain their non-TURN URLs.