### PR TITLE
Add option to publish tracks with join request and enable single pc mode

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -94,6 +94,12 @@ const (
 	maxReconnectCount        = 10
 	initialReconnectInterval = 300 * time.Millisecond
 	maxReconnectInterval     = 60 * time.Second
+
+	// Number of recvonly transceivers pre-allocated on the publisher PC in
+	// single peer connection mode so auto-subscribed media has m-sections
+	// ready in the initial offer.
+	initialMediaSectionsAudio = 3
+	initialMediaSectionsVideo = 3
 )
 
 type RTCEngine struct {
@@ -156,19 +162,29 @@ func NewRTCEngine(
 		joinTimeout:              15 * time.Second,
 		reliableMsgSeq:           1,
 	}
-	if !useSinglePeerConnection {
-		e.signalling = signalling.NewSignalling(signalling.SignallingParams{
-			Logger: e.log,
-		})
-	} else {
-		e.signalling = signalling.NewSignallingJoinRequest(signalling.SignallingJoinRequestParams{
-			Logger: e.log,
-		})
-	}
 	e.signalHandler = signalling.NewSignalHandler(signalling.SignalHandlerParams{
 		Logger:    e.log,
 		Processor: e,
 	})
+	e.configureSignalling(useSinglePeerConnection)
+
+	return e
+}
+
+func (e *RTCEngine) configureSignalling(useSinglePeerConnection bool) {
+	e.useSinglePeerConnection = useSinglePeerConnection
+	if useSinglePeerConnection {
+		e.signalling = signalling.NewSignallingJoinRequest(signalling.SignallingJoinRequestParams{
+			Logger: e.log,
+		})
+	} else {
+		e.signalling = signalling.NewSignalling(signalling.SignallingParams{
+			Logger: e.log,
+		})
+	}
+	if e.signalTransport != nil {
+		e.signalTransport.Close()
+	}
 	e.signalTransport = signalling.NewSignalTransportWebSocket(signalling.SignalTransportWebSocketParams{
 		Logger:                 e.log,
 		Version:                Version,
@@ -177,9 +193,6 @@ func NewRTCEngine(
 		SignalTransportHandler: e,
 		SignalHandler:          e.signalHandler,
 	})
-
-	e.onClose = []func(){}
-	return e
 }
 
 // SetLogger overrides default logger.
@@ -201,19 +214,41 @@ func (e *RTCEngine) JoinContext(
 	url string,
 	token string,
 	connectParams *signalling.ConnectParams,
+	publishWithJoin func() ([]*livekit.AddTrackRequest, error),
 ) (bool, error) {
 	e.url = url
 	e.token.Store(token)
 	e.connParams = connectParams
 
 	var (
-		publisherOffer webrtc.SessionDescription
-		err            error
+		publisherOffer   webrtc.SessionDescription
+		err              error
+		addTrackRequests []*livekit.AddTrackRequest
 	)
 	if e.signalling.PublishInJoin() {
 		e.pclock.Lock()
-		e.createPublisherPCLocked(webrtc.Configuration{})
 
+		// clear & recreate publisher pc to ensure a clean slate for the publisher offer and any pre-added m-sections.
+		e.closePeerConnectionsLocked()
+		if err = e.createPublisherPCLocked(webrtc.Configuration{}); err != nil {
+			e.pclock.Unlock()
+			return false, err
+		}
+
+		// TODO: reuse code with MediaSectionsRequirement handling
+		if err = e.addInitialMediaSectionsLocked(initialMediaSectionsAudio, initialMediaSectionsVideo); err != nil {
+			e.pclock.Unlock()
+			return false, err
+		}
+		e.pclock.Unlock()
+
+		if publishWithJoin != nil {
+			if addTrackRequests, err = publishWithJoin(); err != nil {
+				return false, err
+			}
+		}
+
+		e.pclock.Lock()
 		publisherOffer, err = e.publisher.GetLocalOffer()
 		if err != nil {
 			e.pclock.Unlock()
@@ -223,7 +258,11 @@ func (e *RTCEngine) JoinContext(
 		e.pclock.Unlock()
 	}
 
-	if err = e.signalTransport.Join(ctx, url, token, *connectParams, nil, publisherOffer); err != nil {
+	if err = ctx.Err(); err != nil {
+		return false, err
+	}
+
+	if err = e.signalTransport.Join(ctx, url, token, *connectParams, addTrackRequests, publisherOffer); err != nil {
 		if verr := e.validate(ctx, url, token, connectParams, ""); verr != nil {
 			return false, verr
 		}
@@ -248,6 +287,10 @@ func (e *RTCEngine) Close() {
 	if !e.closed.CompareAndSwap(false, true) {
 		return
 	}
+
+	e.pclock.Lock()
+	e.pendingPublisherOffer = webrtc.SessionDescription{}
+	e.pclock.Unlock()
 
 	go func() {
 		for e.reconnecting.Load() {
@@ -435,6 +478,24 @@ func (e *RTCEngine) createPublisherPCLocked(configuration webrtc.Configuration) 
 	return nil
 }
 
+func (e *RTCEngine) addInitialMediaSectionsLocked(numAudio, numVideo int) error {
+	if e.publisher == nil {
+		return nil
+	}
+	init := webrtc.RTPTransceiverInit{Direction: webrtc.RTPTransceiverDirectionRecvonly}
+	for i := 0; i < numAudio; i++ {
+		if _, err := e.publisher.pc.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio, init); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < numVideo; i++ {
+		if _, err := e.publisher.pc.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo, init); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (e *RTCEngine) createSubscriberPCLocked(configuration webrtc.Configuration) error {
 	if e.useSinglePeerConnection {
 		return nil
@@ -533,6 +594,10 @@ func (e *RTCEngine) closePeerConnections() {
 	e.pclock.Lock()
 	defer e.pclock.Unlock()
 
+	e.closePeerConnectionsLocked()
+}
+
+func (e *RTCEngine) closePeerConnectionsLocked() {
 	if e.publisher != nil {
 		e.publisher.Close()
 		e.publisher = nil
@@ -824,7 +889,7 @@ func (e *RTCEngine) restartConnection() error {
 
 	e.closePeerConnections()
 
-	_, err := e.JoinContext(context.TODO(), e.url, e.token.Load(), e.connParams)
+	_, err := e.JoinContext(context.TODO(), e.url, e.token.Load(), e.connParams, nil)
 	return err
 }
 

--- a/errors.go
+++ b/errors.go
@@ -34,4 +34,5 @@ var (
 	ErrNoPeerConnection         = errors.New("peer connection not established")
 	ErrAborted                  = errors.New("operation was aborted")
 	ErrMissingPrimaryCodec      = errors.New("primary track must be TrackLocalWithCodec when backup codec is present")
+	ErrPublishRequiresSinglePC  = errors.New("WithTrack requires WithSinglePeerConnection() to be enabled")
 )

--- a/integration_test.go
+++ b/integration_test.go
@@ -239,6 +239,418 @@ func TestJoinError(t *testing.T) {
 	require.Contains(t, errString, "unauthorized:")
 }
 
+// TestJoinSinglePeerConnection verifies offer-with-join in single-PC mode:
+// the publisher offer is sent in the JoinRequest, no subscriber PC is
+// created, and subscribed media + data flow through the publisher PC.
+func TestJoinSinglePeerConnection(t *testing.T) {
+	remoteParticipantsOfPub := make(chan string, 1)
+	pub, err := createAgent(t.Name(), &RoomCallback{
+		OnParticipantConnected: func(participant *RemoteParticipant) {
+			remoteParticipantsOfPub <- participant.Identity()
+		},
+	}, "publisher-singlepc", WithSinglePeerConnection())
+	require.NoError(t, err)
+	defer pub.Disconnect()
+
+	require.True(t, pub.useSinglePeerConnection)
+	require.Equal(t, ConnectionStateConnected, pub.ConnectionState())
+	_, hasSubscriber := pub.engine.Subscriber()
+	require.False(t, hasSubscriber, "no subscriber PC should be created in single-PC mode")
+
+	audioTrackName := "audio_singlepc"
+	var trackReceived atomic.Bool
+	var receivedData atomic.String
+	subCB := &RoomCallback{
+		ParticipantCallback: ParticipantCallback{
+			OnDataPacket: func(data DataPacket, params DataReceiveParams) {
+				if u, ok := data.(*UserDataPacket); ok {
+					receivedData.Store(string(u.Payload))
+				}
+			},
+			OnTrackSubscribed: func(track *webrtc.TrackRemote, publication *RemoteTrackPublication, rp *RemoteParticipant) {
+				require.Equal(t, audioTrackName, publication.Name())
+				require.Equal(t, webrtc.RTPCodecTypeAudio, track.Kind())
+				trackReceived.Store(true)
+			},
+		},
+	}
+	sub, err := createAgent(t.Name(), subCB, "subscriber-singlepc", WithSinglePeerConnection())
+	require.NoError(t, err)
+	defer sub.Disconnect()
+	_, hasSubscriber = sub.engine.Subscriber()
+	require.False(t, hasSubscriber)
+
+	<-remoteParticipantsOfPub
+
+	pub.LocalParticipant.PublishDataPacket(UserData([]byte("singlepc")), WithDataPublishReliable(true))
+	localPub := pubNullTrack(t, pub, audioTrackName, webrtc.RTPCodecCapability{
+		MimeType:  webrtc.MimeTypeOpus,
+		ClockRate: 48000,
+		Channels:  2,
+	})
+	require.Equal(t, audioTrackName, localPub.Name())
+
+	require.Eventually(t, trackReceived.Load, 5*time.Second, 100*time.Millisecond,
+		"subscriber should receive audio track over single PC")
+	require.Eventually(t, func() bool { return receivedData.Load() == "singlepc" }, 5*time.Second, 100*time.Millisecond,
+		"subscriber should receive data packet over single PC")
+}
+
+// TestPublishRequiresSinglePC verifies that queuing a track via WithTrack
+// without also enabling WithSinglePeerConnection() is rejected at Join time.
+func TestPublishRequiresSinglePC(t *testing.T) {
+	codec := webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: 48000, Channels: 2}
+	track, err := NewLocalTrack(codec)
+	require.NoError(t, err)
+
+	room := NewRoom(&RoomCallback{})
+	err = room.Join(host, ConnectInfo{
+		APIKey:              apiKey,
+		APISecret:           apiSecret,
+		RoomName:            t.Name(),
+		ParticipantIdentity: "publisher-err",
+	}, WithTrack(track, &TrackPublicationOptions{Name: "x"}))
+	require.ErrorIs(t, err, ErrPublishRequiresSinglePC)
+}
+
+// TestPubSub covers the publish/subscribe roundtrip for both the "post-publish"
+// path (default Join + PublishTrack/PublishSimulcastTrack) and the
+// "pre-publish" path (WithSinglePeerConnection() + WithTrack/
+// WithSimulcastTrack queued for the JoinRequest). The bidirectional subtest
+// has two peers exchange single-layer audio + single-layer video (covers
+// WithTrack and PublishTrack code paths); the simulcast subtest has one
+// publisher push audio + a 3-layer simulcast video to a passive subscriber
+// (covers WithSimulcastTrack and PublishSimulcastTrack). It supersedes the
+// older one-direction TestPrePublishTrack and TestPrePublishSimulcastTrack.
+func TestPubSub(t *testing.T) {
+	cases := []struct {
+		name       string
+		prepublish bool
+	}{
+		{"post_publish", false},
+		{"pre_publish", true},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name+"_bidirectional", func(t *testing.T) {
+			runBidirectionalPubSub(t, c.prepublish)
+		})
+		t.Run(c.name+"_simulcast", func(t *testing.T) {
+			runSimulcastPubSub(t, c.prepublish)
+		})
+	}
+}
+
+func newSingleSampleTrack(t *testing.T, codec webrtc.RTPCodecCapability) *LocalTrack {
+	t.Helper()
+	track, err := NewLocalTrack(codec)
+	require.NoError(t, err)
+	provider := NewSampleTestProvider(codec)
+	track.OnBind(func() {
+		if err := track.StartWrite(provider, func() {}); err != nil {
+			track.log.Errorw("could not start writing", err)
+		}
+	})
+	return track
+}
+
+func newSimulcastSampleTracks(t *testing.T, codec webrtc.RTPCodecCapability, simulcastID string) []*LocalTrack {
+	t.Helper()
+	layers := []*livekit.VideoLayer{
+		{Quality: livekit.VideoQuality_LOW, Width: 160, Height: 120},
+		{Quality: livekit.VideoQuality_MEDIUM, Width: 320, Height: 240},
+		{Quality: livekit.VideoQuality_HIGH, Width: 640, Height: 480},
+	}
+	out := make([]*LocalTrack, 0, len(layers))
+	for _, layer := range layers {
+		layer := layer
+		track, err := NewLocalTrack(codec, WithSimulcast(simulcastID, layer))
+		require.NoError(t, err)
+		provider := NewSampleTestProvider(codec)
+		track.OnBind(func() {
+			if err := track.StartWrite(provider, func() {}); err != nil {
+				track.log.Errorw("could not start writing", err)
+			}
+		})
+		out = append(out, track)
+	}
+	return out
+}
+
+// runBidirectionalPubSub: two peers, each publishes audio + single-layer
+// video, each subscribes to the other's two tracks. Verifies cross-direction
+// pub/sub through both publish paths.
+func runBidirectionalPubSub(t *testing.T, prepublish bool) {
+	audioCodec := webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: 48000, Channels: 2}
+	videoCodec := webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8, ClockRate: 90000}
+
+	type observed struct {
+		sid  string
+		kind webrtc.RTPCodecType
+	}
+	type peer struct {
+		identity               string
+		audioName, videoName   string
+		audioTrack, videoTrack *LocalTrack
+		audioPub, videoPub     *LocalTrackPublication
+		room                   *Room
+		observedLock           sync.Mutex
+		observed               map[string]observed
+		rtpCounts              map[string]*atomic.Int32
+	}
+
+	mkPeer := func(identity string) *peer {
+		return &peer{
+			identity:   identity,
+			audioName:  identity + "_audio",
+			videoName:  identity + "_video",
+			audioTrack: newSingleSampleTrack(t, audioCodec),
+			videoTrack: newSingleSampleTrack(t, videoCodec),
+			observed:   make(map[string]observed),
+			rtpCounts: map[string]*atomic.Int32{
+				identity + "_audio": new(atomic.Int32),
+				identity + "_video": new(atomic.Int32),
+			},
+		}
+	}
+	alice := mkPeer("alice")
+	bob := mkPeer("bob")
+
+	callbackFor := func(p, other *peer) *RoomCallback {
+		return &RoomCallback{
+			ParticipantCallback: ParticipantCallback{
+				OnTrackSubscribed: func(track *webrtc.TrackRemote, publication *RemoteTrackPublication, _ *RemoteParticipant) {
+					name := publication.Name()
+					p.observedLock.Lock()
+					p.observed[name] = observed{sid: publication.SID(), kind: track.Kind()}
+					p.observedLock.Unlock()
+					counter := other.rtpCounts[name]
+					go func() {
+						for {
+							if _, _, err := track.ReadRTP(); err != nil {
+								return
+							}
+							if counter != nil {
+								counter.Add(1)
+							}
+						}
+					}()
+				},
+			},
+		}
+	}
+
+	connectOpts := func(p *peer) []ConnectOption {
+		if !prepublish {
+			return nil
+		}
+		return []ConnectOption{
+			WithSinglePeerConnection(),
+			WithTrack(p.audioTrack, &TrackPublicationOptions{Name: p.audioName}),
+			WithTrack(p.videoTrack, &TrackPublicationOptions{Name: p.videoName}),
+		}
+	}
+
+	join := func(p, other *peer) {
+		p.room = NewRoom(callbackFor(p, other))
+		require.NoError(t, p.room.Join(host, ConnectInfo{
+			APIKey:              apiKey,
+			APISecret:           apiSecret,
+			RoomName:            t.Name(),
+			ParticipantIdentity: p.identity,
+		}, connectOpts(p)...))
+	}
+	join(alice, bob)
+	defer alice.room.Disconnect()
+	join(bob, alice)
+	defer bob.room.Disconnect()
+
+	resolvePublications := func(p *peer) {
+		if prepublish {
+			pubs := p.room.LocalParticipant.TrackPublications()
+			require.Len(t, pubs, 2, "%s should have 2 publications after pre-publish Join", p.identity)
+			for _, pub := range pubs {
+				lp, ok := pub.(*LocalTrackPublication)
+				require.True(t, ok)
+				switch pub.Name() {
+				case p.audioName:
+					p.audioPub = lp
+				case p.videoName:
+					p.videoPub = lp
+				}
+			}
+		} else {
+			audioPub, err := p.room.LocalParticipant.PublishTrack(p.audioTrack, &TrackPublicationOptions{Name: p.audioName})
+			require.NoError(t, err)
+			p.audioPub = audioPub
+			videoPub, err := p.room.LocalParticipant.PublishTrack(p.videoTrack, &TrackPublicationOptions{Name: p.videoName})
+			require.NoError(t, err)
+			p.videoPub = videoPub
+		}
+		for _, pub := range []*LocalTrackPublication{p.audioPub, p.videoPub} {
+			require.NotNil(t, pub, "%s publication missing", p.identity)
+			require.NotEmpty(t, pub.SID(), "%s publication SID should be set", p.identity)
+		}
+	}
+	resolvePublications(alice)
+	resolvePublications(bob)
+
+	waitObserved := func(observer *peer, name string) {
+		require.Eventually(t, func() bool {
+			observer.observedLock.Lock()
+			defer observer.observedLock.Unlock()
+			_, ok := observer.observed[name]
+			return ok
+		}, 10*time.Second, 100*time.Millisecond, "%s should observe %s", observer.identity, name)
+	}
+	for _, name := range []string{bob.audioName, bob.videoName} {
+		waitObserved(alice, name)
+	}
+	for _, name := range []string{alice.audioName, alice.videoName} {
+		waitObserved(bob, name)
+	}
+
+	assertMatch := func(observer, publisher *peer, name string, expectedKind webrtc.RTPCodecType, pub *LocalTrackPublication) {
+		observer.observedLock.Lock()
+		defer observer.observedLock.Unlock()
+		obs := observer.observed[name]
+		require.Equal(t, pub.SID(), obs.sid, "%s -> %s %s SID mismatch", publisher.identity, observer.identity, name)
+		require.Equal(t, expectedKind, obs.kind, "%s %s kind mismatch", publisher.identity, name)
+	}
+	assertMatch(alice, bob, bob.audioName, webrtc.RTPCodecTypeAudio, bob.audioPub)
+	assertMatch(alice, bob, bob.videoName, webrtc.RTPCodecTypeVideo, bob.videoPub)
+	assertMatch(bob, alice, alice.audioName, webrtc.RTPCodecTypeAudio, alice.audioPub)
+	assertMatch(bob, alice, alice.videoName, webrtc.RTPCodecTypeVideo, alice.videoPub)
+
+	allSIDs := map[string]bool{}
+	for _, p := range []*peer{alice, bob} {
+		for _, pub := range []*LocalTrackPublication{p.audioPub, p.videoPub} {
+			allSIDs[pub.SID()] = true
+		}
+	}
+	require.Len(t, allSIDs, 4, "all four publication SIDs should be distinct")
+
+	waitRTP := func(observer, publisher *peer) {
+		for _, name := range []string{publisher.audioName, publisher.videoName} {
+			name := name
+			require.Eventually(t, func() bool {
+				return publisher.rtpCounts[name].Load() > 0
+			}, 10*time.Second, 100*time.Millisecond, "%s should receive RTP for %s", observer.identity, name)
+		}
+	}
+	waitRTP(alice, bob)
+	waitRTP(bob, alice)
+}
+
+// runSimulcastPubSub: one publisher pushes audio + 3-layer simulcast video,
+// one passive subscriber receives them. Asymmetric so the publisher's
+// 3+3 recvonly slot budget in single-PC pre-publish mode is not exhausted
+// by inbound traffic.
+func runSimulcastPubSub(t *testing.T, prepublish bool) {
+	audioCodec := webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: 48000, Channels: 2}
+	videoCodec := webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeVP8, ClockRate: 90000}
+
+	audioName := "simulcast_audio"
+	videoName := "simulcast_video"
+
+	var (
+		subAudioSID, subVideoSID   atomic.String
+		subAudioKind, subVideoKind atomic.Value // webrtc.RTPCodecType
+		subAudioRTP, subVideoRTP   atomic.Int32
+	)
+	subCB := &RoomCallback{
+		ParticipantCallback: ParticipantCallback{
+			OnTrackSubscribed: func(track *webrtc.TrackRemote, publication *RemoteTrackPublication, _ *RemoteParticipant) {
+				name := publication.Name()
+				switch name {
+				case audioName:
+					subAudioSID.Store(publication.SID())
+					subAudioKind.Store(track.Kind())
+				case videoName:
+					subVideoSID.Store(publication.SID())
+					subVideoKind.Store(track.Kind())
+				}
+				go func() {
+					for {
+						if _, _, err := track.ReadRTP(); err != nil {
+							return
+						}
+						switch name {
+						case audioName:
+							subAudioRTP.Add(1)
+						case videoName:
+							subVideoRTP.Add(1)
+						}
+					}
+				}()
+			},
+		},
+	}
+	sub, err := createAgent(t.Name(), subCB, "subscriber-simulcast")
+	require.NoError(t, err)
+	defer sub.Disconnect()
+
+	audioTrack := newSingleSampleTrack(t, audioCodec)
+	simTracks := newSimulcastSampleTracks(t, videoCodec, "SC_"+videoName)
+
+	pubRoom := NewRoom(&RoomCallback{})
+	defer pubRoom.Disconnect()
+
+	var audioPub, videoPub *LocalTrackPublication
+	if prepublish {
+		require.NoError(t, pubRoom.Join(host, ConnectInfo{
+			APIKey:              apiKey,
+			APISecret:           apiSecret,
+			RoomName:            t.Name(),
+			ParticipantIdentity: "publisher-simulcast",
+		},
+			WithSinglePeerConnection(),
+			WithTrack(audioTrack, &TrackPublicationOptions{Name: audioName}),
+			WithSimulcastTrack(simTracks, &TrackPublicationOptions{Name: videoName}),
+		))
+		pubs := pubRoom.LocalParticipant.TrackPublications()
+		require.Len(t, pubs, 2, "publisher should have 2 publications after pre-publish Join")
+		for _, pub := range pubs {
+			lp, ok := pub.(*LocalTrackPublication)
+			require.True(t, ok)
+			switch pub.Name() {
+			case audioName:
+				audioPub = lp
+			case videoName:
+				videoPub = lp
+			}
+		}
+	} else {
+		require.NoError(t, pubRoom.Join(host, ConnectInfo{
+			APIKey:              apiKey,
+			APISecret:           apiSecret,
+			RoomName:            t.Name(),
+			ParticipantIdentity: "publisher-simulcast",
+		}))
+		audioPub, err = pubRoom.LocalParticipant.PublishTrack(audioTrack, &TrackPublicationOptions{Name: audioName})
+		require.NoError(t, err)
+		videoPub, err = pubRoom.LocalParticipant.PublishSimulcastTrack(simTracks, &TrackPublicationOptions{Name: videoName})
+		require.NoError(t, err)
+	}
+	require.NotNil(t, audioPub)
+	require.NotNil(t, videoPub)
+	require.NotEmpty(t, audioPub.SID())
+	require.NotEmpty(t, videoPub.SID())
+	require.NotEqual(t, audioPub.SID(), videoPub.SID())
+
+	require.Eventually(t, func() bool {
+		return subAudioSID.Load() != "" && subVideoSID.Load() != ""
+	}, 10*time.Second, 100*time.Millisecond, "subscriber should observe both audio and simulcast video")
+	require.Equal(t, audioPub.SID(), subAudioSID.Load(), "audio SID should match end-to-end")
+	require.Equal(t, videoPub.SID(), subVideoSID.Load(), "simulcast video SID should match end-to-end")
+	require.Equal(t, webrtc.RTPCodecTypeAudio, subAudioKind.Load())
+	require.Equal(t, webrtc.RTPCodecTypeVideo, subVideoKind.Load())
+
+	require.Eventually(t, func() bool {
+		return subAudioRTP.Load() > 0 && subVideoRTP.Load() > 0
+	}, 10*time.Second, 100*time.Millisecond, "subscriber should receive RTP for both tracks")
+}
+
 func TestResume(t *testing.T) {
 	var reconnected atomic.Bool
 	pubCB := &RoomCallback{

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -56,16 +56,14 @@ func newLocalParticipant(engine *RTCEngine, roomcallback *RoomCallback, serverIn
 	}
 }
 
-// PublishTrack publishes a local track to the room.
-// The track will be available to other participants in the room.
-func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) (*LocalTrackPublication, error) {
+func (p *LocalParticipant) prepareTrackPublication(track webrtc.TrackLocal, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) (*LocalTrackPublication, *livekit.AddTrackRequest, error) {
 	pubOptions := &LocalTrackPublishOptions{}
 	for _, opt := range pubOpts {
 		opt(pubOptions)
 	}
 	if pubOptions.backupCodecTrack != nil {
 		if _, ok := track.(TrackLocalWithCodec); !ok {
-			return nil, ErrMissingPrimaryCodec
+			return nil, nil, ErrMissingPrimaryCodec
 		}
 	}
 
@@ -85,12 +83,8 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 
 	transport := p.getPublishTransport()
 	if transport == nil {
-		return nil, ErrNoPeerConnection
+		return nil, nil, ErrNoPeerConnection
 	}
-
-	pubChan := make(chan *livekit.TrackPublishedResponse, 1)
-	p.engine.RegisterTrackPublishedListener(track.ID(), pubChan)
-	defer p.engine.UnregisterTrackPublishedListener(track.ID())
 
 	pub := NewLocalTrackPublication(kind, track, *opts, p.engine, p.log)
 	pub.onMuteChanged = p.onTrackMuted
@@ -102,7 +96,7 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 	// observed in practice.
 	sender, err := transport.PeerConnection().AddTrack(track)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// LocalTrack will consume rtcp packets so we don't need to consume again
@@ -174,6 +168,31 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 			p.log.Warnw("backup codec publication with encryption is not supported, ignoring backup codec", nil)
 		}
 	}
+	return pub, req, nil
+}
+
+func (p *LocalParticipant) notifyTrackPublished(pub *LocalTrackPublication) {
+	p.Callback.OnLocalTrackPublished(pub, p)
+	p.roomCallback.OnLocalTrackPublished(pub, p)
+}
+
+// PublishTrack publishes a local track to the room.
+// The track will be available to other participants in the room.
+func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) (*LocalTrackPublication, error) {
+	transport := p.getPublishTransport()
+	if transport == nil {
+		return nil, ErrNoPeerConnection
+	}
+
+	pub, req, err := p.prepareTrackPublication(track, opts, pubOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	pubChan := make(chan *livekit.TrackPublishedResponse, 1)
+	p.engine.RegisterTrackPublishedListener(track.ID(), pubChan)
+	defer p.engine.UnregisterTrackPublishedListener(track.ID())
+
 	if err := p.engine.SendAddTrack(req); err != nil {
 		return nil, err
 	}
@@ -191,26 +210,22 @@ func (p *LocalParticipant) PublishTrack(track webrtc.TrackLocal, opts *TrackPubl
 	pub.updateInfo(pubRes.Track)
 	p.addPublication(pub)
 
-	p.Callback.OnLocalTrackPublished(pub, p)
-	p.roomCallback.OnLocalTrackPublished(pub, p)
-
+	p.notifyTrackPublished(pub)
 	p.engine.log.Infow("published track", "name", opts.Name, "source", opts.Source.String(), "trackID", pubRes.Track.Sid)
 	return pub, nil
 }
 
-// PublishSimulcastTrack publishes a simulcast track with up to three quality layers to the server.
-// This allows the server to dynamically switch between different quality levels based on network conditions.
-func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) (*LocalTrackPublication, error) {
+func (p *LocalParticipant) prepareSimulcastTrackPublication(tracks []*LocalTrack, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) (*LocalTrackPublication, *livekit.AddTrackRequest, *LocalTrack, error) {
 	if len(tracks) == 0 {
-		return nil, nil
+		return nil, nil, nil, ErrInvalidSimulcastTrack
 	}
 
 	for _, track := range tracks {
 		if track.Kind() != webrtc.RTPCodecTypeVideo {
-			return nil, ErrUnsupportedSimulcastKind
+			return nil, nil, nil, ErrUnsupportedSimulcastKind
 		}
 		if track.videoLayer == nil || track.RID() == "" {
-			return nil, ErrInvalidSimulcastTrack
+			return nil, nil, nil, ErrInvalidSimulcastTrack
 		}
 	}
 
@@ -237,16 +252,12 @@ func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *Tra
 
 	mainTrack := tracksCopy[len(tracksCopy)-1]
 
-	pubChan := make(chan *livekit.TrackPublishedResponse, 1)
-	p.engine.RegisterTrackPublishedListener(mainTrack.ID(), pubChan)
-	defer p.engine.UnregisterTrackPublishedListener(mainTrack.ID())
-
 	pub := NewLocalTrackPublication(KindFromRTPType(mainTrack.Kind()), nil, *opts, p.engine, p.log)
 	pub.onMuteChanged = p.onTrackMuted
 
 	transport := p.getPublishTransport()
 	if transport == nil {
-		return nil, ErrNoPeerConnection
+		return nil, nil, nil, ErrNoPeerConnection
 	}
 
 	// add transceivers
@@ -265,7 +276,7 @@ func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *Tra
 			// observed in practice.
 			sender, err = pc.AddTrack(st)
 			if err != nil {
-				return nil, err
+				return nil, nil, nil, err
 			}
 
 			// as there is no way to get transceiver from sender, search
@@ -277,7 +288,7 @@ func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *Tra
 			}
 		} else {
 			if err = sender.AddEncoding(st); err != nil {
-				return nil, err
+				return nil, nil, nil, err
 			}
 		}
 		pub.addSimulcastTrack(st)
@@ -330,8 +341,31 @@ func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *Tra
 
 		pub.setBackupCodecTracksForSimulcast(backupTracksCopy)
 	}
-	err = p.engine.SendAddTrack(req)
+	return pub, req, mainTrack, nil
+}
+
+// PublishSimulcastTrack publishes a simulcast track with up to three quality layers to the server.
+// This allows the server to dynamically switch between different quality levels based on network conditions.
+func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) (*LocalTrackPublication, error) {
+	if len(tracks) == 0 {
+		return nil, nil
+	}
+
+	transport := p.getPublishTransport()
+	if transport == nil {
+		return nil, ErrNoPeerConnection
+	}
+
+	pub, req, mainTrack, err := p.prepareSimulcastTrackPublication(tracks, opts, pubOpts...)
 	if err != nil {
+		return nil, err
+	}
+
+	pubChan := make(chan *livekit.TrackPublishedResponse, 1)
+	p.engine.RegisterTrackPublishedListener(mainTrack.ID(), pubChan)
+	defer p.engine.UnregisterTrackPublishedListener(mainTrack.ID())
+
+	if err := p.engine.SendAddTrack(req); err != nil {
 		return nil, err
 	}
 
@@ -348,8 +382,7 @@ func (p *LocalParticipant) PublishSimulcastTrack(tracks []*LocalTrack, opts *Tra
 
 	transport.Negotiate()
 
-	p.Callback.OnLocalTrackPublished(pub, p)
-	p.roomCallback.OnLocalTrackPublished(pub, p)
+	p.notifyTrackPublished(pub)
 
 	p.engine.log.Infow("published simulcast track", "name", opts.Name, "source", opts.Source.String(), "trackID", pubRes.Track.Sid)
 

--- a/room.go
+++ b/room.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v4"
 	"golang.org/x/mod/semver"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
 	protoLogger "github.com/livekit/protocol/logger"
@@ -104,10 +105,24 @@ type ConnectInfo struct {
 	ParticipantAttributes map[string]string
 }
 
-type ConnectOption func(*signalling.ConnectParams)
+type connPubTrack struct {
+	track           webrtc.TrackLocal
+	simulcastTracks []*LocalTrack
+
+	opts    *TrackPublicationOptions
+	pubOpts []LocalTrackPublishOption
+}
+
+type connParams struct {
+	*signalling.ConnectParams
+
+	pubTracks []*connPubTrack
+}
+
+type ConnectOption func(*connParams)
 
 func WithConnectTimeout(timeout time.Duration) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.ConnectTimeout = timeout
 	}
 }
@@ -115,7 +130,7 @@ func WithConnectTimeout(timeout time.Duration) ConnectOption {
 // WithAutoSubscribe sets whether the participant should automatically subscribe to tracks.
 // Default is true.
 func WithAutoSubscribe(val bool) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.AutoSubscribe = val
 	}
 }
@@ -123,7 +138,7 @@ func WithAutoSubscribe(val bool) ConnectOption {
 // WithRetransmitBufferSize sets the retransmit buffer size to respond to NACK requests.
 // Must be one of: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768.
 func WithRetransmitBufferSize(val uint16) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.RetransmitBufferSize = val
 	}
 }
@@ -131,14 +146,14 @@ func WithRetransmitBufferSize(val uint16) ConnectOption {
 // WithPacer enables the use of a pacer on this connection
 // A pacer helps to smooth out video packet rate to avoid overwhelming downstream. Learn more at: https://chromium.googlesource.com/external/webrtc/+/master/modules/pacing/g3doc/index.md
 func WithPacer(pacer pacer.Factory) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.Pacer = pacer
 	}
 }
 
 // WithInterceptors sets custom RTP interceptors for the connection.
 func WithInterceptors(interceptors []interceptor.Factory) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.Interceptors = interceptors
 	}
 }
