### PR TITLE
cloudagents: increase scanner buffer to avoid token too long errors

### DIFF
--- a/pkg/cloudagents/build.go
+++ b/pkg/cloudagents/build.go
@@ -69,6 +69,7 @@ func (c *Client) build(ctx context.Context, id string, environment string, write
 	eg.Go(func() error {
 		defer close(ch)
 		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), 4*1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
 			if strings.HasPrefix(line, "BUILD ERROR:") {

--- a/pkg/cloudagents/logs.go
+++ b/pkg/cloudagents/logs.go
@@ -61,6 +61,7 @@ func (c *Client) StreamLogs(ctx context.Context, logType, agentID, environment s
 		return fmt.Errorf("failed to get logs: %s - %v", errorResponse.Message, errorResponse.Meta)
 	}
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, bufio.MaxScanTokenSize), 4*1024*1024)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Fixes livekit/livekit-cli#822.

`bufio.Scanner` has a default max token size of 64KB. Docker build output and agent logs can exceed this, particularly during package installs like pip, which causes `lk agent deploy --silent` to crash with:

```
bufio.Scanner: token too long
```

Bump the max to 4MB in both the build status scanner (`build.go`) and the log streaming scanner (`logs.go`). The initial buffer stays at the default 64KB — we're just raising the ceiling for lines that need more.