### PR TITLE
Add support for IPv4/IPv6 selection

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -398,6 +398,7 @@ func (e *RTCEngine) createPublisherPCLocked(configuration webrtc.Configuration) 
 		OnRTTUpdate:                e.setRTT,
 		IsSender:                   true,
 		DTLSEllipticCurves:         e.connParams.DTLSEllipticCurves,
+		NetworkTypes:               e.connParams.NetworkTypes,
 	}); err != nil {
 		return err
 	}
@@ -508,6 +509,7 @@ func (e *RTCEngine) createSubscriberPCLocked(configuration webrtc.Configuration)
 		Interceptors:               e.connParams.Interceptors,
 		IncludeDefaultInterceptors: e.connParams.IncludeDefaultInterceptors,
 		DTLSEllipticCurves:         e.connParams.DTLSEllipticCurves,
+		NetworkTypes:               e.connParams.NetworkTypes,
 	}); err != nil {
 		return err
 	}

--- a/room.go
+++ b/room.go
@@ -229,6 +229,16 @@ func WithDTLSEllipticCurves(curves ...dtlsElliptic.Curve) ConnectOption {
 	}
 }
 
+// WithNetworkTypes restricts ICE candidate gathering to the specified network types.
+// For example, to force IPv6-only ICE candidates:
+//
+//	lksdk.WithNetworkTypes([]webrtc.NetworkType{webrtc.NetworkTypeUDP6, webrtc.NetworkTypeTCP6})
+func WithNetworkTypes(types []webrtc.NetworkType) ConnectOption {
+	return func(p *connParams) {
+		p.NetworkTypes = types
+	}
+}
+
 func WithLogger(l protoLogger.Logger) ConnectOption {
 	return func(p *connParams) {
 		p.Logger = l

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -97,6 +97,8 @@ type ConnectParams struct {
 
 	DTLSEllipticCurves []dtlsElliptic.Curve // FIPS 140: override default DTLS curves
 
+	NetworkTypes []webrtc.NetworkType
+
 	// DataEncryptionKeyProvider enables data channel E2EE when set.
 	DataEncryptionKeyProvider e2eetypes.KeyProvider
 

--- a/transport.go
+++ b/transport.go
@@ -81,6 +81,7 @@ type PCTransportParams struct {
 	OnRTTUpdate                func(rtt uint32)
 	IsSender                   bool
 	DTLSEllipticCurves         []dtlsElliptic.Curve
+	NetworkTypes               []webrtc.NetworkType
 }
 
 func (t *PCTransport) registerDefaultInterceptors(params PCTransportParams, i *interceptor.Registry) error {
@@ -214,6 +215,9 @@ func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
 		se.SetDTLSEllipticCurves(params.DTLSEllipticCurves...)
 	}
 	se.SetDTLSRetransmissionInterval(dtlsRetransmissionInterval)
+	if len(params.NetworkTypes) > 0 {
+		se.SetNetworkTypes(params.NetworkTypes)
+	}
 	se.SetICETimeouts(iceDisconnectedTimeout, iceFailedTimeout, iceKeepaliveInterval)
 	lf := pionlogger.NewLoggerFactory(logger)
 	if lf != nil {


### PR DESCRIPTION
Preliminary draft, to expose options to explicitly select IP protocol version via webrtc.NetworkType.