@@ -146,14 +161,14 @@ func WithInterceptors(interceptors []interceptor.Factory) ConnectOption {
 // WithIncludeDefaultInterceptors sets whether to register default interceptors
 // along with custom interceptors.
 func WithIncludeDefaultInterceptors(include bool) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.IncludeDefaultInterceptors = include
 	}
 }
 
 // WithICETransportPolicy sets the ICE transport policy (UDP, Relay, etc.).
 func WithICETransportPolicy(iceTransportPolicy webrtc.ICETransportPolicy) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.ICETransportPolicy = iceTransportPolicy
 	}
 }
@@ -162,21 +177,21 @@ func WithICETransportPolicy(iceTransportPolicy webrtc.ICETransportPolicy) Connec
 // provided by the SFU. Use this when the client is co-located with the SFU
 // and does not need relay candidates.
 func WithDisableTURN() ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.DisableTURN = true
 	}
 }
 
 // WithDisableRegionDiscovery disables automatic region discovery for LiveKit Cloud.
 func WithDisableRegionDiscovery() ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.DisableRegionDiscovery = true
 	}
 }
 
 // WithMetadata sets custom metadata for the participant.
 func WithMetadata(metadata string) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.Metadata = metadata
 	}
 }
@@ -184,7 +199,7 @@ func WithMetadata(metadata string) ConnectOption {
 // WithExtraAttributes sets additional key-value attributes for the participant.
 // Empty string values will be ignored.
 func WithExtraAttributes(attrs map[string]string) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		if len(attrs) != 0 && p.Attributes == nil {
 			p.Attributes = make(map[string]string, len(attrs))
 		}
@@ -198,7 +213,7 @@ func WithExtraAttributes(attrs map[string]string) ConnectOption {
 }
 
 func WithCodecs(codecs []livekit.Codec) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		pCodecs := make([]webrtc.RTPCodecParameters, 0, len(codecs))
 		for i := range codecs {
 			pCodecs = append(pCodecs, protoCodecs.ToWebrtcCodecParameters(&codecs[i]))
@@ -211,13 +226,13 @@ func WithCodecs(codecs []livekit.Codec) ConnectOption {
 // Use this on FIPS 140-enabled systems to specify NIST-approved curves (e.g. P-256, P-384)
 // instead of the default X25519.
 func WithDTLSEllipticCurves(curves ...dtlsElliptic.Curve) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.DTLSEllipticCurves = curves
 	}
 }
 
 func WithLogger(l protoLogger.Logger) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		p.Logger = l
 	}
 }
