### PR TITLE
sync engine fixes

### DIFF
--- a/pkg/synchronizer/ntpestimator.go
+++ b/pkg/synchronizer/ntpestimator.go
@@ -34,12 +34,28 @@ const (
 	// a new SR is considered an outlier and excluded from the regression.
 	outlierThresholdStdDevs = 3.0
 
+	// maxConsecutiveOutliers is how many SRs may be rejected in a row before
+	// the estimator decides the sender's NTP clock has stepped (or otherwise
+	// jumped to a state inconsistent with the prior regression) and rebuilds
+	// from scratch. At typical 1 Hz RTCP this is ~5 seconds of sustained
+	// rejection.
+	maxConsecutiveOutliers = 5
+
+	// minOutlierStdDevNanos is the floor applied to residStd when computing
+	// the outlier threshold. Without it, an exactly-fitting set of samples
+	// would produce residStd = 0 (or a few ULPs), and outlier detection would
+	// effectively disable — letting a sender NTP step through as if it were a
+	// real measurement. 100µs corresponds to ~300µs at the 3σ threshold, which
+	// is well below typical SR jitter on real networks but well above any
+	// float-precision artifact.
+	minOutlierStdDevNanos = 100_000 // 100µs in nanoseconds
+
 	// ntpEpochOffset is the number of seconds between the NTP epoch (1900-01-01)
 	// and the Unix epoch (1970-01-01).
 	ntpEpochOffset = 2208988800
 )
 
