### PR TITLE
Reconnect: fail over across regions instead of re-dialing the pinned one

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -140,9 +140,10 @@ type RTCEngine struct {
 	token      atomic.String
 	connParams *signalling.ConnectParams
 
-	regionProvider *regionURLProvider
-	originalURL    string // the user-provided (global) URL; reconnect fallback
-	cloudHost      string // parsed cloud hostname; empty when not applicable
+	regionProvider          *regionURLProvider
+	originalURL             string      // the user-provided (global) URL; reconnect fallback
+	cloudHost               string      // parsed cloud hostname; empty when not applicable
+	serverDirectedReconnect atomic.Bool // server sent a region list on the last reconnect leave
 
 	joinTimeout time.Duration
 
@@ -939,25 +940,20 @@ func (e *RTCEngine) connectWithRegionFailover() error {
 		return attempt(url)
 	}
 
-	// current region first (benign cases like SFU scale-down stay put), then the
-	// server-sorted region list, then the global URL as a final fallback
-	candidates := []string{e.url}
-	if settings, err := e.regionProvider.RegionSettings(e.cloudHost, e.token.Load()); err != nil {
+	// when the server directed this reconnect with its own region list, honor it
+	// and skip the current region (it told us where to go); otherwise try current
+	// first (benign cases like SFU scale-down stay put)
+	serverDirected := e.serverDirectedReconnect.Swap(false)
+	var settings *livekit.RegionSettings
+	if s, err := e.regionProvider.RegionSettings(e.cloudHost, e.token.Load()); err != nil {
 		e.log.Infow("could not get region settings for reconnect, using current and original url", "error", err)
 	} else {
-		for _, region := range settings.GetRegions() {
-			candidates = append(candidates, region.Url)
-		}
+		settings = s
 	}
-	candidates = append(candidates, e.originalURL)
+	candidates := buildReconnectCandidates(serverDirected, e.url, settings, e.originalURL)
 
-	tried := make(map[string]bool, len(candidates))
 	var lastErr error
 	for _, url := range candidates {
-		if url == "" || tried[url] {
-			continue
-		}
-		tried[url] = true
 		if err := attempt(url); err == nil {
 			return nil
 		} else {
@@ -970,6 +966,32 @@ func (e *RTCEngine) connectWithRegionFailover() error {
 		lastErr = ErrCannotConnectSignal
 	}
 	return lastErr
+}
+
+// buildReconnectCandidates returns the ordered, de-duplicated list of URLs to try
+// on a full reconnect: the current region first (unless the server directed the
+// reconnect with its own region list), then the server-sorted regions, then the
+// original (global) URL as a final fallback. Empty entries are dropped.
+func buildReconnectCandidates(serverDirected bool, currentURL string, settings *livekit.RegionSettings, originalURL string) []string {
+	raw := make([]string, 0, len(settings.GetRegions())+2)
+	if !serverDirected {
+		raw = append(raw, currentURL)
+	}
+	for _, region := range settings.GetRegions() {
+		raw = append(raw, region.Url)
+	}
+	raw = append(raw, originalURL)
+
+	seen := make(map[string]bool, len(raw))
+	out := raw[:0]
+	for _, u := range raw {
+		if u == "" || seen[u] {
+			continue
+		}
+		seen[u] = true
+		out = append(out, u)
+	}
+	return out
 }
 
 func (e *RTCEngine) createSubscriberPCAnswerAndSend() error {
@@ -1547,6 +1569,8 @@ func (e *RTCEngine) OnLeave(leave *livekit.LeaveRequest) {
 	// using the server's authoritative ordering rather than stale DNS/settings
 	if regions := leave.GetRegions(); regions != nil && e.regionProvider != nil && e.cloudHost != "" {
 		e.regionProvider.SetServerReportedRegions(e.cloudHost, regions)
+		// the server told us where to go; the next failover skips the current region
+		e.serverDirectedReconnect.Store(true)
 	}
 	switch leave.GetAction() {
 	case livekit.LeaveRequest_DISCONNECT:

--- a/engine.go
+++ b/engine.go
@@ -914,24 +914,28 @@ func (e *RTCEngine) setRegionConnectInfo(provider *regionURLProvider, originalUR
 }
 
 func (e *RTCEngine) restartConnection() error {
-	return e.connectWithRegionFailover()
+	return e.connectWithRegionFailover(e.attemptJoin)
 }
 
-func (e *RTCEngine) connectWithRegionFailover() error {
-	attempt := func(url string) error {
-		e.cleanupConnection()
-		// bound each candidate so a blackholed endpoint fails fast (otherwise the
-		// signal dial is only capped by the WebSocket handshake timeout, ~45s)
-		timeout := e.joinTimeout
-		if e.connParams != nil && e.connParams.ConnectTimeout > 0 {
-			timeout = e.connParams.ConnectTimeout
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		_, err := e.JoinContext(ctx, url, e.token.Load(), e.connParams, nil)
-		return err
+// attemptJoin tears down the current connection and rejoins to a single URL,
+// bounded by a timeout so a blackholed endpoint fails fast (otherwise the signal
+// dial is only capped by the WebSocket handshake timeout, ~45s).
+func (e *RTCEngine) attemptJoin(url string) error {
+	e.cleanupConnection()
+	timeout := e.joinTimeout
+	if e.connParams != nil && e.connParams.ConnectTimeout > 0 {
+		timeout = e.connParams.ConnectTimeout
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, err := e.JoinContext(ctx, url, e.token.Load(), e.connParams, nil)
+	return err
+}
 
+// connectWithRegionFailover performs a full reconnect by walking the candidate
+// list and connecting to the first that succeeds. attempt connects to a single
+// URL; it is a parameter so tests can mock per-region success/failure.
+func (e *RTCEngine) connectWithRegionFailover(attempt func(url string) error) error {
 	if e.regionProvider == nil || e.cloudHost == "" {
 		url := e.originalURL
 		if url == "" {
@@ -1337,6 +1341,17 @@ func (e *RTCEngine) Simulate(scenario SimulateScenario) {
 				&livekit.SimulateScenario{
 					Scenario: &livekit.SimulateScenario_NodeFailure{
 						NodeFailure: true,
+					},
+				},
+			),
+		)
+
+	case SimulateLeaveRequestFullReconnect:
+		e.signalTransport.SendMessage(
+			e.signalling.SignalSimulateScenario(
+				&livekit.SimulateScenario{
+					Scenario: &livekit.SimulateScenario_LeaveRequestFullReconnect{
+						LeaveRequestFullReconnect: true,
 					},
 				},
 			),

--- a/engine.go
+++ b/engine.go
@@ -140,6 +140,10 @@ type RTCEngine struct {
 	token      atomic.String
 	connParams *signalling.ConnectParams
 
+	regionProvider *regionURLProvider
+	originalURL    string // the user-provided (global) URL; reconnect fallback
+	cloudHost      string // parsed cloud hostname; empty when not applicable
+
 	joinTimeout time.Duration
 
 	dataCryptor *e2ee.DataCryptor // E2EE data channel encryption (nil = disabled)
@@ -824,6 +828,9 @@ func (e *RTCEngine) handleDisconnect(fullReconnect bool) {
 				e.log.Infow("resuming connection...", "reconnectCount", reconnectCount)
 				if err := e.resumeConnection(); err != nil {
 					e.log.Errorw("resume connection failed", err)
+					// escalate to a full reconnect so region failover engages
+					// instead of retrying resume against the same (dead) region
+					e.requiresFullReconnect.Store(true)
 				} else {
 					return
 				}
@@ -895,11 +902,74 @@ func (e *RTCEngine) cleanupConnection() {
 	e.closePeerConnections()
 }
 
-func (e *RTCEngine) restartConnection() error {
-	e.cleanupConnection()
+// setRegionConnectInfo wires the region provider and the original (global) URL
+// into the engine so the reconnect path can fail over across regions. cloudHost
+// is empty when region discovery does not apply, in which case reconnect just
+// re-dials the original URL.
+func (e *RTCEngine) setRegionConnectInfo(provider *regionURLProvider, originalURL, cloudHost string) {
+	e.regionProvider = provider
+	e.originalURL = originalURL
+	e.cloudHost = cloudHost
+}
 
-	_, err := e.JoinContext(context.TODO(), e.url, e.token.Load(), e.connParams, nil)
-	return err
+func (e *RTCEngine) restartConnection() error {
+	return e.connectWithRegionFailover()
+}
+
+func (e *RTCEngine) connectWithRegionFailover() error {
+	attempt := func(url string) error {
+		e.cleanupConnection()
+		// bound each candidate so a blackholed endpoint fails fast (otherwise the
+		// signal dial is only capped by the WebSocket handshake timeout, ~45s)
+		timeout := e.joinTimeout
+		if e.connParams != nil && e.connParams.ConnectTimeout > 0 {
+			timeout = e.connParams.ConnectTimeout
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		_, err := e.JoinContext(ctx, url, e.token.Load(), e.connParams, nil)
+		return err
+	}
+
+	if e.regionProvider == nil || e.cloudHost == "" {
+		url := e.originalURL
+		if url == "" {
+			url = e.url
+		}
+		return attempt(url)
+	}
+
+	// current region first (benign cases like SFU scale-down stay put), then the
+	// server-sorted region list, then the global URL as a final fallback
+	candidates := []string{e.url}
+	if settings, err := e.regionProvider.RegionSettings(e.cloudHost, e.token.Load()); err != nil {
+		e.log.Infow("could not get region settings for reconnect, using current and original url", "error", err)
+	} else {
+		for _, region := range settings.GetRegions() {
+			candidates = append(candidates, region.Url)
+		}
+	}
+	candidates = append(candidates, e.originalURL)
+
+	tried := make(map[string]bool, len(candidates))
+	var lastErr error
+	for _, url := range candidates {
+		if url == "" || tried[url] {
+			continue
+		}
+		tried[url] = true
+		if err := attempt(url); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			e.log.Infow("region reconnect attempt failed, trying next candidate", "url", url, "error", err)
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = ErrCannotConnectSignal
+	}
+	return lastErr
 }
 
 func (e *RTCEngine) createSubscriberPCAnswerAndSend() error {
@@ -1473,6 +1543,11 @@ func (e *RTCEngine) OnTokenRefresh(refreshToken string) {
 
 func (e *RTCEngine) OnLeave(leave *livekit.LeaveRequest) {
 	e.log.Debugw("received leave request", "action", leave.GetAction())
+	// adopt any server-reported region list so the ensuing reconnect fails over
+	// using the server's authoritative ordering rather than stale DNS/settings
+	if regions := leave.GetRegions(); regions != nil && e.regionProvider != nil && e.cloudHost != "" {
+		e.regionProvider.SetServerReportedRegions(e.cloudHost, regions)
+	}
 	switch leave.GetAction() {
 	case livekit.LeaveRequest_DISCONNECT:
 		e.Close()

--- a/engine.go
+++ b/engine.go
@@ -983,7 +983,8 @@ func buildReconnectCandidates(serverDirected bool, currentURL string, settings *
 	raw = append(raw, originalURL)
 
 	seen := make(map[string]bool, len(raw))
-	out := raw[:0]
+
+	out := make([]string, 0, len(raw))
 	for _, u := range raw {
 		if u == "" || seen[u] {
 			continue

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,6 +1,8 @@
 package lksdk
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -169,4 +171,145 @@ func TestBuildReconnectCandidates(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestConnectWithRegionFailover drives the full-reconnect walk with a mocked
+// per-candidate connect, proving region fallback without a real server: the
+// current region is skipped when the server directs the reconnect, failed
+// regions are walked past, and the first working region wins.
+func TestConnectWithRegionFailover(t *testing.T) {
+	const host = "test.livekit.cloud"
+	mockRegions := &livekit.RegionSettings{
+		Regions: []*livekit.RegionInfo{
+			{Url: "wss://region-b"},
+			{Url: "wss://region-c"},
+		},
+	}
+	newEngine := func(serverDirected bool) *RTCEngine {
+		e := &RTCEngine{
+			log:            logger,
+			regionProvider: newRegionURLProvider(),
+			cloudHost:      host,
+			url:            "wss://region-a", // current region
+			originalURL:    "wss://global",
+		}
+		e.token.Store("tok")
+		// server-pushed list (excludes the current region) — fresh, so the walk
+		// uses it without a network fetch
+		e.regionProvider.SetServerReportedRegions(host, mockRegions)
+		e.serverDirectedReconnect.Store(serverDirected)
+		return e
+	}
+	down := errors.New("region down")
+
+	t.Run("server-directed skips current and falls back past a failed region", func(t *testing.T) {
+		e := newEngine(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			if url == "wss://region-b" {
+				return down // initial region fails
+			}
+			return nil // region-c succeeds
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://region-b", "wss://region-c"}, dialed)
+		require.NotContains(t, dialed, "wss://region-a", "current region must be skipped when server-directed")
+	})
+
+	t.Run("not server-directed tries current first then falls back", func(t *testing.T) {
+		e := newEngine(false)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			if url == "wss://region-a" {
+				return down // current fails
+			}
+			return nil // region-b succeeds
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://region-a", "wss://region-b"}, dialed)
+	})
+
+	t.Run("all candidates fail returns the last error", func(t *testing.T) {
+		e := newEngine(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			return down
+		})
+		require.ErrorIs(t, err, down)
+		require.Equal(t, []string{"wss://region-b", "wss://region-c", "wss://global"}, dialed)
+	})
+
+	t.Run("falls back to the global url when all regions fail", func(t *testing.T) {
+		e := newEngine(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			if url == "wss://global" {
+				return nil // only the global url is reachable
+			}
+			return down
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://region-b", "wss://region-c", "wss://global"}, dialed)
+	})
+
+	t.Run("non-cloud dials only the original url", func(t *testing.T) {
+		// no region provider / cloud host -> the region branch is skipped entirely
+		e := &RTCEngine{
+			log:         logger,
+			url:         "wss://current",
+			originalURL: "wss://global",
+		}
+		e.token.Store("tok")
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://global"}, dialed)
+	})
+
+	t.Run("server-directed flag is consumed per sweep", func(t *testing.T) {
+		e := newEngine(true)
+		failAll := func(dialed *[]string) func(string) error {
+			return func(url string) error {
+				*dialed = append(*dialed, url)
+				return down
+			}
+		}
+		var sweep1, sweep2 []string
+		_ = e.connectWithRegionFailover(failAll(&sweep1))
+		_ = e.connectWithRegionFailover(failAll(&sweep2))
+
+		require.NotContains(t, sweep1, "wss://region-a", "first sweep is server-directed: current is skipped")
+		require.Equal(t, "wss://region-a", sweep2[0], "second sweep reverts to current-first once the flag is consumed")
+	})
+
+	t.Run("degrades to the global url when region settings are unavailable", func(t *testing.T) {
+		rs := newRegionSettingsServer(t, &livekit.RegionSettings{})
+		rs.mu.Lock()
+		rs.status = http.StatusServiceUnavailable
+		rs.mu.Unlock()
+		e := &RTCEngine{
+			log:            logger,
+			regionProvider: newTestProvider(rs),
+			cloudHost:      rs.hostname,
+			url:            "wss://current",
+			originalURL:    "wss://global",
+		}
+		e.token.Store("test-token") // the fake settings server asserts this exact bearer token
+		e.serverDirectedReconnect.Store(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			return nil
+		})
+		require.NoError(t, err)
+		// no region list available and current skipped (server-directed) -> only global
+		require.Equal(t, []string{"wss://global"}, dialed)
+	})
 }

--- a/engine_test.go
+++ b/engine_test.go
@@ -102,3 +102,71 @@ func TestFilterTURNServers(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildReconnectCandidates(t *testing.T) {
+	regions := &livekit.RegionSettings{
+		Regions: []*livekit.RegionInfo{
+			{Url: "wss://r1"},
+			{Url: "wss://r2"},
+		},
+	}
+	tests := []struct {
+		name           string
+		serverDirected bool
+		currentURL     string
+		settings       *livekit.RegionSettings
+		originalURL    string
+		want           []string
+	}{
+		{
+			name:        "current first, then regions, then global",
+			currentURL:  "wss://current",
+			settings:    regions,
+			originalURL: "wss://global",
+			want:        []string{"wss://current", "wss://r1", "wss://r2", "wss://global"},
+		},
+		{
+			name:           "server-directed skips current",
+			serverDirected: true,
+			currentURL:     "wss://current",
+			settings:       regions,
+			originalURL:    "wss://global",
+			want:           []string{"wss://r1", "wss://r2", "wss://global"},
+		},
+		{
+			name:        "dedupes current when it is also the geo-best region",
+			currentURL:  "wss://r1",
+			settings:    regions,
+			originalURL: "wss://global",
+			want:        []string{"wss://r1", "wss://r2", "wss://global"},
+		},
+		{
+			name:        "nil settings falls back to current and global",
+			currentURL:  "wss://current",
+			settings:    nil,
+			originalURL: "wss://global",
+			want:        []string{"wss://current", "wss://global"},
+		},
+		{
+			name:           "server-directed with nil settings tries only global",
+			serverDirected: true,
+			currentURL:     "wss://current",
+			settings:       nil,
+			originalURL:    "wss://global",
+			want:           []string{"wss://global"},
+		},
+		{
+			name:        "drops empty urls",
+			currentURL:  "",
+			settings:    regions,
+			originalURL: "",
+			want:        []string{"wss://r1", "wss://r2"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildReconnectCandidates(tc.serverDirected, tc.currentURL, tc.settings, tc.originalURL)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/regionurlprovider.go
+++ b/regionurlprovider.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,9 +33,9 @@ type regionURLProvider struct {
 }
 
 type hostnameSettingsCacheItem struct {
-	regionSettings    *livekit.RegionSettings
-	updatedAt         time.Time
-	regionURLAttempts map[string]int
+	regionSettings *livekit.RegionSettings
+	updatedAt      time.Time
+	cacheTTL       time.Duration // from Cache-Control max-age; falls back to the default
 }
 
 func newRegionURLProvider() *regionURLProvider {
@@ -51,8 +52,14 @@ func (r *regionURLProvider) RefreshRegionSettings(cloudHostname, token string) e
 	hostnameSettings := r.hostnameSettingsCache[cloudHostname]
 	r.mutex.RUnlock()
 
-	if hostnameSettings != nil && time.Since(hostnameSettings.updatedAt) < regionHostnameProviderSettingsCacheTime {
-		return nil
+	if hostnameSettings != nil {
+		ttl := hostnameSettings.cacheTTL
+		if ttl <= 0 {
+			ttl = regionHostnameProviderSettingsCacheTime
+		}
+		if time.Since(hostnameSettings.updatedAt) < ttl {
+			return nil
+		}
 	}
 
 	settingsURL := regionSettingsURL(cloudHostname)
@@ -83,12 +90,17 @@ func (r *regionURLProvider) RefreshRegionSettings(cloudHostname, token string) e
 		return errors.New("refreshRegionSettings failed to decode region settings: " + err.Error())
 	}
 
-	item := &hostnameSettingsCacheItem{
-		regionSettings:    regions,
-		updatedAt:         time.Now(),
-		regionURLAttempts: map[string]int{},
+	ttl := regionHostnameProviderSettingsCacheTime
+	if maxAge := parseRegionSettingsMaxAge(resp.Header.Get("Cache-Control")); maxAge > 0 {
+		ttl = maxAge
 	}
+
 	r.mutex.Lock()
+	item := &hostnameSettingsCacheItem{
+		regionSettings: regions,
+		updatedAt:      time.Now(),
+		cacheTTL:       ttl,
+	}
 	r.hostnameSettingsCache[cloudHostname] = item
 	r.mutex.Unlock()
 
@@ -99,22 +111,62 @@ func (r *regionURLProvider) RefreshRegionSettings(cloudHostname, token string) e
 	return nil
 }
 
-// PopBestURL removes and returns the best region URL. Once all URLs are exhausted, it will return an error.
-// RefreshRegionSettings must be called to repopulate the list of regions.
-func (r *regionURLProvider) PopBestURL(cloudHostname, token string) (string, error) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	hostnameSettings := r.hostnameSettingsCache[cloudHostname]
-
-	if hostnameSettings == nil || hostnameSettings.regionSettings == nil || len(hostnameSettings.regionSettings.Regions) == 0 {
-		return "", errors.New("no regions available")
+// RegionSettings returns the cached region list for a hostname, refreshing it if
+// stale. The returned list is owned by the cache and must not be mutated; the
+// caller is responsible for tracking its own per-failover attempt state.
+func (r *regionURLProvider) RegionSettings(cloudHostname, token string) (*livekit.RegionSettings, error) {
+	if err := r.RefreshRegionSettings(cloudHostname, token); err != nil {
+		r.mutex.RLock()
+		cached := r.hostnameSettingsCache[cloudHostname]
+		r.mutex.RUnlock()
+		if cached == nil {
+			return nil, err
+		}
+		// a cached list exists; fall through and use it
 	}
 
-	bestRegionURL := hostnameSettings.regionSettings.Regions[0].Url
-	hostnameSettings.regionSettings.Regions = hostnameSettings.regionSettings.Regions[1:]
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	item := r.hostnameSettingsCache[cloudHostname]
+	if item == nil {
+		return nil, errors.New("no regions available")
+	}
+	return item.regionSettings, nil
+}
 
-	return bestRegionURL, nil
+// SetServerReportedRegions stores a region list pushed by the server (e.g. on a
+// reconnect LeaveRequest), overriding the cached /settings/regions list and
+// resetting the cache TTL so the next failover uses it without re-fetching.
+func (r *regionURLProvider) SetServerReportedRegions(cloudHostname string, regions *livekit.RegionSettings) {
+	if regions == nil {
+		return
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	ttl := regionHostnameProviderSettingsCacheTime
+	if existing := r.hostnameSettingsCache[cloudHostname]; existing != nil && existing.cacheTTL > 0 {
+		ttl = existing.cacheTTL
+	}
+	r.hostnameSettingsCache[cloudHostname] = &hostnameSettingsCacheItem{
+		regionSettings: regions,
+		updatedAt:      time.Now(),
+		cacheTTL:       ttl,
+	}
+}
+
+// parseRegionSettingsMaxAge extracts the max-age (seconds) from a Cache-Control
+// header value, returning 0 when absent or unparseable. Directive names are
+// case-insensitive per RFC 9111.
+func parseRegionSettingsMaxAge(cacheControl string) time.Duration {
+	for _, directive := range strings.Split(cacheControl, ",") {
+		directive = strings.ToLower(strings.TrimSpace(directive))
+		if strings.HasPrefix(directive, "max-age=") {
+			if secs, err := strconv.Atoi(strings.TrimPrefix(directive, "max-age=")); err == nil && secs > 0 {
+				return time.Duration(secs) * time.Second
+			}
+		}
+	}
+	return 0
 }
 
 func parseCloudURL(serverURL string) (string, error) {

--- a/regionurlprovider_test.go
+++ b/regionurlprovider_test.go
@@ -84,7 +84,7 @@ func newTestProvider(rs *regionSettingsServer) *regionURLProvider {
 	return p
 }
 
-func TestRegionURLProvider_FetchAndPopOrder(t *testing.T) {
+func TestRegionURLProvider_RegionSettingsOrder(t *testing.T) {
 	rs := newRegionSettingsServer(t, &livekit.RegionSettings{
 		Regions: []*livekit.RegionInfo{
 			{Region: "us-east", Url: "wss://us-east.example.com", Distance: 10},
@@ -94,24 +94,23 @@ func TestRegionURLProvider_FetchAndPopOrder(t *testing.T) {
 	})
 	p := newTestProvider(rs)
 
-	require.NoError(t, p.RefreshRegionSettings(rs.hostname, "test-token"))
-	require.EqualValues(t, 1, rs.hits.Load(), "should hit /settings/regions once")
-
-	// PopBestURL returns regions in the order the server provided them (server
-	// sorts by proximity), removing each as it goes.
-	for _, want := range []string{
+	want := []string{
 		"wss://us-east.example.com",
 		"wss://us-west.example.com",
 		"wss://eu.example.com",
-	} {
-		got, err := p.PopBestURL(rs.hostname, "test-token")
+	}
+	// RegionSettings returns the list in server order and does not mutate it, so
+	// repeated calls return the same list and only fetch once.
+	for n := 0; n < 2; n++ {
+		settings, err := p.RegionSettings(rs.hostname, "test-token")
 		require.NoError(t, err)
+		var got []string
+		for _, region := range settings.GetRegions() {
+			got = append(got, region.Url)
+		}
 		require.Equal(t, want, got)
 	}
-
-	// once exhausted, PopBestURL errors until RefreshRegionSettings repopulates
-	_, err := p.PopBestURL(rs.hostname, "test-token")
-	require.Error(t, err)
+	require.EqualValues(t, 1, rs.hits.Load(), "should hit /settings/regions once")
 }
 
 func TestRegionURLProvider_CacheAvoidsRefetch(t *testing.T) {
@@ -135,12 +134,9 @@ func TestRegionURLProvider_RefreshRepopulates(t *testing.T) {
 	})
 	p := newTestProvider(rs)
 
-	require.NoError(t, p.RefreshRegionSettings(rs.hostname, "test-token"))
-	got, err := p.PopBestURL(rs.hostname, "test-token")
+	settings, err := p.RegionSettings(rs.hostname, "test-token")
 	require.NoError(t, err)
-	require.Equal(t, "wss://a.example.com", got)
-	_, err = p.PopBestURL(rs.hostname, "test-token")
-	require.Error(t, err, "exhausted")
+	require.Equal(t, "wss://a.example.com", settings.GetRegions()[0].Url)
 
 	// expire the cache and serve a different region list
 	p.mutex.Lock()
@@ -150,11 +146,10 @@ func TestRegionURLProvider_RefreshRepopulates(t *testing.T) {
 		Regions: []*livekit.RegionInfo{{Region: "b", Url: "wss://b.example.com"}},
 	})
 
-	require.NoError(t, p.RefreshRegionSettings(rs.hostname, "test-token"))
-	require.EqualValues(t, 2, rs.hits.Load(), "refresh past TTL must refetch")
-	got, err = p.PopBestURL(rs.hostname, "test-token")
+	settings, err = p.RegionSettings(rs.hostname, "test-token")
 	require.NoError(t, err)
-	require.Equal(t, "wss://b.example.com", got)
+	require.EqualValues(t, 2, rs.hits.Load(), "refresh past TTL must refetch")
+	require.Equal(t, "wss://b.example.com", settings.GetRegions()[0].Url)
 }
 
 func TestRegionURLProvider_FetchError(t *testing.T) {
@@ -164,9 +159,44 @@ func TestRegionURLProvider_FetchError(t *testing.T) {
 	rs.mu.Unlock()
 	p := newTestProvider(rs)
 
-	err := p.RefreshRegionSettings(rs.hostname, "test-token")
-	require.Error(t, err)
-
-	_, err = p.PopBestURL(rs.hostname, "test-token")
+	_, err := p.RegionSettings(rs.hostname, "test-token")
 	require.Error(t, err, "no regions cached after a failed fetch")
+}
+
+// TestRegionURLProvider_SetServerReportedRegions verifies that a server-pushed
+// region list (e.g. from a reconnect LeaveRequest) overrides the cached list and
+// is used without hitting /settings/regions.
+func TestRegionURLProvider_SetServerReportedRegions(t *testing.T) {
+	rs := newRegionSettingsServer(t, &livekit.RegionSettings{
+		Regions: []*livekit.RegionInfo{{Region: "a", Url: "wss://a.example.com"}},
+	})
+	p := newTestProvider(rs)
+
+	p.SetServerReportedRegions(rs.hostname, &livekit.RegionSettings{
+		Regions: []*livekit.RegionInfo{
+			{Region: "b", Url: "wss://b.example.com"},
+			{Region: "c", Url: "wss://c.example.com"},
+		},
+	})
+
+	settings, err := p.RegionSettings(rs.hostname, "test-token")
+	require.NoError(t, err)
+	require.Equal(t, "wss://b.example.com", settings.GetRegions()[0].Url)
+	require.EqualValues(t, 0, rs.hits.Load(), "server-reported regions must not trigger a fetch")
+}
+
+func TestParseRegionSettingsMaxAge(t *testing.T) {
+	cases := map[string]time.Duration{
+		"max-age=60":         60 * time.Second,
+		"public, max-age=30": 30 * time.Second,
+		"public, Max-Age=60": 60 * time.Second, // directive names are case-insensitive
+		"MAX-AGE=90":         90 * time.Second,
+		"no-cache":           0,
+		"":                   0,
+		"max-age=abc":        0,
+		"max-age=0":          0,
+	}
+	for in, want := range cases {
+		require.Equal(t, want, parseRegionSettingsMaxAge(in), "input %q", in)
+	}
 }

--- a/room.go
+++ b/room.go
@@ -497,39 +497,44 @@ func (r *Room) JoinWithContextAndToken(ctx context.Context, url, token string, o
 
 	isSuccess := false
 	cloudHostname, _ := parseCloudURL(url)
-	if !params.DisableRegionDiscovery && cloudHostname != "" {
-		if err := r.regionURLProvider.RefreshRegionSettings(cloudHostname, token); err != nil {
-			r.log.Errorw("failed to get best url", err)
+	regionHost := cloudHostname
+	if params.DisableRegionDiscovery {
+		regionHost = ""
+	}
+	// wire the original URL + region provider into the engine so the reconnect
+	// path can fail over across regions, not just the initial connect
+	r.engine.setRegionConnectInfo(r.regionURLProvider, url, regionHost)
+	if regionHost != "" {
+		settings, err := r.regionURLProvider.RegionSettings(regionHost, token)
+		if err != nil {
+			r.log.Errorw("failed to get region settings", err)
 		} else {
-			for tries := uint(0); !isSuccess; tries++ {
+			for i, region := range settings.GetRegions() {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				bestURL, err := r.regionURLProvider.PopBestURL(cloudHostname, token)
-				if err != nil {
-					r.log.Errorw("failed to get best url", err)
-					break
-				}
+				bestURL := region.Url
 
 				r.log.Debugw("RTC engine joining room", "url", bestURL, "connectTimeout", params.ConnectTimeout)
 				callCtx, cancelCallCtx := context.WithTimeout(ctx, params.ConnectTimeout)
 				isSuccess, err = r.engine.JoinContext(callCtx, bestURL, token, params.ConnectParams, pubFunc)
 				cancelCallCtx()
-				if err != nil {
-					cleanPubReg()
-					// try the next URL with exponential backoff
-					d := time.Duration(1<<min(tries, 6)) * 100 * time.Millisecond // max 6.4 seconds
-					r.log.Errorw(
-						"failed to join room", err,
-						"retrying in", d,
-						"url", bestURL,
-					)
-					select {
-					case <-time.After(d):
-					case <-ctx.Done():
-						return ctx.Err()
-					}
-					continue
+				if err == nil {
+					break
+				}
+
+				cleanPubReg()
+				// try the next URL with exponential backoff
+				d := time.Duration(1<<min(uint(i), 6)) * 100 * time.Millisecond // max 6.4 seconds
+				r.log.Errorw(
+					"failed to join room", err,
+					"retrying in", d,
+					"url", bestURL,
+				)
+				select {
+				case <-time.After(d):
+				case <-ctx.Done():
+					return ctx.Err()
 				}
 			}
 		}

--- a/room.go
+++ b/room.go
@@ -61,6 +61,9 @@ const (
 	SimulateMigration
 	SimulateServerLeave
 	SimulateNodeFailure
+	// SimulateLeaveRequestFullReconnect asks the server to send a reconnect
+	// LeaveRequest that drops the current region, exercising region failover.
+	SimulateLeaveRequestFullReconnect
 )
 
 type ConnectionState string


### PR DESCRIPTION
During a regional outage, egress (which connects through this SDK) failed to reconnect: it kept dialing the region it was originally pinned to until it exhausted its retries, then gave up and ended the recording. Tracing it showed the SDK only ever picked a region on the **initial** connect — the reconnect path reused `e.url` (the region edge URL) and had no notion of regions at all.

This PR teaches the reconnect path to fail over across regions, and cleans up the region machinery along the way so initial connect and reconnect share one source of truth.

A full reconnect no longer re-dials a single URL. It walks an ordered candidate list — the current region first (a single shot, so benign cases like an SFU scale-down stay put), then the server-sorted region list, then the original global URL — and connects to the first that works. If the current region is gone, we step to the next-best one instead of hammering the dead one. A local `tried` set dedupes candidates (the current region is usually also the geo-nearest entry in the list).

Previously the provider both cached regions endpoint *and* tracked which URLs had been handed out, mutating the cached list as it went (`PopBestURL`). Those are two different lifetimes — a shared, long-lived cache vs. transient per-failover progress — and conflating them forced awkward "copy the attempted set forward on refresh" code. The provider is now just a cache: `RegionSettings` returns the immutable list (fetching if stale), and the failover walk owns its own attempt state as a local variable.

When the server asks us to reconnect, it can attach a region list. We now adopt it before reconnecting, so the failover uses the server's authoritative ordering instead of a possibly-stale regions response.

A resume always targets the same node, so on a region outage it would just retry the dead region forever. On a failed resume we now set `requiresFullReconnect`, so the next attempt becomes a full reconnect and region failover can engage.

The reconnect path passed `context.TODO()`, so a blackholed endpoint was only capped by the WebSocket handshake timeout (~45s). With the new multi-candidate walk that would dominate the wall-clock (N candidates × ~45s per sweep). Each candidate is now bounded by `ConnectParams.ConnectTimeout` (falling back to `joinTimeout`), matching what the initial connect already does, so a dead candidate fails fast and we move on.

In addition to that we honor `Cache-Control: max-age` on regions response now.

This mirrors the JS client's reconnect model: 10 sweeps, the same `n² × 300ms` backoff base between sweeps, an explicit per-attempt timeout, and consumption of server-reported regions.

Big thanks to @boks1971 for spotting the issue! 🙏 