### PR TITLE
TEL-588: expose original raw protocol disconnect reason

### DIFF
--- a/callback.go
+++ b/callback.go
@@ -138,6 +138,9 @@ const (
 )
 
 // GetDisconnectionReason converts a protocol disconnect reason to a DisconnectionReason.
+// Many protocol reasons (e.g. ROOM_DELETED, SERVER_SHUTDOWN, MEDIA_FAILURE) collapse
+// into OtherReason. New code that needs to distinguish between them should read the
+// raw protocol value via Room.DisconnectReason() instead.
 func GetDisconnectionReason(reason livekit.DisconnectReason) DisconnectionReason {
 	// TODO: SDK should forward the original reason and provide helpers like IsRequestedLeave.
 	r := OtherReason

--- a/engine.go
+++ b/engine.go
@@ -42,7 +42,7 @@ import (
 type engineHandler interface {
 	OnLocalTrackUnpublished(response *livekit.TrackUnpublishedResponse)
 	OnTrackRemoteMuted(request *livekit.MuteTrackRequest)
-	OnDisconnected(reason DisconnectionReason)
+	OnDisconnected(protoReason livekit.DisconnectReason)
 	OnMediaTrack(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver)
 	OnParticipantUpdate([]*livekit.ParticipantInfo)
 	OnSpeakersChanged([]*livekit.SpeakerInfo)
@@ -832,7 +832,7 @@ func (e *RTCEngine) handleDisconnect(fullReconnect bool) {
 			}
 		}
 
-		e.engineHandler.OnDisconnected(Failed)
+		e.engineHandler.OnDisconnected(livekit.DisconnectReason_SIGNAL_CLOSE)
 	}()
 }
 
@@ -1472,7 +1472,7 @@ func (e *RTCEngine) OnLeave(leave *livekit.LeaveRequest) {
 		e.Close()
 		reason := leave.GetReason()
 		e.log.Infow("server initiated leave", "reason", reason)
-		e.engineHandler.OnDisconnected(GetDisconnectionReason(reason))
+		e.engineHandler.OnDisconnected(reason)
 
 	case livekit.LeaveRequest_RECONNECT:
 		e.handleDisconnect(true)

--- a/room.go
+++ b/room.go
@@ -309,6 +309,7 @@ type Room struct {
 	callback                *RoomCallback
 	connectionState         ConnectionState
 	sidReady                chan struct{}
+	disconnectReason        livekit.DisconnectReason
 
 	remoteParticipants map[livekit.ParticipantIdentity]*RemoteParticipant
 	sidToIdentity      map[livekit.ParticipantID]livekit.ParticipantIdentity
@@ -1069,11 +1070,26 @@ func (r *Room) OnRoomJoined(
 	}
 }
 
-func (r *Room) OnDisconnected(reason DisconnectionReason) {
+func (r *Room) OnDisconnected(reason livekit.DisconnectReason) {
+	r.lock.Lock()
+	r.disconnectReason = reason
+	r.lock.Unlock()
+
 	r.callback.OnDisconnected()
-	r.callback.OnDisconnectedWithReason(reason)
+	r.callback.OnDisconnectedWithReason(GetDisconnectionReason(reason))
 
 	r.cleanup()
+}
+
+// DisconnectReason returns the raw protocol disconnect reason reported by the
+// server. Returns livekit.DisconnectReason_UNKNOWN_REASON if the room has not
+// been disconnected or no reason was reported. Use this when the coarse
+// DisconnectionReason enum surfaced by OnDisconnectedWithReason collapses
+// values you need to distinguish (e.g. ROOM_DELETED vs ROOM_CLOSED).
+func (r *Room) DisconnectReason() livekit.DisconnectReason {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.disconnectReason
 }
 
 func (r *Room) OnRestarting() {


### PR DESCRIPTION
We currently rely on `OnDisconnectedWithReason` to check whether it's a success/client error/server error. The existing `DisconnectionReason` is not sufficient to cover all reasons. For example,  `ROOM_DELETED`, `SERVER_SHUTDOWN`, `MEDIA_FAILURE` will collapse into `OtherReason`. This PR exposes the original protocol disconnect reason through `DisconnectReason`.