@@ -226,14 +241,65 @@ func WithLogger(l protoLogger.Logger) ConnectOption {
 // When set, outgoing data packets are encrypted and incoming EncryptedPacket
 // messages are decrypted automatically using the provided KeyProvider.
 func WithDataEncryption(opts *EncryptionOptions) ConnectOption {
-	return func(p *signalling.ConnectParams) {
+	return func(p *connParams) {
 		if opts != nil {
 			p.DataEncryptionKeyProvider = opts.KeyProvider
 		}
 	}
 }
 
+// WithSinglePeerConnection enables single peer connection mode. In this mode
+// the publisher PC handles both publishing and receiving media.
+func WithSinglePeerConnection() ConnectOption {
+	return func(p *connParams) {
+		p.UseSinglePeerConnection = true
+	}
+}
+
+// WithTrack queues a track to be published as part of the join
+// request. Requires WithSinglePeerConnection(). It can be called multiple times to
+// publish multiple tracks.
+//
+// The track's LocalTrackPublication is available via the OnLocalTrackPublished
+// callback or LocalParticipant.TrackPublications() as soon as Join returns.
+func WithTrack(track webrtc.TrackLocal, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) ConnectOption {
+	return func(p *connParams) {
+		p.pubTracks = append(p.pubTracks, &connPubTrack{
+			track:   track,
+			opts:    opts,
+			pubOpts: pubOpts,
+		})
+	}
+}
+
+// WithSimulcastTrack queues a simulcast video track (multiple
+// LocalTracks representing different quality layers, low to high) to be
+// published as part of the join request. Requires WithSinglePeerConnection().
+//
+// The track's LocalTrackPublication is available via the OnLocalTrackPublished
+// callback or LocalParticipant.TrackPublications() as soon as Join returns.
+func WithSimulcastTrack(tracks []*LocalTrack, opts *TrackPublicationOptions, pubOpts ...LocalTrackPublishOption) ConnectOption {
+	return func(p *connParams) {
+		p.pubTracks = append(p.pubTracks, &connPubTrack{
+			simulcastTracks: tracks,
+			opts:            opts,
+			pubOpts:         pubOpts,
+		})
+	}
+}
+
 type PLIWriter func(webrtc.SSRC)
+
+type trackPublicationWithJoin struct {
+	pub *LocalTrackPublication
+	// cid keys the trackPublished listener. For a single-layer publication
+	// it's the track's CID; for a simulcast publication it's the main
+	// (highest-quality) layer's CID, matching AddTrackRequest.Cid.
+	cid       string
+	opts      *TrackPublicationOptions
+	pubChan   chan *livekit.TrackPublishedResponse
+	simulcast bool
+}
 
 type Room struct {
 	log                     protoLogger.Logger
@@ -355,11 +421,6 @@ func (r *Room) Join(url string, info ConnectInfo, opts ...ConnectOption) error {
 
 // JoinWithContext - like Join, but accepts a context for cancellation/deadline.
 func (r *Room) JoinWithContext(ctx context.Context, url string, info ConnectInfo, opts ...ConnectOption) error {
-	var params signalling.ConnectParams
-	for _, opt := range opts {
-		opt(&params)
-	}
-
 	// generate token
 	at := auth.NewAccessToken(info.APIKey, info.APISecret)
 	grant := &auth.VideoGrant{
@@ -388,10 +449,14 @@ func (r *Room) JoinWithToken(url, token string, opts ...ConnectOption) error {
 
 // JoinWithContextAndToken - like JoinWithToken, but accepts a context for cancellation/deadline.
 func (r *Room) JoinWithContextAndToken(ctx context.Context, url, token string, opts ...ConnectOption) error {
-	params := &signalling.ConnectParams{
-		AutoSubscribe:  true,
-		ConnectTimeout: 3 * time.Second,
+	params := &connParams{
+		ConnectParams: &signalling.ConnectParams{
+			AutoSubscribe:           true,
+			ConnectTimeout:          3 * time.Second,
+			UseSinglePeerConnection: r.useSinglePeerConnection,
+		},
 	}
+
 	for _, opt := range opts {
 		opt(params)
 	}
@@ -403,6 +468,32 @@ func (r *Room) JoinWithContextAndToken(ctx context.Context, url, token string, o
 	// Enable data channel E2EE if a key provider was supplied.
 	if params.DataEncryptionKeyProvider != nil {
 		r.engine.dataCryptor = e2ee.NewDataCryptor(params.DataEncryptionKeyProvider)
+	}
+
+	if params.UseSinglePeerConnection {
+		r.useSinglePeerConnection = params.UseSinglePeerConnection
+	}
+	r.engine.configureSignalling(r.useSinglePeerConnection)
+
+	if len(params.pubTracks) > 0 && !r.useSinglePeerConnection {
+		return ErrPublishRequiresSinglePC
+	}
+
+	var trackPubs []*trackPublicationWithJoin
+	pubFunc := func() ([]*livekit.AddTrackRequest, error) {
+		pubs, req, err := r.publishTracksWithJoin(params.pubTracks)
+		trackPubs = pubs
+		return req, err
+	}
+	cleanPubReg := func() {
+		for _, tp := range trackPubs {
+			r.engine.UnregisterTrackPublishedListener(tp.cid)
+			// clean simulcast track transceiver as it has been set during publishing
+			for _, lt := range tp.pub.simulcastTracks {
+				lt.SetTransceiver(nil)
+			}
+		}
+		trackPubs = nil
 	}
 
 	isSuccess := false
@@ -423,9 +514,10 @@ func (r *Room) JoinWithContextAndToken(ctx context.Context, url, token string, o
 
 				r.log.Debugw("RTC engine joining room", "url", bestURL, "connectTimeout", params.ConnectTimeout)
 				callCtx, cancelCallCtx := context.WithTimeout(ctx, params.ConnectTimeout)
-				isSuccess, err = r.engine.JoinContext(callCtx, bestURL, token, params)
+				isSuccess, err = r.engine.JoinContext(callCtx, bestURL, token, params.ConnectParams, pubFunc)
 				cancelCallCtx()
 				if err != nil {
+					cleanPubReg()
 					// try the next URL with exponential backoff
 					d := time.Duration(1<<min(tries, 6)) * 100 * time.Millisecond // max 6.4 seconds
 					r.log.Errorw(
@@ -445,9 +537,14 @@ func (r *Room) JoinWithContextAndToken(ctx context.Context, url, token string, o
 	}
 
 	if !isSuccess {
-		if _, err := r.engine.JoinContext(ctx, url, token, params); err != nil {
+		if _, err := r.engine.JoinContext(ctx, url, token, params.ConnectParams, pubFunc); err != nil {
+			cleanPubReg()
 			return err
 		}
+	}
+
+	if err := r.completePublishWithJoin(ctx, trackPubs); err != nil {
+		return err
 	}
 
 	return nil
@@ -764,6 +861,92 @@ func (r *Room) getLocalParticipantSID() string {
 	}
 
 	return ""
+}
+
+func (r *Room) publishTracksWithJoin(pubTracks []*connPubTrack) ([]*trackPublicationWithJoin, []*livekit.AddTrackRequest, error) {
+	addTrackRequests := make([]*livekit.AddTrackRequest, 0, len(pubTracks))
+	trackPubs := make([]*trackPublicationWithJoin, 0, len(pubTracks))
+
+	rollback := func() {
+		for _, tp := range trackPubs {
+			r.engine.UnregisterTrackPublishedListener(tp.cid)
+			for _, lt := range tp.pub.simulcastTracks {
+				lt.SetTransceiver(nil)
+			}
+		}
+	}
+
+	for _, pubTrack := range pubTracks {
+		var (
+			publication *LocalTrackPublication
+			req         *livekit.AddTrackRequest
+			simulcast   bool
+			err         error
+		)
+		switch {
+		case len(pubTrack.simulcastTracks) > 0:
+			publication, req, _, err = r.LocalParticipant.prepareSimulcastTrackPublication(pubTrack.simulcastTracks, pubTrack.opts, pubTrack.pubOpts...)
+			simulcast = true
+		case pubTrack.track != nil:
+			publication, req, err = r.LocalParticipant.prepareTrackPublication(pubTrack.track, pubTrack.opts, pubTrack.pubOpts...)
+		default:
+			err = ErrInvalidParameter
+		}
+		if err != nil {
+			r.log.Errorw("failed to prepare publish track with join", err)
+			// Roll back listeners and transceivers we already registered so the
+			// publisher PC doesn't ship orphan m-sections in the join offer.
+			rollback()
+			return nil, nil, err
+		}
+		pubChan := make(chan *livekit.TrackPublishedResponse, 1)
+		r.engine.RegisterTrackPublishedListener(req.Cid, pubChan)
+		trackPubs = append(trackPubs, &trackPublicationWithJoin{
+			pub:       publication,
+			cid:       req.Cid,
+			opts:      pubTrack.opts,
+			pubChan:   pubChan,
+			simulcast: simulcast,
+		})
+		addTrackRequests = append(addTrackRequests, req)
+	}
+
+	return trackPubs, addTrackRequests, nil
+}
+
+func (r *Room) completePublishWithJoin(ctx context.Context, trackPubs []*trackPublicationWithJoin) error {
+	if len(trackPubs) == 0 {
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	waitCtx, cancel := context.WithTimeout(gctx, trackPublishTimeout)
+	defer cancel()
+	for _, tp := range trackPubs {
+		publication, cid, opts, pubChan, simulcast := tp.pub, tp.cid, tp.opts, tp.pubChan, tp.simulcast
+		g.Go(func() error {
+			defer r.engine.UnregisterTrackPublishedListener(cid)
+
+			var pubRes *livekit.TrackPublishedResponse
+			select {
+			case pubRes = <-pubChan:
+			case <-waitCtx.Done():
+				return waitCtx.Err()
+			}
+
+			publication.updateInfo(pubRes.Track)
+			r.LocalParticipant.addPublication(publication)
+			r.LocalParticipant.notifyTrackPublished(publication)
+			label := "published track"
+			if simulcast {
+				label = "published simulcast track"
+			}
+			r.engine.log.Infow(label, "name", opts.Name, "source", opts.Source.String(), "trackID", pubRes.Track.Sid)
+			return nil
+		})
+	}
+
+	return g.Wait()
 }
 
 // Establishes the participant as a receiver for calls of the specified RPC method.

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -100,6 +100,10 @@ type ConnectParams struct {
 	// DataEncryptionKeyProvider enables data channel E2EE when set.
 	DataEncryptionKeyProvider e2eetypes.KeyProvider
 
+	// UseSinglePeerConnection enables single peer connection mode in which the
+	// publisher PC is reused for both publishing and receiving media.
+	UseSinglePeerConnection bool
+
 	// internal use
 	Codecs []webrtc.RTPCodecParameters
 


### PR DESCRIPTION
Adds WithSinglePeerConnection / WithTrack / WithSimulcastTrack connect options that bundle the AddTrackRequest and publisher offer into the JoinRequest, saving time on connection/publishing.

Benchmark with 100ms rtt, 10 rounds
  | case                             | min    | p90    | avg    | max    | saved (ms / RTT) |
|----------------------------------|--------|--------|--------|--------|------------------|
| dual-pc post-publish / audio     | 1.049s | 1.205s | 1.136s | 1.216s | — (baseline)     |
| single-pc post-publish / audio   | 967ms  | 1.031s | 986ms  | 1.056s | 150 ms / 1.4 RTT |
| single-pc pre-publish / audio    | 855ms  | 876ms  | 866ms  | 880ms  | 270 ms / 2.5 RTT |
| dual-pc post-publish / video     | 1.073s | 1.277s | 1.170s | 1.282s | — (baseline)     |
| single-pc post-publish / video   | 954ms  | 1.064s | 1.019s | 1.133s | 151 ms / 1.4 RTT |
| single-pc pre-publish / video    | 879ms  | 977ms  | 931ms  | 978ms  | 239 ms / 2.2 RTT |