### PR TITLE
bump protocol to 1.46.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/media-sdk v0.0.0-20260424094251-1e21ae1138de
 	github.com/livekit/mediatransportutil v0.0.0-20251128105421-19c7a7b81c22
-	github.com/livekit/protocol v1.45.9-0.20260514181713-80e20dbf4fc6
+	github.com/livekit/protocol v1.46.0
 	github.com/magefile/mage v1.17.0
 	github.com/moby/buildkit v0.26.2
 	github.com/moby/patternmatcher v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/livekit/media-sdk v0.0.0-20260424094251-1e21ae1138de h1:obfPAPRvdcmCA
 github.com/livekit/media-sdk v0.0.0-20260424094251-1e21ae1138de/go.mod h1:7ssWiG+U4xnbvLih9WiZbhQP6zIKMjgXdUtIE1bm/E8=
 github.com/livekit/mediatransportutil v0.0.0-20251128105421-19c7a7b81c22 h1:dzCBxOGLLWVtQhL7OYK2EGN+5Q+23Mq/jfz4vQisirA=
 github.com/livekit/mediatransportutil v0.0.0-20251128105421-19c7a7b81c22/go.mod h1:mSNtYzSf6iY9xM3UX42VEI+STHvMgHmrYzEHPcdhB8A=
-github.com/livekit/protocol v1.45.9-0.20260514181713-80e20dbf4fc6 h1:eCK2ZuTrnG6i4sQ0h9tYCs/bUKK9J+hZvotluycaQkA=
-github.com/livekit/protocol v1.45.9-0.20260514181713-80e20dbf4fc6/go.mod h1:KEPIJ/ZdMFQ9tmmfv/uT9TjQEuEcZupCZBabuRGEC1k=
+github.com/livekit/protocol v1.46.0 h1:onBkn2UEIX4qboVRtbdR1KZYNUoHfxHbgg7nqJ76e5s=
+github.com/livekit/protocol v1.46.0/go.mod h1:KEPIJ/ZdMFQ9tmmfv/uT9TjQEuEcZupCZBabuRGEC1k=
 github.com/livekit/psrpc v0.7.1 h1:ms37az0QTD3UXIWuUC5D/SkmKOlRMVRsI261eBWu/Vw=
 github.com/livekit/psrpc v0.7.1/go.mod h1:bZ4iHFQptTkbPnB0LasvRNu/OBYXEu1NA6O5BMFo9kk=
 github.com/mackerelio/go-osstat v0.2.7 h1:TCavZi10wF49bT6iQZ9eT2keGZQpC69MTDfdJej5e94=


### PR DESCRIPTION
need to bump the protocol version as there was a mismatch causing errors in livekit-cli