### PR TITLE
Add helpers for registering JSON and protobuf RPCs.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1010,28 +1010,24 @@ func (e *RTCEngine) publishDataPacketLossy(pck *livekit.DataPacket) error {
 }
 
 // TODO: adjust RPC methods to return error on publishDataPacket failure
-func (e *RTCEngine) publishRpcResponse(destinationIdentity, requestId string, payload *string, err *RpcError) error {
+func (e *RTCEngine) publishRpcResponse(destinationIdentity, requestId string, payload []byte, err *RpcError) error {
+	resp := &livekit.DataPacket_RpcResponse{
+		RpcResponse: &livekit.RpcResponse{
+			RequestId: requestId,
+		},
+	}
 	packet := &livekit.DataPacket{
 		DestinationIdentities: []string{destinationIdentity},
-		Value: &livekit.DataPacket_RpcResponse{
-			RpcResponse: &livekit.RpcResponse{
-				RequestId: requestId,
-			},
-		},
+		Value:                 resp,
 	}
 
 	if err != nil {
-		packet.Value.(*livekit.DataPacket_RpcResponse).RpcResponse.Value = &livekit.RpcResponse_Error{
+		resp.RpcResponse.Value = &livekit.RpcResponse_Error{
 			Error: err.toProto(),
 		}
 	} else {
-		if payload == nil {
-			emptyStr := ""
-			payload = &emptyStr
-		}
-
-		packet.Value.(*livekit.DataPacket_RpcResponse).RpcResponse.Value = &livekit.RpcResponse_Payload{
-			Payload: *payload,
+		resp.RpcResponse.Value = &livekit.RpcResponse_Payload{
+			Payload: string(payload),
 		}
 	}
 

--- a/room.go
+++ b/room.go
@@ -17,6 +17,7 @@ package lksdk
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -947,7 +948,7 @@ func (r *Room) completePublishWithJoin(ctx context.Context, trackPubs []*trackPu
 	return g.Wait()
 }
 
-// Establishes the participant as a receiver for calls of the specified RPC method.
+// RegisterRpcCtxMethod establishes the participant as a receiver for calls of the specified RPC method.
 // Will overwrite any existing callback for the same method.
 //
 //   - @param method - The name of the indicated RPC method
@@ -970,11 +971,27 @@ func (r *Room) completePublishWithJoin(ctx context.Context, trackPubs []*trackPu
 // You may throw errors of type `RpcError` with a string `message` in the handler,
 // and they will be received on the caller's side with the message intact.
 // Other errors thrown in your handler will not be transmitted as-is, and will instead arrive to the caller as `1500` ("Application Error").
-func (r *Room) RegisterRpcMethod(method string, handler RpcHandlerFunc) error {
+func (r *Room) RegisterRpcCtxMethod(method string, handler RpcHandlerCtxFunc) error {
 	if _, loaded := r.rpcHandlers.LoadOrStore(method, handler); loaded {
 		return fmt.Errorf("rpc handler already registered for method: %s, unregisterRpcMethod before trying to register again", method)
 	}
 	return nil
+}
+
+func (r *Room) RegisterRpcMethod(method string, handler RpcHandlerFunc) error {
+	return r.RegisterRpcCtxMethod(method, func(ctx context.Context, data []byte) ([]byte, error) {
+		req := RpcInvocationData{Payload: string(data)}
+		if deadline, ok := ctx.Deadline(); ok && !deadline.IsZero() {
+			req.ResponseTimeout = time.Until(deadline)
+		}
+		if meta := RPCMetadataFromContext(ctx); meta != nil {
+			req.RequestID = meta.RequestID
+			req.CallerIdentity = meta.CallerIdentity
+			req.ResponseTimeout = meta.ResponseTimeout
+		}
+		resp, err := handler(req)
+		return []byte(resp), err
+	})
 }
 
 // UnregisterRpcMethod unregisters a previously registered RPC method.
@@ -1493,41 +1510,51 @@ func (r *Room) OnStreamTrailer(streamTrailer *livekit.DataStream_Trailer) {
 
 func (r *Room) OnRpcRequest(callerIdentity, requestId, method, payload string, responseTimeout time.Duration, version uint32) {
 	r.engine.publishRpcAck(callerIdentity, requestId)
+	returnError := func(e *RpcError) {
+		r.engine.publishRpcResponse(callerIdentity, requestId, nil, e)
+	}
 
 	if version != 1 {
-		r.engine.publishRpcResponse(callerIdentity, requestId, nil, rpcErrorFromBuiltInCodes(RpcUnsupportedVersion, nil))
+		returnError(rpcErrorFromBuiltInCodes(RpcUnsupportedVersion, nil))
 		return
 	}
 
 	handler, ok := r.rpcHandlers.Load(method)
 	if !ok {
-		r.engine.publishRpcResponse(callerIdentity, requestId, nil, rpcErrorFromBuiltInCodes(RpcUnsupportedMethod, nil))
+		returnError(rpcErrorFromBuiltInCodes(RpcUnsupportedMethod, nil))
 		return
 	}
-
-	response, err := handler.(RpcHandlerFunc)(RpcInvocationData{
+	ctx := context.Background()
+	ctx = withRPCMetadata(ctx, &RpcInvocationMetadata{
 		RequestID:       requestId,
 		CallerIdentity:  callerIdentity,
-		Payload:         payload,
 		ResponseTimeout: responseTimeout,
 	})
+	var cancel func()
+	if responseTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, responseTimeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	response, err := handler.(RpcHandlerCtxFunc)(ctx, []byte(payload))
 
 	if err != nil {
-		if _, ok := err.(*RpcError); ok {
-			r.engine.publishRpcResponse(callerIdentity, requestId, nil, err.(*RpcError))
-		} else {
-			r.log.Warnw("unexpected error returned by RPC handler for method, using application error instead", err, "method", method)
-			r.engine.publishRpcResponse(callerIdentity, requestId, nil, rpcErrorFromBuiltInCodes(RpcApplicationError, nil))
+		if e, ok := errors.AsType[*RpcError](err); ok {
+			returnError(e)
+			return
 		}
+		r.log.Warnw("unexpected error returned by RPC handler for method, using application error instead", err, "method", method)
+		returnError(rpcErrorFromBuiltInCodes(RpcApplicationError, nil))
 		return
 	}
 
-	if byteLength(response) > MaxDataBytes {
-		r.engine.publishRpcResponse(callerIdentity, requestId, nil, rpcErrorFromBuiltInCodes(RpcResponsePayloadTooLarge, nil))
+	if len(response) > MaxDataBytes {
+		returnError(rpcErrorFromBuiltInCodes(RpcResponsePayloadTooLarge, nil))
 		return
 	}
-
-	r.engine.publishRpcResponse(callerIdentity, requestId, &response, nil)
+	r.engine.publishRpcResponse(callerIdentity, requestId, response, nil)
 }
 
 func (r *Room) OnRpcAck(requestId string) {

--- a/rpc.go
+++ b/rpc.go
@@ -1,8 +1,12 @@
 package lksdk
 
 import (
+	"context"
 	"fmt"
 	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/livekit/protocol/livekit"
 )
@@ -77,7 +81,17 @@ type RpcInvocationData struct {
 	ResponseTimeout time.Duration
 }
 
-// Specialized error handling for RPC methods.
+// Data passed to method handler for incoming RPC invocations
+type RpcInvocationMetadata struct {
+	// The unique request ID. Will match at both sides of the call, useful for debugging or logging.
+	RequestID string
+	// The unique participant identity of the caller.
+	CallerIdentity string
+	// The maximum time the caller will wait for a response.
+	ResponseTimeout time.Duration
+}
+
+// RpcError specialized error handling for RPC methods.
 //
 // Instances of this type, when thrown in a method handler, will have their `message`
 // serialized and sent across the wire. The sender will receive an equivalent error on the other side.
@@ -89,7 +103,7 @@ type RpcError struct {
 	Data    *string
 }
 
-// Creates an error object with the given code and message, plus an optional data payload.
+// NewRpcError creates an error object with the given code and message, plus an optional data payload.
 //
 // If thrown in an RPC method handler, the error will be sent back to the caller.
 //
@@ -149,3 +163,72 @@ type rpcPendingResponseHandler struct {
 }
 
 type RpcHandlerFunc func(data RpcInvocationData) (string, error)
+type RpcHandlerCtxFunc func(ctx context.Context, data []byte) ([]byte, error)
+
+type protoMsg[T any] interface {
+	*T
+	proto.Message
+}
+
+type rpcMetadataKey struct{}
+
+func withRPCMetadata(ctx context.Context, meta *RpcInvocationMetadata) context.Context {
+	return context.WithValue(ctx, rpcMetadataKey{}, meta)
+}
+
+func RPCMetadataFromContext(ctx context.Context) *RpcInvocationMetadata {
+	meta, _ := ctx.Value(rpcMetadataKey{}).(*RpcInvocationMetadata)
+	return meta
+}
+
+var _ RoomRPCInterface = (*Room)(nil)
+
+type RoomRPCInterface interface {
+	RegisterRpcCtxMethod(method string, handler RpcHandlerCtxFunc) error
+}
+
+func RegisterRPCMethodProto[
+	Req protoMsg[ReqT],
+	Resp proto.Message,
+	ReqT any,
+](
+	r RoomRPCInterface, name string,
+	fnc func(ctx context.Context, r Req) (Resp, error),
+) error {
+	return r.RegisterRpcCtxMethod(name, func(ctx context.Context, data []byte) ([]byte, error) {
+		var req Req = new(ReqT)
+		if len(data) != 0 {
+			if err := proto.Unmarshal(data, req); err != nil {
+				return nil, err
+			}
+		}
+		resp, err := fnc(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return proto.Marshal(resp)
+	})
+}
+
+func RegisterRPCMethodJSON[
+	Req protoMsg[ReqT],
+	Resp proto.Message,
+	ReqT any,
+](
+	r RoomRPCInterface, name string,
+	fnc func(ctx context.Context, r Req) (Resp, error),
+) error {
+	return r.RegisterRpcCtxMethod(name, func(ctx context.Context, data []byte) ([]byte, error) {
+		var req Req = new(ReqT)
+		if len(data) != 0 {
+			if err := protojson.Unmarshal(data, req); err != nil {
+				return nil, err
+			}
+		}
+		resp, err := fnc(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return protojson.Marshal(resp)
+	})
+}


### PR DESCRIPTION
Add helpers for registering JSON and protobuf encoded participant RPCs.

While at it, add a RPC handler function that accepts a context and passes payloads as `[]byte`. All the metadata is still available in the context.