-var errNotReady = errors.New("NtpEstimator: not enough sender reports for regression (need >= 2)")
+var errNotReady = errors.New("NtpEstimator: not enough sender reports for regression")
 
 // srSample holds one sender report observation used in the regression.
 type srSample struct {
@@ -72,6 +88,8 @@ type NtpEstimator struct {
 	meanY      float64 // mean of NTP nanos values in the current window
 	residStd   float64 // residual standard deviation in NTP nanos
 	ready      bool
+
+	consecutiveOutliers int
 }
 
 // NewNtpEstimator creates an NtpEstimator for a codec with the given clock rate.
@@ -87,6 +105,10 @@ func NewNtpEstimator(clockRate uint32) *NtpEstimator {
 func (e *NtpEstimator) Reset() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	e.resetLocked()
+}
+
+func (e *NtpEstimator) resetLocked() {
 	e.samples = [maxSRSamples]srSample{}
 	e.sampleLen = 0
 	e.sampleHead = 0
@@ -98,6 +120,7 @@ func (e *NtpEstimator) Reset() {
 	e.meanY = 0
 	e.residStd = 0
 	e.ready = false
+	e.consecutiveOutliers = 0
 }
 
 // SRResult indicates the outcome of processing a sender report.
@@ -133,14 +156,28 @@ func (e *NtpEstimator) OnSenderReport(ntpTime uint64, rtpTimestamp uint32, recei
 
 	// Outlier rejection: if we already have a valid regression, check whether
 	// this new sample deviates from the prediction by more than 3 standard
-	// deviations.
-	if e.ready && e.residStd > 0 {
+	// deviations. Persistent rejection (e.g., sender's NTP clock stepped)
+	// triggers a full reset so the regression can rebuild from the new state.
+	// residStd is floored to avoid disabling detection when the prior samples
+	// happened to fit the line exactly.
+	if e.ready {
+		std := e.residStd
+		if std < minOutlierStdDevNanos {
+			std = minOutlierStdDevNanos
+		}
 		predicted := e.slopeNanos*(float64(unwrapped)-e.meanX) + e.meanY
 		residual := math.Abs(float64(ntpNanos) - predicted)
-		if residual > outlierThresholdStdDevs*e.residStd {
-			return SROutlier
+		if residual > outlierThresholdStdDevs*std {
+			e.consecutiveOutliers++
+			if e.consecutiveOutliers < maxConsecutiveOutliers {
+				return SROutlier
+			}
+			// Persistent outliers: rebuild from scratch starting with this SR.
+			e.resetLocked()
+			unwrapped = e.unwrapRTP(rtpTimestamp)
 		}
 	}
+	e.consecutiveOutliers = 0
 
 	// Write into circular buffer.
 	e.samples[e.sampleHead] = srSample{

--- a/pkg/synchronizer/ntpestimator.go
+++ b/pkg/synchronizer/ntpestimator.go
@@ -19,6 +19,8 @@ import (
 	"math"
 	"sync"
 	"time"
+
+	"github.com/livekit/mediatransportutil/pkg/latency"
 )
 
 const (
@@ -67,6 +69,15 @@ type srSample struct {
 // NtpEstimator maintains a linear regression over a sliding window of RTCP
 // sender report pairs to map RTP timestamps to NTP time. It is modeled after
 // Chrome's RtpToNtpEstimator.
+//
+// Each NtpEstimator also owns a per-track OWDEstimator. OWD is per-track
+// rather than per-participant because audio and video tracks of the same
+// participant typically have different (senderNTP, receivedAt) relationships:
+// video frames carry an encoder-delay-shifted NTP timestamp relative to the
+// audio sample taken at the same real-world instant. Feeding both into one
+// shared estimator produces a blended estimate biased toward whichever track
+// happens to have lower raw OWD, and the OWDEstimator's path-change detector
+// misfires on the sign-alternating input pattern.
 type NtpEstimator struct {
 	mu        sync.Mutex
 	clockRate uint32
@@ -90,12 +101,17 @@ type NtpEstimator struct {
 	ready      bool
 
 	consecutiveOutliers int
+
+	// owdEstimator tracks the per-track propagation delay (receiver wall time
+	// minus sender NTP at SR emission). Updated only on accepted SRs.
+	owdEstimator *latency.OWDEstimator
 }
 
 // NewNtpEstimator creates an NtpEstimator for a codec with the given clock rate.
 func NewNtpEstimator(clockRate uint32) *NtpEstimator {
 	return &NtpEstimator{
-		clockRate: clockRate,
+		clockRate:    clockRate,
+		owdEstimator: latency.NewOWDEstimator(latency.OWDEstimatorParamsDefault),
 	}
 }
 
@@ -121,6 +137,10 @@ func (e *NtpEstimator) resetLocked() {
 	e.residStd = 0
 	e.ready = false
 	e.consecutiveOutliers = 0
+	// Reset OWD: a sender NTP step that triggered the regression rebuild also
+	// invalidates the previously-measured clock offset, so the estimator must
+	// re-converge from the new sender state.
+	e.owdEstimator = latency.NewOWDEstimator(latency.OWDEstimatorParamsDefault)
 }
 
 // SRResult indicates the outcome of processing a sender report.
@@ -196,7 +216,21 @@ func (e *NtpEstimator) OnSenderReport(ntpTime uint64, rtpTimestamp uint32, recei
 		e.ready = true
 	}
 
+	// Feed the OWD estimator only with accepted SRs — outliers would
+	// contaminate the propagation-delay measurement.
+	e.owdEstimator.Update(ntpNanos, receivedAt.UnixNano())
+
 	return SRAccepted
+}
+
+// EstimatedOWD returns the current estimated propagation delay for this track.
+// The value may be negative when the sender's NTP clock is ahead of the
+// receiver's wall clock — that is by design; the cross-participant alignment
+// formula relies on the OWD absorbing whatever clock offset exists.
+func (e *NtpEstimator) EstimatedOWD() time.Duration {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return time.Duration(e.owdEstimator.EstimatedPropagationDelay())
 }
 
 // IsReady returns true once at least 2 sender reports have been processed

--- a/pkg/synchronizer/ntpestimator.go
+++ b/pkg/synchronizer/ntpestimator.go
@@ -210,9 +210,12 @@ func (e *NtpEstimator) OnSenderReport(ntpTime uint64, rtpTimestamp uint32, recei
 		e.sampleLen++
 	}
 
-	// Recompute regression if we have enough samples.
-	if e.sampleLen >= minSamplesReady {
-		e.computeRegression()
+	// Recompute regression if we have enough samples. computeRegression
+	// returns false on degenerate input (e.g., all RTP timestamps identical,
+	// which yields sumDxDx == 0). In that case ready stays at its prior
+	// value rather than flipping to true with stale/zero regression
+	// coefficients — IsReady() must imply usable slope/mean.
+	if e.sampleLen >= minSamplesReady && e.computeRegression() {
 		e.ready = true
 	}
 
@@ -265,7 +268,11 @@ func (e *NtpEstimator) Slope() float64 {
 // computeRegression performs ordinary least squares on the current samples
 // using centered data to preserve float64 precision.
 // Model: ntpNanos = slopeNanos * (unwrappedRTP - meanX) + meanY
-func (e *NtpEstimator) computeRegression() {
+//
+// Returns false if the input is degenerate (all RTP timestamps identical,
+// yielding sumDxDx == 0). The caller must NOT set ready=true in that case —
+// the existing slope/mean values are stale and would produce wrong NTP times.
+func (e *NtpEstimator) computeRegression() bool {
 	n := float64(e.sampleLen)
 
 	// First pass: compute means for centering.
@@ -288,7 +295,7 @@ func (e *NtpEstimator) computeRegression() {
 
 	if sumDxDx == 0 {
 		// Degenerate case: all RTP timestamps identical.
-		return
+		return false
 	}
 
 	e.slopeNanos = sumDxDy / sumDxDx
@@ -307,9 +314,13 @@ func (e *NtpEstimator) computeRegression() {
 		e.residStd = math.Sqrt(sumResidSq / (n - 2))
 	} else {
 		// With exactly 2 points the regression is exact; use a small positive
-		// value so that the 3-sigma check is not trivially zero.
+		// value so that the 3-sigma check is not trivially zero. (Currently
+		// unreachable since the caller requires sampleLen >= minSamplesReady
+		// (= 4) before invoking; left in place for robustness if minSamplesReady
+		// is lowered.)
 		e.residStd = math.Sqrt(sumResidSq / n)
 	}
+	return true
 }
 
 // iterSamples calls fn for each valid sample in the circular buffer.

--- a/pkg/synchronizer/ntpestimator_test.go
+++ b/pkg/synchronizer/ntpestimator_test.go
@@ -223,3 +223,111 @@ func TestNtpEstimator_Slope(t *testing.T) {
 	require.Less(t, relError, 1e-6,
 		"slope should be ~%e, got %e (relative error %e)", expectedSlope, gotSlope, relError)
 }
+
+func TestNtpEstimator_PersistentOutliersRebuildRegression(t *testing.T) {
+	// Simulates a sender NTP step correction: after a steady regression,
+	// every SR arrives with the same large NTP offset. The estimator must
+	// reject the first few outliers, then reset and rebuild from the new
+	// state — and the rebuilt regression must accurately map the post-step
+	// RTP/NTP relationship.
+	const clockRate = 90000
+	e := NewNtpEstimator(clockRate)
+
+	baseTime := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	// Build a stable regression with 5 SRs.
+	for i := 0; i < 5; i++ {
+		wallTime := baseTime.Add(time.Duration(i) * time.Second)
+		rtpTS := uint32(i) * clockRate
+		e.OnSenderReport(ntpToUint64(wallTime), rtpTS, wallTime)
+	}
+	require.True(t, e.IsReady())
+
+	// Step the sender's NTP clock forward by 500ms while RTP keeps ticking
+	// at its normal rate. Every subsequent SR is now ~500ms off the old
+	// regression — far above 3σ.
+	const ntpStep = 500 * time.Millisecond
+	for i := 5; i < 5+maxConsecutiveOutliers-1; i++ {
+		wallTime := baseTime.Add(time.Duration(i)*time.Second + ntpStep)
+		rtpTS := uint32(i) * clockRate
+		result := e.OnSenderReport(ntpToUint64(wallTime), rtpTS, wallTime)
+		require.Equal(t, SROutlier, result, "SR %d should still be rejected", i)
+	}
+
+	// The Nth outlier triggers reset; the SR is accepted as the new baseline.
+	resetIdx := 5 + maxConsecutiveOutliers - 1
+	wallTime := baseTime.Add(time.Duration(resetIdx)*time.Second + ntpStep)
+	rtpTS := uint32(resetIdx) * clockRate
+	result := e.OnSenderReport(ntpToUint64(wallTime), rtpTS, wallTime)
+	require.Equal(t, SRAccepted, result, "Nth consecutive outlier should trigger reset and acceptance")
+	require.False(t, e.IsReady(), "regression should not be ready until minSamplesReady SRs accumulate")
+
+	// Feed minSamplesReady more SRs at the new (stepped) NTP base.
+	for i := resetIdx + 1; i < resetIdx+1+minSamplesReady; i++ {
+		wallTime := baseTime.Add(time.Duration(i)*time.Second + ntpStep)
+		rtpTS := uint32(i) * clockRate
+		result := e.OnSenderReport(ntpToUint64(wallTime), rtpTS, wallTime)
+		require.Equal(t, SRAccepted, result, "post-reset SR %d should be accepted", i)
+	}
+	require.True(t, e.IsReady(), "regression should be ready after rebuild")
+
+	// The rebuilt regression should accurately map post-step RTP timestamps.
+	queryIdx := resetIdx + 2
+	got, err := e.RtpToNtp(uint32(queryIdx) * clockRate)
+	require.NoError(t, err)
+	want := baseTime.Add(time.Duration(queryIdx)*time.Second + ntpStep)
+	diff := got.Sub(want)
+	if diff < 0 {
+		diff = -diff
+	}
+	require.Less(t, diff, time.Millisecond,
+		"post-rebuild mapping should be accurate; got %v want %v (off by %v)", got, want, diff)
+}
+
+func TestNtpEstimator_IntermittentOutliersDoNotReset(t *testing.T) {
+	// Network glitches that produce occasional outliers — but interleaved
+	// with normal SRs — should not trigger the rebuild path.
+	const clockRate = 90000
+	e := NewNtpEstimator(clockRate)
+
+	baseTime := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	// Build a stable regression.
+	for i := 0; i < 5; i++ {
+		wallTime := baseTime.Add(time.Duration(i) * time.Second)
+		rtpTS := uint32(i) * clockRate
+		e.OnSenderReport(ntpToUint64(wallTime), rtpTS, wallTime)
+	}
+	require.True(t, e.IsReady())
+
+	// Alternate: 4 outliers spread across 8 SRs (never consecutive enough to
+	// trigger reset). Each outlier resets the counter, so we never reach
+	// maxConsecutiveOutliers.
+	for i := 0; i < 8; i++ {
+		idx := 5 + i
+		wallTime := baseTime.Add(time.Duration(idx) * time.Second)
+		rtpTS := uint32(idx) * clockRate
+
+		if i%2 == 0 {
+			// Outlier: same RTP slot but NTP wildly off.
+			badNTP := baseTime.Add(time.Duration(idx+50) * time.Second)
+			result := e.OnSenderReport(ntpToUint64(badNTP), rtpTS, wallTime)
+			require.Equal(t, SROutlier, result, "outlier SR at idx %d should be rejected", idx)
+		} else {
+			// Normal SR.
+			result := e.OnSenderReport(ntpToUint64(wallTime), rtpTS, wallTime)
+			require.Equal(t, SRAccepted, result, "normal SR at idx %d should be accepted", idx)
+		}
+	}
+
+	// Original regression should still be valid.
+	got, err := e.RtpToNtp(uint32(2.5 * clockRate))
+	require.NoError(t, err)
+	want := baseTime.Add(2500 * time.Millisecond)
+	diff := got.Sub(want)
+	if diff < 0 {
+		diff = -diff
+	}
+	require.Less(t, diff, 10*time.Millisecond,
+		"original regression should survive intermittent outliers; off by %v", diff)
+}

--- a/pkg/synchronizer/participantclock.go
+++ b/pkg/synchronizer/participantclock.go
@@ -18,31 +18,30 @@ import (
 	"sync"
 	"time"
 
-	"github.com/livekit/mediatransportutil/pkg/latency"
 	"github.com/livekit/protocol/logger"
 )
 
-// ParticipantClock holds OWD and NTP estimation state for a single participant.
+// ParticipantClock holds NTP estimation state for a single participant. OWD
+// is tracked per-track inside each NtpEstimator (see NtpEstimator comment for
+// why a participant-wide OWD estimator is incorrect when a participant has
+// both audio and video tracks).
 type ParticipantClock struct {
-	mu           sync.Mutex
-	logger       logger.Logger
-	owdEstimator *latency.OWDEstimator
-	tracks       map[string]*NtpEstimator
-	ntpEpoch     time.Time // NTP time from first SR
-	hasEpoch     bool
+	mu     sync.Mutex
+	logger logger.Logger
+	tracks map[string]*NtpEstimator
 }
 
 // NewParticipantClock creates a new ParticipantClock.
 func NewParticipantClock(l logger.Logger) *ParticipantClock {
 	return &ParticipantClock{
-		logger:       l,
-		owdEstimator: latency.NewOWDEstimator(latency.OWDEstimatorParamsDefault),
-		tracks:       make(map[string]*NtpEstimator),
+		logger: l,
+		tracks: make(map[string]*NtpEstimator),
 	}
 }
 
 // OnSenderReport processes an RTCP sender report for a track.
-// It updates the NTP estimator, OWD estimator, and records the NTP epoch.
+// It updates the track's NTP estimator (which in turn updates the per-track
+// OWD estimator on accepted SRs).
 func (pc *ParticipantClock) OnSenderReport(trackID string, clockRate uint32, ntpTime uint64, rtpTimestamp uint32, receivedAt time.Time) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -60,17 +59,6 @@ func (pc *ParticipantClock) OnSenderReport(trackID string, clockRate uint32, ntp
 			"rtpTimestamp", rtpTimestamp,
 			"ntpTime", ntpTime,
 		)
-	}
-	if result != SRAccepted {
-		return
-	}
-
-	senderNtpNanos := ntpTimestampToNanos(ntpTime)
-	pc.owdEstimator.Update(senderNtpNanos, receivedAt.UnixNano())
-
-	if !pc.hasEpoch {
-		pc.ntpEpoch = nanosToTime(senderNtpNanos)
-		pc.hasEpoch = true
 	}
 }
 
@@ -90,17 +78,12 @@ func (pc *ParticipantClock) RtpToReceiverClock(trackID string, rtpTimestamp uint
 		return time.Time{}, errNotReady
 	}
 
-	if !pc.hasEpoch {
-		return time.Time{}, errNoSenderReports
-	}
-
 	ntpTime, err := est.RtpToNtp(rtpTimestamp)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	estimatedOWD := time.Duration(pc.owdEstimator.EstimatedPropagationDelay())
-	return ntpTime.Add(estimatedOWD), nil
+	return ntpTime.Add(est.EstimatedOWD()), nil
 }
 
 // ResetTrack clears the NTP estimator for a track, forcing it to rebuild

--- a/pkg/synchronizer/sessiontimeline.go
+++ b/pkg/synchronizer/sessiontimeline.go
@@ -66,6 +66,39 @@ func (st *SessionTimeline) SetSessionStart(t time.Time) {
 	st.hasStart = true
 }
 
+// SetSessionStartIfNotSet atomically sets the session start time only if it
+// has not yet been set. Returns true on the first successful set, false
+// otherwise. This is used by SyncEngine.initializeIfNeeded to order the
+// timeline state ahead of the public startedAt publication, eliminating the
+// window in which startedAt is visible as non-zero but hasStart is still
+// false (which would silently drop SR callbacks and force one packet to
+// wall-clock PTS on a different track).
+func (st *SessionTimeline) SetSessionStartIfNotSet(t time.Time) bool {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if st.hasStart {
+		return false
+	}
+	st.sessionStart = t
+	st.hasStart = true
+	return true
+}
+
+// GetSessionStartNanos returns the session start time in Unix nanoseconds,
+// or 0 if not yet set. This is the authoritative read for callers that need
+// a stable value — reading SyncEngine.startedAt directly is racy during the
+// brief window after the winning initializeIfNeeded goroutine has set the
+// timeline but not yet published startedAt atomically.
+func (st *SessionTimeline) GetSessionStartNanos() int64 {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	if !st.hasStart {
+		return 0
+	}
+	return st.sessionStart.UnixNano()
+}
+
 // AddParticipant registers a new participant with the given participantID.
 func (st *SessionTimeline) AddParticipant(participantID string) *ParticipantClock {
 	st.mu.Lock()

--- a/pkg/synchronizer/start_gate.go
+++ b/pkg/synchronizer/start_gate.go
@@ -1,12 +1,27 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package synchronizer
 
 import (
 	"strings"
 	"time"
 
+	"github.com/pion/webrtc/v4"
+
 	"github.com/livekit/media-sdk/jitter"
 	"github.com/livekit/protocol/logger"
-	"github.com/pion/webrtc/v4"
 )
 
 // startGate is a lightweight buffer that decides when a track should be

--- a/pkg/synchronizer/start_gate.go
+++ b/pkg/synchronizer/start_gate.go
@@ -88,18 +88,37 @@ func (b *burstEstimatorGate) Push(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int
 
 	if !b.hasLast {
 		b.lastTS = pkt.Timestamp
-		b.lastArrival = pkt.ReceivedAt
+		// Sanitize zero ReceivedAt: a zero time.Time as lastArrival would
+		// make every subsequent packet's arrivalDelta = realTime - zeroEpoch
+		// ≈ 50+ years, triggering restartSequence on every packet until
+		// flushAfter expires (2 s). Use time.Now() instead, mirroring what
+		// initializeLocked does in syncenginetrack.
+		if pkt.ReceivedAt.IsZero() {
+			b.lastArrival = time.Now()
+		} else {
+			b.lastArrival = pkt.ReceivedAt
+		}
 		b.hasLast = true
 		b.buffer = append(b.buffer[:0], pkt)
 		return nil, 0, false
 	}
 
 	signedTsDelta := int32(pkt.Timestamp - b.lastTS)
-	arrivalDelta := pkt.ReceivedAt.Sub(b.lastArrival)
+	arrivalAt := pkt.ReceivedAt
+	if arrivalAt.IsZero() {
+		arrivalAt = time.Now()
+	}
+	arrivalDelta := arrivalAt.Sub(b.lastArrival)
 
 	if signedTsDelta < 0 {
-		// ignore out-of-order packets while continuing to wait for stability
-		return nil, 0, false
+		// Out-of-order packet during burst estimation: cadence inputs require
+		// monotonic timestamps, so this packet cannot contribute. Count and
+		// report the drop so the caller's metrics/logging see it (otherwise
+		// OOO packets vanish silently and logCompletion's droppedPackets
+		// undercount — a real observability hole for shallow jitter buffer
+		// configurations where pre-gate reordering is incomplete).
+		b.totalDropped++
+		return nil, 1, false
 	}
 
 	if signedTsDelta == 0 {
@@ -112,7 +131,7 @@ func (b *burstEstimatorGate) Push(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int
 	}
 
 	b.lastTS = pkt.Timestamp
-	b.lastArrival = pkt.ReceivedAt
+	b.lastArrival = arrivalAt
 
 	tsDuration := b.timestampToDuration(uint32(signedTsDelta))
 

--- a/pkg/synchronizer/syncengine.go
+++ b/pkg/synchronizer/syncengine.go
@@ -211,12 +211,15 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 	// Feed the SR to the session timeline (updates NTP estimator + OWD).
 	e.timeline.OnSenderReport(participantID, trackID, clockRate, sr.NTPTime, sr.RTPTime, now)
 
-	// Call onSR callback if set.
+	// Call onSR callback if set. If the track has been closed concurrently,
+	// drop the callback — the consumer (e.g., tempo controller) may have torn
+	// down by now.
 	st.mu.Lock()
 	onSR := st.onSR
+	closed := st.closed
 	st.mu.Unlock()
 
-	if onSR == nil {
+	if onSR == nil || closed {
 		return
 	}
 

--- a/pkg/synchronizer/syncengine.go
+++ b/pkg/synchronizer/syncengine.go
@@ -93,6 +93,12 @@ type SyncEngine struct {
 
 	startedAt atomic.Int64
 	endedAt   atomic.Int64
+	// ended is the authoritative "End() has been called" signal. It is
+	// distinct from endedAt: endedAt is the PTS-derived end timestamp (zero
+	// if End was called before any track started), whereas ended is set
+	// unconditionally on End() so post-End AddTrack can detect the sealed
+	// state even when the session never produced media.
+	ended atomic.Bool
 
 	// high-water mark for removed tracks, so End() includes their PTS
 	maxRemovedPTS time.Duration
@@ -166,9 +172,12 @@ func (e *SyncEngine) AddTrack(track TrackRemote, participantID string) TrackSync
 		st.startGate = newStartGate(clockRate, track.Kind(), nil)
 	}
 
-	if e.endedAt.Load() != 0 {
+	if e.ended.Load() {
 		// Post-End: the session is sealed. Mark the track closed so every
-		// GetPTS returns io.EOF without emitting media.
+		// GetPTS returns io.EOF without emitting media. Use the dedicated
+		// `ended` flag rather than endedAt: when End() ran with no tracks
+		// initialized yet (startedAt == 0), endedAt stays at 0 since there
+		// is no meaningful PTS-derived timestamp.
 		st.closed = true
 		st.logger.Warnw("AddTrack called after End(); returning closed track", nil)
 	}
@@ -252,18 +261,26 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 
 	now := time.Now()
 
-	// Feed the SR to the session timeline (updates NTP estimator + OWD).
-	e.timeline.OnSenderReport(participantID, trackID, clockRate, sr.NTPTime, sr.RTPTime, now)
-
-	// Call onSR callback if set. If the track has been closed concurrently,
-	// drop the callback — the consumer (e.g., tempo controller) may have torn
-	// down by now.
+	// Feed the SR to the session timeline UNDER st.mu so that a concurrent
+	// removeTrackLocked (which takes st.mu via closeLocked) cannot delete the
+	// track's NtpEstimator from pc.tracks between our lookup and our update —
+	// otherwise pc.OnSenderReport would auto-create a zombie estimator that
+	// nothing will ever clean up (it lives in pc.tracks until the participant
+	// itself is removed, which only happens when the participant's LAST
+	// track is removed).
+	//
+	// We also drop the SR entirely if the track was closed before we got
+	// here: a removed track's SRs should not influence the timeline.
 	st.mu.Lock()
+	if st.closed {
+		st.mu.Unlock()
+		return
+	}
+	e.timeline.OnSenderReport(participantID, trackID, clockRate, sr.NTPTime, sr.RTPTime, now)
 	onSR := st.onSR
-	closed := st.closed
 	st.mu.Unlock()
 
-	if onSR == nil || closed {
+	if onSR == nil {
 		return
 	}
 
@@ -302,33 +319,82 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 	onSR(drift)
 }
 
-// End signals the end of the session and sets drain ceilings on all tracks.
+// End signals the end of the session. After End() returns, all currently
+// registered tracks will return io.EOF from GetPTS for any packet whose PTS
+// would exceed the high-water mark of emissions seen so far, and any future
+// AddTrack will return an already-closed track.
+//
+// End() is safe to call multiple times: the ended flag and endedAt are stable
+// once set, and drain ceilings on already-drained tracks are idempotent.
 func (e *SyncEngine) End() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Start from the high-water mark of removed tracks.
-	maxPTS := e.maxRemovedPTS
+	if e.ended.Load() {
+		// Idempotent: second End() call has nothing to do. lastPTSAdjusted
+		// on surviving tracks cannot have advanced past the drain ceiling
+		// set by the first call (GetPTS would have returned io.EOF), so
+		// recomputing maxPTS would just yield the same value and rewriting
+		// endedAt would be redundant.
+		return
+	}
+	e.ended.Store(true)
+
+	// Acquire all per-track locks for a single atomic snapshot + drain pass.
+	// Holding every st.mu through both the max-PTS read AND the drain-ceiling
+	// write closes the TOCTOU in which a track could advance lastPTSAdjusted
+	// between the snapshot loop and the drain-set loop, emitting a packet
+	// past what endedAt promised. GetPTS is the only other st.mu holder, and
+	// it never acquires more than one st.mu at a time, so there is no
+	// deadlock risk in lock-everything order.
 	for _, st := range e.tracks {
 		st.mu.Lock()
+	}
+
+	maxPTS := e.maxRemovedPTS
+	for _, st := range e.tracks {
 		if st.lastPTSAdjusted > maxPTS {
 			maxPTS = st.lastPTSAdjusted
 		}
-		st.mu.Unlock()
 	}
 
 	startedAt := e.startedAt.Load()
 	if startedAt > 0 {
 		e.endedAt.Store(startedAt + int64(maxPTS))
-	} else {
-		e.endedAt.Store(time.Now().UnixNano())
+	}
+	// else: leave endedAt = 0. End() was called before any track started;
+	// there is no meaningful PTS-derived end timestamp. The `ended` flag
+	// above is what tells AddTrack to return closed tracks.
+
+	// Per-track disposition: tracks that have already emitted media get a
+	// drain ceiling so their in-flight packets can flush up to maxPTS; tracks
+	// that have not yet emitted are closed outright. The latter handles two
+	// distinct edge cases under one rule:
+	//
+	//   1. End() called before any track started. All hasEmitted are false,
+	//      so all tracks close — no media leaks via the post-init first
+	//      packet that would otherwise slip through `pts > maxPTS` when
+	//      maxPTS == 0.
+	//
+	//   2. End() called after some tracks started but a sibling track is
+	//      still buffered in the start gate (initialized via PrimeForStart
+	//      but not yet emitted via GetPTS). Without this rule, the sibling
+	//      track would inherit a maxPTS == 0 drain ceiling (since it never
+	//      contributed to lastPTSAdjusted) — but maxPTS gets the global max
+	//      from the active tracks, so its first packet's pts (typically
+	//      sessionOffset) could still slip through up to that global value.
+	//      Closing here prevents post-End emission from a track that never
+	//      produced media before the seal.
+	for _, st := range e.tracks {
+		if st.hasEmitted {
+			st.maxPTS = maxPTS
+			st.maxPTSSet = true
+		} else {
+			st.closeLocked()
+		}
 	}
 
-	// Set drain ceiling on all tracks.
 	for _, st := range e.tracks {
-		st.mu.Lock()
-		st.maxPTS = maxPTS
-		st.maxPTSSet = true
 		st.mu.Unlock()
 	}
 }
@@ -363,8 +429,15 @@ func (e *SyncEngine) getMediaDeadline() (time.Duration, bool) {
 
 // initializeIfNeeded sets the session start time on the first track
 // initialization and returns the resulting startedAt value alongside a
-// non-nil onStarted callback IFF this call won the CAS (and an onStarted
+// non-nil onStarted callback IFF this call won the race (and an onStarted
 // callback is configured).
+//
+// The timeline's sessionStart is established BEFORE startedAt is published
+// atomically. This ordering matters: any code path that checks
+// startedAt.Load() != 0 and then queries the timeline (e.g., OnRTCP →
+// GetSessionPTS) must not see startedAt set without the timeline also being
+// ready, or it would silently drop the SR callback / force wall-clock PTS
+// on a concurrent GetPTS that observed startedAt before timeline.hasStart.
 //
 // The caller is responsible for invoking the returned callback AFTER releasing
 // any per-track mutex it holds. Invoking the user-supplied onStarted while
@@ -373,11 +446,19 @@ func (e *SyncEngine) getMediaDeadline() (time.Duration, bool) {
 // Close on it).
 func (e *SyncEngine) initializeIfNeeded(receivedAt time.Time) (int64, func()) {
 	nano := receivedAt.UnixNano()
-	if e.startedAt.CompareAndSwap(0, nano) {
-		e.timeline.SetSessionStart(receivedAt)
+	if e.timeline.SetSessionStartIfNotSet(receivedAt) {
+		// We won. Publish startedAt only after the timeline is observably
+		// ready, so callers gated on startedAt see consistent state.
+		e.startedAt.Store(nano)
 		return nano, e.onStarted
 	}
-	return e.startedAt.Load(), nil
+	// Non-winner: another goroutine has already set the timeline, but may not
+	// yet have published e.startedAt atomically. Read from the timeline to
+	// get a stable value — reading e.startedAt.Load() here could return 0
+	// during that brief window and cause the caller's sessionOffset to be
+	// computed as receivedAt.UnixNano() (huge), permanently offsetting that
+	// track from the session timeline.
+	return e.timeline.GetSessionStartNanos(), nil
 }
 
 // hasTracksForParticipantLocked returns true if any remaining track belongs

--- a/pkg/synchronizer/syncengine.go
+++ b/pkg/synchronizer/syncengine.go
@@ -123,30 +123,58 @@ func NewSyncEngine(opts ...SyncEngineOption) *SyncEngine {
 }
 
 // AddTrack registers a new track and returns a TrackSync handle.
+//
+// If the track's SSRC or track ID collides with an existing entry (common with
+// browser/SFU renegotiation), the existing entry is closed and cleaned up
+// first — this prevents leaked tracks, missed maxRemovedPTS contributions, and
+// stale NtpEstimator state in the shared ParticipantClock.
+//
+// If End() has already been called on the engine, the returned track is
+// immediately closed so the caller's pipeline drains cleanly without emitting
+// post-end media.
 func (e *SyncEngine) AddTrack(track TrackRemote, participantID string) TrackSync {
 	ssrc := uint32(track.SSRC())
+	trackID := track.ID()
 	clockRate := track.Codec().ClockRate
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	// Defensively clean up colliding entries. The two lookups may resolve to
+	// the same track (exact re-add) or to two distinct tracks (partial reuse);
+	// removeTrackLocked deletes from both maps, so the second check naturally
+	// sees nil for the same-track case.
+	if existing := e.tracks[ssrc]; existing != nil {
+		e.removeTrackLocked(existing)
+	}
+	if existing := e.trackIDs[trackID]; existing != nil {
+		e.removeTrackLocked(existing)
+	}
+
 	// Ensure the participant exists in the timeline.
 	e.timeline.GetOrAddParticipant(participantID)
 
 	st := &syncEngineTrack{
-		engine:    e,
-		track:     track,
-		participantID:  participantID,
-		logger:    e.getTrackLogger(track),
-		converter: rtputil.NewRTPConverter(int64(clockRate)),
+		engine:        e,
+		track:         track,
+		participantID: participantID,
+		logger:        e.getTrackLogger(track),
+		converter:     rtputil.NewRTPConverter(int64(clockRate)),
 	}
 
 	if e.enableStartGate {
 		st.startGate = newStartGate(clockRate, track.Kind(), nil)
 	}
 
+	if e.endedAt.Load() != 0 {
+		// Post-End: the session is sealed. Mark the track closed so every
+		// GetPTS returns io.EOF without emitting media.
+		st.closed = true
+		st.logger.Warnw("AddTrack called after End(); returning closed track", nil)
+	}
+
 	e.tracks[ssrc] = st
-	e.trackIDs[track.ID()] = st
+	e.trackIDs[trackID] = st
 
 	return st
 }
@@ -154,36 +182,52 @@ func (e *SyncEngine) AddTrack(track TrackRemote, participantID string) TrackSync
 // RemoveTrack removes a track by track ID.
 func (e *SyncEngine) RemoveTrack(trackID string) {
 	e.mu.Lock()
+	defer e.mu.Unlock()
 	st, ok := e.trackIDs[trackID]
 	if !ok {
-		e.mu.Unlock()
 		return
 	}
+	e.removeTrackLocked(st)
+}
 
-	// Preserve removed track's PTS high-water mark so End() includes it.
+// removeTrackLocked closes a track, snapshots its final PTS into the engine's
+// high-water mark, removes it from the lookup maps, and tears down the
+// associated timeline state. Caller must hold e.mu.
+//
+// Performing all of this under e.mu (rather than dropping the lock partway as
+// the original implementation did) guarantees three properties:
+//   - No concurrent GetPTS can advance lastPTSAdjusted between the snapshot
+//     and the close (st.closed is set under st.mu inside the same critical
+//     section that reads lastPTSAdjusted).
+//   - The hasTracksForParticipantLocked → RemoveParticipant decision is made
+//     against a consistent map state, eliminating the TOCTOU window in which
+//     a concurrent AddTrack for the same participant could have its freshly
+//     inserted ParticipantClock deleted out from under it.
+//   - There is no opportunity for End() to interleave and observe a stale
+//     maxRemovedPTS.
+func (e *SyncEngine) removeTrackLocked(st *syncEngineTrack) {
 	st.mu.Lock()
-	if st.lastPTSAdjusted > e.maxRemovedPTS {
-		e.maxRemovedPTS = st.lastPTSAdjusted
-	}
+	st.closeLocked()
+	lastPTS := st.lastPTSAdjusted
+	participantID := st.participantID
+	trackID := st.track.ID()
+	ssrc := uint32(st.track.SSRC())
 	st.mu.Unlock()
 
-	ssrc := uint32(st.track.SSRC())
+	if lastPTS > e.maxRemovedPTS {
+		e.maxRemovedPTS = lastPTS
+	}
 	delete(e.tracks, ssrc)
 	delete(e.trackIDs, trackID)
-	e.mu.Unlock()
 
-	// Clean up track from participant, and remove the participant from the
-	// timeline if this was their last track.
-	participantID := st.participantID
 	if pc := e.timeline.GetParticipantClock(participantID); pc != nil {
 		pc.RemoveTrack(trackID)
 	}
-	if !e.hasTracksForParticipant(participantID) {
+	if !e.hasTracksForParticipantLocked(participantID) {
 		e.timeline.RemoveParticipant(participantID)
 	}
 
-	st.logger.Infow("track removed", "lastPTS", st.lastPTSAdjusted)
-	st.Close()
+	st.logger.Infow("track removed", "lastPTS", lastPTS)
 }
 
 // OnRTCP processes an RTCP packet, dispatching sender reports to the appropriate
@@ -317,24 +361,28 @@ func (e *SyncEngine) getMediaDeadline() (time.Duration, bool) {
 	return fn()
 }
 
-// initializeIfNeeded sets the session start time and fires the onStarted callback
-// on the first track initialization. Returns the startedAt value.
-func (e *SyncEngine) initializeIfNeeded(receivedAt time.Time) int64 {
+// initializeIfNeeded sets the session start time on the first track
+// initialization and returns the resulting startedAt value alongside a
+// non-nil onStarted callback IFF this call won the CAS (and an onStarted
+// callback is configured).
+//
+// The caller is responsible for invoking the returned callback AFTER releasing
+// any per-track mutex it holds. Invoking the user-supplied onStarted while
+// st.mu is held would expose the callback to a reentrancy deadlock if it
+// touched the originating track (e.g., calling GetPTS, LastPTSAdjusted, or
+// Close on it).
+func (e *SyncEngine) initializeIfNeeded(receivedAt time.Time) (int64, func()) {
 	nano := receivedAt.UnixNano()
 	if e.startedAt.CompareAndSwap(0, nano) {
 		e.timeline.SetSessionStart(receivedAt)
-		if e.onStarted != nil {
-			e.onStarted()
-		}
+		return nano, e.onStarted
 	}
-	return e.startedAt.Load()
+	return e.startedAt.Load(), nil
 }
 
-// hasTracksForParticipant returns true if any remaining track belongs to the
-// given participant participantID. Caller must NOT hold e.mu.
-func (e *SyncEngine) hasTracksForParticipant(participantID string) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+// hasTracksForParticipantLocked returns true if any remaining track belongs
+// to the given participantID. Caller must hold e.mu.
+func (e *SyncEngine) hasTracksForParticipantLocked(participantID string) bool {
 	for _, st := range e.tracks {
 		if st.participantID == participantID {
 			return true

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -68,8 +68,13 @@ func makeExtPacket(ts uint32, sn uint16, receivedAt time.Time) jitter.ExtPacket 
 // --- Tests ---
 
 func TestSyncEngine_ImplementsSyncInterface(t *testing.T) {
-	// Compile-time check that SyncEngine implements Sync.
+	// Compile-time check that SyncEngine implements Sync and that
+	// syncEngineTrack implements TrackSync. Without the second assertion,
+	// dropping or breaking a TrackSync method would only surface at the
+	// AddTrack return-type assignment sites — which would be reported as a
+	// confusing assignment error rather than a missing-method error.
 	var _ Sync = (*SyncEngine)(nil)
+	var _ TrackSync = (*syncEngineTrack)(nil)
 }
 
 func TestSyncEngine_FallbackToWallClockBeforeSRs(t *testing.T) {
@@ -118,8 +123,10 @@ func TestSyncEngine_TransitionsToNTPAfterSRs(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, int64(pts1), int64(pts0))
 
-	// Feed 3 sender reports to make NTP estimator ready.
-	for i := 0; i < 3; i++ {
+	// Feed 5 sender reports to make NTP estimator ready (minSamplesReady=4,
+	// so 3 was not enough — the original test was passing only because it
+	// never actually exercised the NTP path).
+	for i := 0; i < 5; i++ {
 		srTime := now.Add(time.Duration(i) * time.Second)
 		rtpTS := uint32(i) * 48000
 		ntpTime := ntpToUint64(srTime)

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -327,3 +327,96 @@ func TestSyncEngine_OnRTCP_DriftCallback_NotCalledBeforeTrackInitialized(t *test
 
 	require.False(t, fired, "onSR must not fire before any packets have initialized the track")
 }
+
+func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
+	// A single backward (reordered) packet must NOT trigger the discontinuity
+	// reset that wipes lastNtpPTS / ntpCorrection / transitionSlew / etc.
+	// Without the signed-delta guard, an unsigned uint32 subtraction would
+	// wrap a one-frame backward delta into ~24h and trip the 30s threshold.
+	engine := NewSyncEngine()
+	track := newMockAudioTrack("audio-1", 1000)
+	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	now := time.Now()
+	tr.PrimeForStart(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(0, 0, now))
+	// Build up some state.
+	for i := 1; i <= 5; i++ {
+		pkt := makeExtPacket(uint32(i)*960, uint16(i), now.Add(time.Duration(i)*20*time.Millisecond))
+		tr.GetPTS(pkt)
+	}
+
+	// Seed lastNtpPTS so we can verify it survives the reorder.
+	tr.mu.Lock()
+	tr.lastNtpPTS = 100 * time.Millisecond
+	tr.transitionSlew = 50 * time.Millisecond
+	tr.mu.Unlock()
+
+	// Feed a backward packet (one frame behind lastTS).
+	backPkt := makeExtPacket(uint32(4)*960, 6, now.Add(120*time.Millisecond))
+	_, _ = tr.GetPTS(backPkt)
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	require.Equal(t, 100*time.Millisecond, tr.lastNtpPTS, "lastNtpPTS must survive backward reorder")
+	// transitionSlew may decay slightly via the normal slew loop, but must not
+	// be wiped to zero (which is what the unsigned-wrap discontinuity reset did).
+	require.Greater(t, tr.transitionSlew, 40*time.Millisecond,
+		"transitionSlew must survive backward reorder (got %v)", tr.transitionSlew)
+}
+
+func TestSyncEngine_ForwardDiscontinuityStillResetsNTPState(t *testing.T) {
+	// Sanity check: a genuine large forward RTP jump (≥30s of media) MUST still
+	// trigger the discontinuity reset. The signed-delta fix in #8 must not
+	// disable this path.
+	engine := NewSyncEngine()
+	track := newMockAudioTrack("audio-1", 1000)
+	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	now := time.Now()
+	tr.PrimeForStart(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(960, 1, now.Add(20*time.Millisecond)))
+
+	tr.mu.Lock()
+	tr.lastNtpPTS = 100 * time.Millisecond
+	tr.transitionSlew = 50 * time.Millisecond
+	tr.mu.Unlock()
+
+	// Jump 60s of RTP forward.
+	bigJumpTS := uint32(960) + uint32(48000*60)
+	tr.GetPTS(makeExtPacket(bigJumpTS, 2, now.Add(60*time.Second)))
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	require.Equal(t, time.Duration(0), tr.lastNtpPTS, "lastNtpPTS must be reset on forward discontinuity")
+	require.Equal(t, time.Duration(0), tr.transitionSlew, "transitionSlew must be reset on forward discontinuity")
+}
+
+func TestSyncEngine_OnSR_NotCalledAfterRemoveTrack(t *testing.T) {
+	// After RemoveTrack closes the track, a subsequent SR for the same SSRC
+	// (if it slipped in via an in-flight RTCP packet) must not invoke onSR.
+	// In practice, RemoveTrack also removes the track from the SSRC map, so
+	// OnRTCP would early-return — but Close() nulls onSR as defense in depth
+	// for the snapshot-and-drop-lock race in OnRTCP.
+	engine := NewSyncEngine()
+	track := newMockAudioTrack("audio-1", 1000)
+	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	fired := false
+	tr.OnSenderReport(func(d time.Duration) { fired = true })
+
+	now := time.Now()
+	tr.PrimeForStart(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(0, 0, now))
+
+	// Close the track directly to simulate the post-snapshot race.
+	tr.Close()
+
+	tr.mu.Lock()
+	require.Nil(t, tr.onSR, "Close() must drop the SR callback")
+	require.True(t, tr.closed, "Close() must set closed=true")
+	tr.mu.Unlock()
+
+	require.False(t, fired, "no callback should have fired during Close")
+}

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -383,6 +383,9 @@ func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
 	tr.mu.Lock()
 	initialLastNtpPTS := tr.lastNtpPTS
 	initialTransitionSlew := tr.transitionSlew
+	initialLastTS := tr.lastTS
+	initialLastWallPTS := tr.lastWallPTS
+	initialLastSlewPTS := tr.lastSlewPTS
 	tr.mu.Unlock()
 	require.Greater(t, int64(initialLastNtpPTS), int64(0), "lastNtpPTS should be populated by the prime sequence")
 
@@ -400,6 +403,11 @@ func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
 	// backward packet, but must not be wiped to zero.
 	require.InDelta(t, float64(initialTransitionSlew), float64(tr.transitionSlew), float64(10*time.Millisecond),
 		"transitionSlew must survive backward reorder (initial %v, got %v)", initialTransitionSlew, tr.transitionSlew)
+	// RTP/wall/slew baselines must stay anchored to the last forward packet so
+	// the next forward packet's expected-extrapolation baselines line up.
+	require.Equal(t, initialLastTS, tr.lastTS, "lastTS must not shift backward on reorder")
+	require.Equal(t, initialLastWallPTS, tr.lastWallPTS, "lastWallPTS must not shift backward on reorder")
+	require.Equal(t, initialLastSlewPTS, tr.lastSlewPTS, "lastSlewPTS must not shift backward on reorder")
 }
 
 func TestSyncEngine_ForwardDiscontinuityStillResetsNTPState(t *testing.T) {

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -214,7 +214,7 @@ func TestSyncEngineTrack_wallClockPTSForRTP_UsesRTPDelta(t *testing.T) {
 	st.mu.Lock()
 	st.startTime = startTime
 	st.lastTS = 48000 // 1s at 48kHz
-	st.lastPTS = time.Second
+	st.lastWallPTS = time.Second
 	st.initialized = true
 	st.mu.Unlock()
 
@@ -233,7 +233,7 @@ func TestSyncEngineTrack_wallClockPTSForRTP_BackwardRTPFallsBackToWallClock(t *t
 	st.mu.Lock()
 	st.startTime = startTime
 	st.lastTS = 48000 * 100 // 100s of media already
-	st.lastPTS = 100 * time.Second
+	st.lastWallPTS = 100 * time.Second
 	st.initialized = true
 	st.mu.Unlock()
 
@@ -328,6 +328,38 @@ func TestSyncEngine_OnRTCP_DriftCallback_NotCalledBeforeTrackInitialized(t *test
 	require.False(t, fired, "onSR must not fire before any packets have initialized the track")
 }
 
+// primeNTPReady drives enough SRs and forward packets through the track to
+// leave it in a steady NTP-ready state with non-zero lastNtpPTS. The SRs are
+// fed directly to the timeline (rather than via engine.OnRTCP) so that
+// receivedAt can be controlled — using engine.OnRTCP would stamp receivedAt
+// with time.Now(), producing a large negative OWD when senderNtp is in the
+// test's synthetic future. Returns the time of the last forward packet.
+func primeNTPReady(t *testing.T, engine *SyncEngine, tr *syncEngineTrack, participantID, trackID string, now time.Time) time.Time {
+	t.Helper()
+	const clockRate = uint32(48000)
+	tr.PrimeForStart(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(0, 0, now))
+	// Feed enough SRs to make the NTP regression ready. receivedAt == srTime
+	// so the OWD estimator settles at ~0 and sessionPTS values stay positive.
+	for i := 1; i <= 5; i++ {
+		srTime := now.Add(time.Duration(i) * time.Second)
+		engine.timeline.OnSenderReport(participantID, trackID, clockRate, ntpToUint64(srTime), uint32(i)*clockRate, srTime)
+	}
+	// Process forward packets so lastNtpPTS / transitionSlew get populated via
+	// the real flow rather than direct field assignment. RTP timestamps match
+	// the SR range to keep regression extrapolation accurate.
+	lastRecv := now
+	for i := 1; i <= 5; i++ {
+		lastRecv = now.Add(time.Duration(i) * time.Second)
+		tr.GetPTS(makeExtPacket(uint32(i)*clockRate, uint16(i), lastRecv))
+	}
+	tr.mu.Lock()
+	require.True(t, tr.hasLastNtpPTS, "test setup: NTP regression should be ready after 5 SRs + 5 packets")
+	require.True(t, tr.ntpTransitioned, "test setup: ntpTransitioned should be set after first NTP-ready packet")
+	tr.mu.Unlock()
+	return lastRecv
+}
+
 func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
 	// A single backward (reordered) packet must NOT trigger the discontinuity
 	// reset that wipes lastNtpPTS / ntpCorrection / transitionSlew / etc.
@@ -338,59 +370,57 @@ func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
 	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
 
 	now := time.Now()
-	tr.PrimeForStart(makeExtPacket(0, 0, now))
-	tr.GetPTS(makeExtPacket(0, 0, now))
-	// Build up some state.
-	for i := 1; i <= 5; i++ {
-		pkt := makeExtPacket(uint32(i)*960, uint16(i), now.Add(time.Duration(i)*20*time.Millisecond))
-		tr.GetPTS(pkt)
-	}
+	lastRecv := primeNTPReady(t, engine, tr, "alice", "audio-1", now)
 
-	// Seed lastNtpPTS so we can verify it survives the reorder.
+	// Snapshot state populated by the real flow.
 	tr.mu.Lock()
-	tr.lastNtpPTS = 100 * time.Millisecond
-	tr.transitionSlew = 50 * time.Millisecond
+	initialLastNtpPTS := tr.lastNtpPTS
+	initialTransitionSlew := tr.transitionSlew
 	tr.mu.Unlock()
+	require.Greater(t, int64(initialLastNtpPTS), int64(0), "lastNtpPTS should be populated by the prime sequence")
 
-	// Feed a backward packet (one frame behind lastTS).
-	backPkt := makeExtPacket(uint32(4)*960, 6, now.Add(120*time.Millisecond))
+	// Feed a backward packet (one frame behind lastTS). NTP regression remains
+	// ready, so this should NOT trigger any clearing — neither the
+	// discontinuity reset nor the NTP-unavailable cleanup.
+	backPkt := makeExtPacket(uint32(4)*48000, 100, lastRecv.Add(20*time.Millisecond))
 	_, _ = tr.GetPTS(backPkt)
 
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
-	require.Equal(t, 100*time.Millisecond, tr.lastNtpPTS, "lastNtpPTS must survive backward reorder")
-	// transitionSlew may decay slightly via the normal slew loop, but must not
-	// be wiped to zero (which is what the unsigned-wrap discontinuity reset did).
-	require.Greater(t, tr.transitionSlew, 40*time.Millisecond,
-		"transitionSlew must survive backward reorder (got %v)", tr.transitionSlew)
+	require.Equal(t, initialLastNtpPTS, tr.lastNtpPTS, "lastNtpPTS must survive backward reorder")
+	require.True(t, tr.ntpTransitioned, "ntpTransitioned must survive backward reorder")
+	// transitionSlew may decay slightly via the normal slew loop on the
+	// backward packet, but must not be wiped to zero.
+	require.InDelta(t, float64(initialTransitionSlew), float64(tr.transitionSlew), float64(10*time.Millisecond),
+		"transitionSlew must survive backward reorder (initial %v, got %v)", initialTransitionSlew, tr.transitionSlew)
 }
 
 func TestSyncEngine_ForwardDiscontinuityStillResetsNTPState(t *testing.T) {
 	// Sanity check: a genuine large forward RTP jump (≥30s of media) MUST still
-	// trigger the discontinuity reset. The signed-delta fix in #8 must not
-	// disable this path.
+	// trigger the discontinuity reset. The signed-delta fix must not disable
+	// this path.
 	engine := NewSyncEngine()
 	track := newMockAudioTrack("audio-1", 1000)
 	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
 
 	now := time.Now()
-	tr.PrimeForStart(makeExtPacket(0, 0, now))
-	tr.GetPTS(makeExtPacket(0, 0, now))
-	tr.GetPTS(makeExtPacket(960, 1, now.Add(20*time.Millisecond)))
+	lastRecv := primeNTPReady(t, engine, tr, "alice", "audio-1", now)
 
 	tr.mu.Lock()
-	tr.lastNtpPTS = 100 * time.Millisecond
-	tr.transitionSlew = 50 * time.Millisecond
+	require.Greater(t, int64(tr.lastNtpPTS), int64(0), "lastNtpPTS should be populated before the jump")
+	lastTS := tr.lastTS
 	tr.mu.Unlock()
 
-	// Jump 60s of RTP forward.
-	bigJumpTS := uint32(960) + uint32(48000*60)
-	tr.GetPTS(makeExtPacket(bigJumpTS, 2, now.Add(60*time.Second)))
+	// Jump 60s of RTP forward — well past the 30s discontinuity threshold.
+	bigJumpTS := lastTS + uint32(48000*60)
+	tr.GetPTS(makeExtPacket(bigJumpTS, 200, lastRecv.Add(60*time.Second)))
 
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
+	require.False(t, tr.hasLastNtpPTS, "hasLastNtpPTS must be reset on forward discontinuity")
 	require.Equal(t, time.Duration(0), tr.lastNtpPTS, "lastNtpPTS must be reset on forward discontinuity")
 	require.Equal(t, time.Duration(0), tr.transitionSlew, "transitionSlew must be reset on forward discontinuity")
+	require.False(t, tr.ntpTransitioned, "ntpTransitioned must be reset on forward discontinuity")
 }
 
 func TestSyncEngine_OnSR_NotCalledAfterRemoveTrack(t *testing.T) {

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -67,9 +67,10 @@ type syncEngineTrack struct {
 	startTime       time.Time
 	sessionOffset   time.Duration // offset from session start to this track's start
 	lastTS          uint32
-	lastPTS         time.Duration
-	lastPTSAdjusted time.Duration
-	initialized     bool
+	lastWallPTS     time.Duration // last pure wall-clock-derived PTS, independent of NTP corrections; used as the baseline for wallClockPTSForRTPLocked
+	lastPTSAdjusted time.Duration // last emitted PTS (post-NTP-correction, post-slew, post-monotonicity)
+	initialized     bool          // initializeLocked has run (startTime/sessionOffset/lastTS are set)
+	hasEmitted      bool          // GetPTS has returned at least one PTS; used to distinguish "no prior emission" from "prior emission was zero-valued"
 	closed          bool
 
 	// NTP transition and smoothing
@@ -77,6 +78,7 @@ type syncEngineTrack struct {
 	transitionSlew  time.Duration
 	lastSlewPTS     time.Duration // PTS at which slew was last updated
 	lastNtpPTS      time.Duration // last raw NTP PTS (before corrections), for jump detection
+	hasLastNtpPTS   bool          // lastNtpPTS holds a baseline from the current NTP regression (cleared when NTP becomes unavailable or on RTP discontinuity)
 	ntpCorrection   time.Duration // smoothing correction for SR-induced NTP jumps
 
 	// pipeline time feedback
@@ -92,12 +94,21 @@ type syncEngineTrack struct {
 // PrimeForStart implements TrackSync. It buffers packets through the optional
 // start gate and initializes the track on the first valid packet.
 func (st *syncEngineTrack) PrimeForStart(pkt jitter.ExtPacket) ([]jitter.ExtPacket, int, bool) {
+	// onStarted (if any) is invoked after st.mu is released to avoid reentrancy
+	// deadlock; see initializeIfNeeded for the rationale.
+	var onStarted func()
+	defer func() {
+		if onStarted != nil {
+			onStarted()
+		}
+	}()
+
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
 	if st.initialized || st.startGate == nil {
 		if !st.initialized {
-			st.initializeLocked(pkt)
+			onStarted = st.initializeLocked(pkt)
 		}
 		return []jitter.ExtPacket{pkt}, 0, true
 	}
@@ -112,15 +123,17 @@ func (st *syncEngineTrack) PrimeForStart(pkt jitter.ExtPacket) ([]jitter.ExtPack
 	}
 
 	if !st.initialized {
-		st.initializeLocked(ready[0])
+		onStarted = st.initializeLocked(ready[0])
 	}
 
 	return ready, dropped, true
 }
 
 // initializeLocked sets the track's start time and registers with the engine.
-// Caller must hold st.mu.
-func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) {
+// Caller must hold st.mu. Returns a non-nil onStarted callback IFF this call
+// was the first track initialization for the engine; the caller MUST invoke
+// the returned callback only after releasing st.mu.
+func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) func() {
 	receivedAt := pkt.ReceivedAt
 	if receivedAt.IsZero() {
 		receivedAt = time.Now()
@@ -132,7 +145,7 @@ func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) {
 	st.initialized = true
 
 	// Initialize the engine's session start time.
-	sessionStart := st.engine.initializeIfNeeded(receivedAt)
+	sessionStart, onStarted := st.engine.initializeIfNeeded(receivedAt)
 	st.sessionOffset = time.Duration(receivedAt.UnixNano() - sessionStart)
 
 	st.logger.Infow("initialized track",
@@ -140,11 +153,21 @@ func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) {
 		"sessionOffset", st.sessionOffset,
 		"rtpTS", pkt.Timestamp,
 	)
+	return onStarted
 }
 
 // GetPTS implements TrackSync. It computes the presentation timestamp for a packet
 // using the NTP-grounded timeline when available, falling back to wall clock otherwise.
 func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
+	// onStarted (if any) is invoked after st.mu is released to avoid reentrancy
+	// deadlock; see initializeIfNeeded for the rationale.
+	var onStarted func()
+	defer func() {
+		if onStarted != nil {
+			onStarted()
+		}
+	}()
+
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
@@ -153,13 +176,15 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 	}
 
 	if !st.initialized {
-		st.initializeLocked(pkt)
+		onStarted = st.initializeLocked(pkt)
 	}
 
 	ts := pkt.Timestamp
 
 	// Same RTP timestamp as last packet: return same PTS (same frame).
-	if ts == st.lastTS && st.lastPTSAdjusted > 0 {
+	// hasEmitted distinguishes "we've previously emitted for this lastTS" from
+	// the first-call case where lastTS was just set by initializeLocked.
+	if st.hasEmitted && ts == st.lastTS {
 		return st.lastPTSAdjusted, nil
 	}
 
@@ -192,20 +217,60 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 	rtpDelta := ts - st.lastTS
 	rtpDeltaDuration := st.converter.ToDuration(rtpDelta)
 
-	if st.lastTS != 0 && signedRTPDelta > 0 && rtpDeltaDuration >= 30*time.Second {
-		// Discontinuity: stream restart, SSRC reuse with new RTP offset, or massive gap.
+	// ntpNowReady tracks whether the NTP regression is the source for THIS
+	// packet's PTS. This is the unified gate for jump detection, transition
+	// computation, and lastNtpPTS tracking — and the trigger for clearing
+	// smoothing state when NTP goes away. Anything that invalidates the
+	// regression mid-session (estimator outlier rebuild via the timeline,
+	// ResetTrack from a discontinuity below, useWallClockOnly mode) flows
+	// through this single gate.
+	ntpNowReady := ntpErr == nil && !useWallClockOnly
+
+	// signedRTPDelta > 0 implicitly skips the first call (delta is 0 there because
+	// initializeLocked set lastTS to this packet's ts) and any backward reorders.
+	discontinuity := signedRTPDelta > 0 && rtpDeltaDuration >= 30*time.Second
+	if discontinuity {
+		// Stream restart, SSRC reuse with new RTP offset, or massive gap.
+		// Reset the timeline-side regression. rawNtpPTS we already have was
+		// computed against the pre-reset regression; treat NTP as unavailable
+		// for this packet so we fall back to wallPTS and clear smoothing state
+		// in the unified branch below.
 		st.engine.timeline.ResetTrack(st.participantID, st.track.ID())
-		st.lastNtpPTS = 0
-		st.ntpCorrection = 0
-		st.ntpTransitioned = false
-		st.transitionSlew = 0
-		st.lastSlewPTS = 0
+		ntpNowReady = false
+		// NTP smoothing state (lastNtpPTS, transitionSlew, ntpCorrection) is
+		// cleared by the !ntpNowReady branch below. lastSlewPTS does not need
+		// to be cleared: the end-of-iter update overwrites it with the
+		// pre-slew PTS for this packet, providing a valid baseline for the
+		// next iteration's slewPTSDelta.
 		st.logger.Warnw("stream discontinuity detected, resetting NTP state", nil,
 			"rtpDelta", rtpDelta,
 			"rtpDeltaDuration", rtpDeltaDuration,
 		)
-	} else if !useWallClockOnly && ntpErr == nil && st.lastNtpPTS > 0 && signedRTPDelta > 0 {
-		// Detect regression jumps: compare raw NTP PTS against expected.
+	}
+
+	if !ntpNowReady {
+		// NTP is not the source for this packet — either it was never ready,
+		// the estimator was rebuilt internally (persistent outliers in the
+		// timeline's NtpEstimator), the discontinuity branch above just reset
+		// it, or we're in audio-drift-compensated mode. Forget any in-flight
+		// NTP smoothing state so that a future NTP-ready packet triggers a
+		// fresh transition against whatever regression is current then.
+		//
+		// Without this clear, ntpTransitioned would stay true from the prior
+		// NTP session, the transition correction would never be recomputed
+		// against the new regression, and lastNtpPTS would feed a stale
+		// expectation into the jump-detection branch on the very first
+		// post-rebuild packet — producing a large bogus ntpCorrection.
+		if st.ntpTransitioned || st.hasLastNtpPTS || st.ntpCorrection != 0 || st.transitionSlew != 0 {
+			st.ntpTransitioned = false
+			st.transitionSlew = 0
+			st.ntpCorrection = 0
+			st.hasLastNtpPTS = false
+			st.lastNtpPTS = 0
+		}
+	} else if st.hasLastNtpPTS && signedRTPDelta > 0 {
+		// Steady NTP: detect regression jumps by comparing raw NTP PTS against
+		// the previous packet's raw value extrapolated by RTP delta.
 		expectedRawNtpPTS := st.lastNtpPTS + rtpDeltaDuration
 		jump := rawNtpPTS - expectedRawNtpPTS
 		if jump > deadbandThreshold || jump < -deadbandThreshold {
@@ -216,15 +281,24 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 			)
 		}
 	}
-	// Only track lastNtpPTS for forward packets — using a backward sample
-	// would corrupt the next iteration's expected-jump baseline.
-	if ntpErr == nil && (st.lastTS == 0 || signedRTPDelta > 0) {
+
+	// Track lastNtpPTS for forward (or first-NTP-packet) updates — using a
+	// backward sample would corrupt the next iteration's expected-jump
+	// baseline. signedRTPDelta >= 0 covers the first call (delta = 0, by way
+	// of initializeLocked setting lastTS to this packet's ts) and forward
+	// packets. hasLastNtpPTS is the canonical "have we recorded a baseline"
+	// flag; lastNtpPTS being zero is also a valid raw NTP value at session
+	// start so we never rely on it as a sentinel.
+	if ntpNowReady && signedRTPDelta >= 0 {
 		st.lastNtpPTS = rawNtpPTS
+		st.hasLastNtpPTS = true
 	}
 
-	// Step 3: Compute final PTS with corrections.
+	// Step 3: Compute final PTS with corrections. ntpNowReady (set above) is
+	// the unified gate — covers ntpErr, useWallClockOnly, AND the discontinuity
+	// reset that just invalidated rawNtpPTS by resetting the regression.
 	var pts time.Duration
-	if ntpErr != nil || useWallClockOnly {
+	if !ntpNowReady {
 		pts = wallPTS
 	} else {
 		// Apply NTP jump correction.
@@ -254,9 +328,19 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		}
 	}
 
+	// Capture the pre-slew, pre-force-correction, pre-monotonicity PTS as the
+	// next iteration's slew baseline. This is what tracks "media-time
+	// progression" — using the post-correction emitted PTS instead (the
+	// pre-#911 author's original choice and a regression in #911) freezes the
+	// decay clock whenever a force-correction jump or monotonicity bump shifts
+	// the output away from raw media time: slewPTSDelta collapses to ~1ms
+	// (monotonicity step) per packet, dropping the decay step from the
+	// intended 100µs to ~5µs, and stalling drain for tens of minutes.
+	preSlewPTS := pts
+
 	// Compute PTS delta for slew rate calculations.
 	var slewPTSDelta time.Duration
-	if st.lastSlewPTS > 0 {
+	if st.hasEmitted {
 		slewPTSDelta = pts - st.lastSlewPTS
 	}
 
@@ -318,8 +402,10 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		}
 	}
 
-	// Step 7: Enforce monotonicity.
-	if pts < st.lastPTSAdjusted+time.Millisecond && st.lastPTSAdjusted > 0 {
+	// Step 7: Enforce monotonicity. hasEmitted distinguishes "we have a prior
+	// emitted PTS to be greater than" from the first-emission case where
+	// lastPTSAdjusted is zero by default.
+	if st.hasEmitted && pts < st.lastPTSAdjusted+time.Millisecond {
 		pts = st.lastPTSAdjusted + time.Millisecond
 	}
 
@@ -328,27 +414,25 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		return 0, io.EOF
 	}
 
-	// Update state. lastSlewPTS records the final emitted PTS so the next
-	// packet's slewPTSDelta reflects the true PTS-space progression (including
-	// any force-correct jump and monotonicity bump applied above).
+	// Update state. lastWallPTS captures the pre-adjustment wall-clock-derived
+	// PTS for this packet so that wallClockPTSForRTPLocked has an NTP-independent
+	// baseline for the next packet's RTP-delta extrapolation. lastSlewPTS holds
+	// the pre-slew/pre-force-correction PTS (captured as preSlewPTS above) so
+	// the next iteration's slewPTSDelta tracks media-time progression rather
+	// than output-space movement — see preSlewPTS comment for why.
 	st.lastTS = ts
-	st.lastPTS = pts
+	st.lastWallPTS = wallPTS
 	st.lastPTSAdjusted = pts
-	st.lastSlewPTS = pts
+	st.lastSlewPTS = preSlewPTS
+	st.hasEmitted = true
 
 	return pts, nil
 }
 
 // wallClockPTS computes a PTS based on wall-clock timing and RTP deltas.
+// Independent of NTP corrections — used as a sanity reference for NTP-derived PTS.
 func (st *syncEngineTrack) wallClockPTS(pkt jitter.ExtPacket) time.Duration {
-	ts := pkt.Timestamp
-
-	// Same RTP timestamp as last packet: same frame.
-	if st.lastTS == ts && st.lastPTS > 0 {
-		return st.lastPTS
-	}
-
-	return st.wallClockPTSForRTPLocked(ts, pkt.ReceivedAt)
+	return st.wallClockPTSForRTPLocked(pkt.Timestamp, pkt.ReceivedAt)
 }
 
 // wallClockPTSForRTP computes the wall-clock-grounded PTS for the given RTP
@@ -370,12 +454,13 @@ func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.T
 	// Wall-clock elapsed since this track started, plus session offset
 	wallElapsed := receivedAt.Sub(st.startTime) + st.sessionOffset
 
-	// If we have a previous timestamp, use RTP delta for more precision.
+	// If we have processed at least one packet, use RTP delta from the previous
+	// pure-wall-clock baseline for more precision (immune to receivedAt jitter).
 	// uint32 subtraction wraps for backward RTP timestamps; the sanity check
 	// below catches the resulting huge positive delta and falls back to wall clock.
-	if st.lastPTS > 0 {
+	if st.initialized {
 		rtpDelta := ts - st.lastTS
-		rtpDerived := st.lastPTS + st.converter.ToDuration(rtpDelta)
+		rtpDerived := st.lastWallPTS + st.converter.ToDuration(rtpDelta)
 
 		// Sanity check: if RTP-derived PTS diverges from wall-clock by > 5s, use wall clock.
 		diff := rtpDerived - wallElapsed
@@ -412,6 +497,14 @@ func (st *syncEngineTrack) LastPTSAdjusted() time.Duration {
 func (st *syncEngineTrack) Close() {
 	st.mu.Lock()
 	defer st.mu.Unlock()
+	st.closeLocked()
+}
+
+// closeLocked is the lock-held implementation of Close. Caller must hold st.mu.
+// Used by SyncEngine.removeTrackLocked to inline the close action within the
+// same critical section that snapshots lastPTSAdjusted, eliminating the race
+// window between snapshot and close.
+func (st *syncEngineTrack) closeLocked() {
 	st.closed = true
 	// Drop the SR callback so any in-flight OnRTCP that has already snapshotted
 	// the track but not yet read onSR sees nil and skips the callback.

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -182,10 +182,17 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 
 	// Step 2: Detect discontinuities and NTP regression jumps on RAW NTP PTS.
 	// This operates before any corrections to avoid feedback loops.
+	//
+	// Signed delta distinguishes forward gaps from backward (reordered) packets.
+	// Unsigned uint32 subtraction would wrap a one-frame backward delta into
+	// ~24 hours, falsely triggering the discontinuity branch and wiping all
+	// NTP state. The jitter buffer should normally hand us in-order packets,
+	// but defense-in-depth is cheap.
+	signedRTPDelta := int32(ts - st.lastTS)
 	rtpDelta := ts - st.lastTS
 	rtpDeltaDuration := st.converter.ToDuration(rtpDelta)
 
-	if st.lastTS != 0 && rtpDeltaDuration >= 30*time.Second {
+	if st.lastTS != 0 && signedRTPDelta > 0 && rtpDeltaDuration >= 30*time.Second {
 		// Discontinuity: stream restart, SSRC reuse with new RTP offset, or massive gap.
 		st.engine.timeline.ResetTrack(st.participantID, st.track.ID())
 		st.lastNtpPTS = 0
@@ -197,7 +204,7 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 			"rtpDelta", rtpDelta,
 			"rtpDeltaDuration", rtpDeltaDuration,
 		)
-	} else if !useWallClockOnly && ntpErr == nil && st.lastNtpPTS > 0 && rtpDelta > 0 {
+	} else if !useWallClockOnly && ntpErr == nil && st.lastNtpPTS > 0 && signedRTPDelta > 0 {
 		// Detect regression jumps: compare raw NTP PTS against expected.
 		expectedRawNtpPTS := st.lastNtpPTS + rtpDeltaDuration
 		jump := rawNtpPTS - expectedRawNtpPTS
@@ -209,8 +216,10 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 			)
 		}
 	}
-	if ntpErr == nil {
-		st.lastNtpPTS = rawNtpPTS // Always track raw NTP PTS, never corrected
+	// Only track lastNtpPTS for forward packets — using a backward sample
+	// would corrupt the next iteration's expected-jump baseline.
+	if ntpErr == nil && (st.lastTS == 0 || signedRTPDelta > 0) {
+		st.lastNtpPTS = rawNtpPTS
 	}
 
 	// Step 3: Compute final PTS with corrections.
@@ -289,8 +298,6 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		}
 	}
 
-	st.lastSlewPTS = pts
-
 	// Step 6: Pipeline time feedback — if the track has fallen behind the
 	// pipeline's deadline for too long, force-correct PTS forward.
 	if deadline, ok := st.engine.getMediaDeadline(); ok && st.engine.maxMediaRunningTimeDelay > 0 {
@@ -321,10 +328,13 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		return 0, io.EOF
 	}
 
-	// Update state.
+	// Update state. lastSlewPTS records the final emitted PTS so the next
+	// packet's slewPTSDelta reflects the true PTS-space progression (including
+	// any force-correct jump and monotonicity bump applied above).
 	st.lastTS = ts
-	st.lastPTS = pts // the raw PTS before adjustment (for wall clock computation)
+	st.lastPTS = pts
 	st.lastPTSAdjusted = pts
+	st.lastSlewPTS = pts
 
 	return pts, nil
 }
@@ -403,4 +413,7 @@ func (st *syncEngineTrack) Close() {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	st.closed = true
+	// Drop the SR callback so any in-flight OnRTCP that has already snapshotted
+	// the track but not yet read onSR sees nil and skips the callback.
+	st.onSR = nil
 }

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -106,6 +106,14 @@ func (st *syncEngineTrack) PrimeForStart(pkt jitter.ExtPacket) ([]jitter.ExtPack
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
+	if st.closed {
+		// Track was closed (either via Close, removeTrackLocked, or post-End
+		// AddTrack). Skip initialization entirely — initializeLocked would
+		// otherwise spuriously fire onStarted for a track that will only
+		// ever return io.EOF from GetPTS. Signal done with no packets.
+		return nil, 0, true
+	}
+
 	if st.initialized || st.startGate == nil {
 		if !st.initialized {
 			onStarted = st.initializeLocked(pkt)
@@ -147,6 +155,13 @@ func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) func() {
 	// Initialize the engine's session start time.
 	sessionStart, onStarted := st.engine.initializeIfNeeded(receivedAt)
 	st.sessionOffset = time.Duration(receivedAt.UnixNano() - sessionStart)
+	// Seed lastWallPTS to sessionOffset so wallClockPTSForRTPLocked returns
+	// sessionOffset (not 0) for the first packet's RTP-delta extrapolation.
+	// Without this, late-joining tracks would have lastWallPTS=0 and emit
+	// wallPTS starting at 0 instead of sessionOffset, then the NTP trust
+	// threshold clamp (500ms) would lock pts to the wrong wallPTS for any
+	// sessionOffset between ~20ms and 5s (the sanity-fallback range).
+	st.lastWallPTS = st.sessionOffset
 
 	st.logger.Infow("initialized track",
 		"startTime", st.startTime,
@@ -305,6 +320,7 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		pts = rawNtpPTS + st.ntpCorrection
 
 		// Clamp corrected PTS to within trust threshold of wall clock.
+		clamped := false
 		diff := pts - wallPTS
 		if diff > ntpTrustThreshold || diff < -ntpTrustThreshold {
 			st.logger.Warnw("NTP PTS exceeds trust threshold, clamping to wall clock", nil,
@@ -314,10 +330,17 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 				"diff", diff,
 			)
 			pts = wallPTS
+			clamped = true
 		}
 
-		// On first successful NTP PTS, compute transition correction.
-		if !st.ntpTransitioned {
+		// On first successful NTP PTS that is NOT clamped, compute the
+		// transition correction. If clamped, we leave ntpTransitioned=false
+		// so a future un-clamped packet can establish the transition fresh.
+		// Setting ntpTransitioned=true here on a clamp would compute
+		// transitionSlew = wallPTS - wallPTS = 0 and lock that in — when
+		// rawNtpPTS later converges back within the trust threshold, pts
+		// would jump by up to ntpTrustThreshold with no slew to absorb it.
+		if !clamped && !st.ntpTransitioned {
 			st.transitionSlew = wallPTS - pts
 			st.ntpTransitioned = true
 			st.logger.Infow("NTP transition",
@@ -409,7 +432,7 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		pts = st.lastPTSAdjusted + time.Millisecond
 	}
 
-	// Step 7: Enforce drain ceiling.
+	// Step 8: Enforce drain ceiling.
 	if st.maxPTSSet && pts > st.maxPTS {
 		return 0, io.EOF
 	}
@@ -451,6 +474,17 @@ func (st *syncEngineTrack) wallClockPTSForRTP(ts uint32, receivedAt time.Time) (
 // wallClockPTSForRTPLocked is the lock-held implementation of wall-clock PTS
 // computation. Caller must hold st.mu.
 func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.Time) time.Duration {
+	// Defense in depth: if receivedAt is the zero time.Time, wallElapsed
+	// below would be a ~63-billion-second negative duration, the sanity
+	// threshold would reject rtpDerived, and the function would return 0
+	// regardless of sessionOffset — locking the trust-threshold clamp onto
+	// a bogus baseline. initializeLocked already substitutes time.Now() for
+	// zero ReceivedAt on the first packet; do the same here in case a later
+	// caller (e.g., OnRTCP using sr.RTPTime + an unset receivedAt) misses it.
+	if receivedAt.IsZero() {
+		receivedAt = time.Now()
+	}
+
 	// Wall-clock elapsed since this track started, plus session offset
 	wallElapsed := receivedAt.Sub(st.startTime) + st.sessionOffset
 
@@ -504,9 +538,19 @@ func (st *syncEngineTrack) Close() {
 // Used by SyncEngine.removeTrackLocked to inline the close action within the
 // same critical section that snapshots lastPTSAdjusted, eliminating the race
 // window between snapshot and close.
+//
+// Closing only stops FUTURE OnRTCP invocations (which check st.closed before
+// the timeline call). An OnRTCP that has already acquired st.mu and read
+// st.onSR into a local before closeLocked can run will still invoke that
+// captured callback once after close — st.mu serializes the two but the
+// callback function pointer is already copied. Consumers must therefore
+// tolerate one final SR callback per RemoveTrack/Close. Tightening this
+// would require holding st.mu across the user-supplied callback, which is
+// an unacceptable constraint on what the callback may do.
 func (st *syncEngineTrack) closeLocked() {
 	st.closed = true
-	// Drop the SR callback so any in-flight OnRTCP that has already snapshotted
-	// the track but not yet read onSR sees nil and skips the callback.
+	// Clear the field too: OnRTCP invocations that arrive AFTER close and
+	// somehow pass the closed check would see nil. Also helps GC release
+	// any state captured by the callback closure.
 	st.onSR = nil
 }

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -443,10 +443,21 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 	// the pre-slew/pre-force-correction PTS (captured as preSlewPTS above) so
 	// the next iteration's slewPTSDelta tracks media-time progression rather
 	// than output-space movement — see preSlewPTS comment for why.
-	st.lastTS = ts
-	st.lastWallPTS = wallPTS
+	//
+	// Anchor lastTS / lastWallPTS / lastSlewPTS on forward (signedRTPDelta >= 0)
+	// progression only — matches the lastNtpPTS guard above. A backward
+	// (reordered) packet would otherwise leave the next iteration's
+	// expectedRawNtpPTS (uses lastNtpPTS + (ts - lastTS) extrapolation) reading
+	// from mismatched baselines, and would feed a large positive slewPTSDelta
+	// into the decay loop on the next forward packet — burning slew far faster
+	// than intended. lastPTSAdjusted updates unconditionally so monotonicity
+	// always sees the most recently emitted PTS.
+	if signedRTPDelta >= 0 {
+		st.lastTS = ts
+		st.lastWallPTS = wallPTS
+		st.lastSlewPTS = preSlewPTS
+	}
 	st.lastPTSAdjusted = pts
-	st.lastSlewPTS = preSlewPTS
 	st.hasEmitted = true
 
 	return pts, nil


### PR DESCRIPTION
- fixes NTP estimator freezing forever after a sender clock step (now self-heals after 5 consecutive outliers; also floors residStd so float-precision zeros don't disable outlier detection)
- fixes backward RTP timestamps wiping NTP state (was unsigned-wrapping into a 24h delta and tripping the 30s discontinuity reset)
- fixes onSR firing after RemoveTrack
- fixes lastSlewPTS recording the pre-force-correct / pre-monotonicity PTS instead of the actually-emitted PTS