### PR TITLE
Close connections before retrying a different URL.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -269,6 +269,7 @@ func (e *RTCEngine) JoinContext(
 	}
 
 	if err = e.waitUntilConnected(); err != nil {
+		e.cleanupConnection()
 		return false, err
 	}
 
@@ -879,7 +880,7 @@ func (e *RTCEngine) resumeConnection() error {
 	return nil
 }
 
-func (e *RTCEngine) restartConnection() error {
+func (e *RTCEngine) cleanupConnection() {
 	if e.signalTransport.IsStarted() {
 		// TODO: special reason for reconnect?
 		e.SendLeaveWithReason(livekit.DisconnectReason_UNKNOWN_REASON)
@@ -887,6 +888,10 @@ func (e *RTCEngine) restartConnection() error {
 	e.signalTransport.Close()
 
 	e.closePeerConnections()
+}
+
+func (e *RTCEngine) restartConnection() error {
+	e.cleanupConnection()
 
 	_, err := e.JoinContext(context.TODO(), e.url, e.token.Load(), e.connParams, nil)
 	return err


### PR DESCRIPTION
With multiple retries to connect (including region fallback), the first attempt timed out connecting peer connection, but did not close the peer connections or the signalling channel.

On a subsequent attempt, it connected to a different region and immediately declared connected. Guessing the previous region finished connecting the peer connection just after the timeout.

Anyhow, I think what happened is that the previous signal connection read loop hit an error after the new region connection started. So, that close the underlying websocket. And that underlying websocket is pointing at the new region. So, it looked like the client closed the signalling websocket immediately after start when looking at it from server side.

Fix by closing the connections on a join failure so that it is not carried over state.