### PR TITLE
Cover region walk behavior with tests 

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1341,6 +1341,17 @@ func (e *RTCEngine) Simulate(scenario SimulateScenario) {
 				},
 			),
 		)
+
+	case SimulateLeaveRequestFullReconnect:
+		e.signalTransport.SendMessage(
+			e.signalling.SignalSimulateScenario(
+				&livekit.SimulateScenario{
+					Scenario: &livekit.SimulateScenario_LeaveRequestFullReconnect{
+						LeaveRequestFullReconnect: true,
+					},
+				},
+			),
+		)
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -914,24 +914,28 @@ func (e *RTCEngine) setRegionConnectInfo(provider *regionURLProvider, originalUR
 }
 
 func (e *RTCEngine) restartConnection() error {
-	return e.connectWithRegionFailover()
+	return e.connectWithRegionFailover(e.attemptJoin)
 }
 
-func (e *RTCEngine) connectWithRegionFailover() error {
-	attempt := func(url string) error {
-		e.cleanupConnection()
-		// bound each candidate so a blackholed endpoint fails fast (otherwise the
-		// signal dial is only capped by the WebSocket handshake timeout, ~45s)
-		timeout := e.joinTimeout
-		if e.connParams != nil && e.connParams.ConnectTimeout > 0 {
-			timeout = e.connParams.ConnectTimeout
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		_, err := e.JoinContext(ctx, url, e.token.Load(), e.connParams, nil)
-		return err
+// attemptJoin tears down the current connection and rejoins to a single URL,
+// bounded by a timeout so a blackholed endpoint fails fast (otherwise the signal
+// dial is only capped by the WebSocket handshake timeout, ~45s).
+func (e *RTCEngine) attemptJoin(url string) error {
+	e.cleanupConnection()
+	timeout := e.joinTimeout
+	if e.connParams != nil && e.connParams.ConnectTimeout > 0 {
+		timeout = e.connParams.ConnectTimeout
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, err := e.JoinContext(ctx, url, e.token.Load(), e.connParams, nil)
+	return err
+}
 
+// connectWithRegionFailover performs a full reconnect by walking the candidate
+// list and connecting to the first that succeeds. attempt connects to a single
+// URL; it is a parameter so tests can mock per-region success/failure.
+func (e *RTCEngine) connectWithRegionFailover(attempt func(url string) error) error {
 	if e.regionProvider == nil || e.cloudHost == "" {
 		url := e.originalURL
 		if url == "" {

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,6 +1,8 @@
 package lksdk
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -169,4 +171,145 @@ func TestBuildReconnectCandidates(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestConnectWithRegionFailover drives the full-reconnect walk with a mocked
+// per-candidate connect, proving region fallback without a real server: the
+// current region is skipped when the server directs the reconnect, failed
+// regions are walked past, and the first working region wins.
+func TestConnectWithRegionFailover(t *testing.T) {
+	const host = "test.livekit.cloud"
+	mockRegions := &livekit.RegionSettings{
+		Regions: []*livekit.RegionInfo{
+			{Url: "wss://region-b"},
+			{Url: "wss://region-c"},
+		},
+	}
+	newEngine := func(serverDirected bool) *RTCEngine {
+		e := &RTCEngine{
+			log:            logger,
+			regionProvider: newRegionURLProvider(),
+			cloudHost:      host,
+			url:            "wss://region-a", // current region
+			originalURL:    "wss://global",
+		}
+		e.token.Store("tok")
+		// server-pushed list (excludes the current region) — fresh, so the walk
+		// uses it without a network fetch
+		e.regionProvider.SetServerReportedRegions(host, mockRegions)
+		e.serverDirectedReconnect.Store(serverDirected)
+		return e
+	}
+	down := errors.New("region down")
+
+	t.Run("server-directed skips current and falls back past a failed region", func(t *testing.T) {
+		e := newEngine(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			if url == "wss://region-b" {
+				return down // initial region fails
+			}
+			return nil // region-c succeeds
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://region-b", "wss://region-c"}, dialed)
+		require.NotContains(t, dialed, "wss://region-a", "current region must be skipped when server-directed")
+	})
+
+	t.Run("not server-directed tries current first then falls back", func(t *testing.T) {
+		e := newEngine(false)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			if url == "wss://region-a" {
+				return down // current fails
+			}
+			return nil // region-b succeeds
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://region-a", "wss://region-b"}, dialed)
+	})
+
+	t.Run("all candidates fail returns the last error", func(t *testing.T) {
+		e := newEngine(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			return down
+		})
+		require.ErrorIs(t, err, down)
+		require.Equal(t, []string{"wss://region-b", "wss://region-c", "wss://global"}, dialed)
+	})
+
+	t.Run("falls back to the global url when all regions fail", func(t *testing.T) {
+		e := newEngine(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			if url == "wss://global" {
+				return nil // only the global url is reachable
+			}
+			return down
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://region-b", "wss://region-c", "wss://global"}, dialed)
+	})
+
+	t.Run("non-cloud dials only the original url", func(t *testing.T) {
+		// no region provider / cloud host -> the region branch is skipped entirely
+		e := &RTCEngine{
+			log:         logger,
+			url:         "wss://current",
+			originalURL: "wss://global",
+		}
+		e.token.Store("tok")
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"wss://global"}, dialed)
+	})
+
+	t.Run("server-directed flag is consumed per sweep", func(t *testing.T) {
+		e := newEngine(true)
+		failAll := func(dialed *[]string) func(string) error {
+			return func(url string) error {
+				*dialed = append(*dialed, url)
+				return down
+			}
+		}
+		var sweep1, sweep2 []string
+		_ = e.connectWithRegionFailover(failAll(&sweep1))
+		_ = e.connectWithRegionFailover(failAll(&sweep2))
+
+		require.NotContains(t, sweep1, "wss://region-a", "first sweep is server-directed: current is skipped")
+		require.Equal(t, "wss://region-a", sweep2[0], "second sweep reverts to current-first once the flag is consumed")
+	})
+
+	t.Run("degrades to the global url when region settings are unavailable", func(t *testing.T) {
+		rs := newRegionSettingsServer(t, &livekit.RegionSettings{})
+		rs.mu.Lock()
+		rs.status = http.StatusServiceUnavailable
+		rs.mu.Unlock()
+		e := &RTCEngine{
+			log:            logger,
+			regionProvider: newTestProvider(rs),
+			cloudHost:      rs.hostname,
+			url:            "wss://current",
+			originalURL:    "wss://global",
+		}
+		e.token.Store("test-token") // the fake settings server asserts this exact bearer token
+		e.serverDirectedReconnect.Store(true)
+		var dialed []string
+		err := e.connectWithRegionFailover(func(url string) error {
+			dialed = append(dialed, url)
+			return nil
+		})
+		require.NoError(t, err)
+		// no region list available and current skipped (server-directed) -> only global
+		require.Equal(t, []string{"wss://global"}, dialed)
+	})
 }

--- a/room.go
+++ b/room.go
@@ -61,6 +61,9 @@ const (
 	SimulateMigration
 	SimulateServerLeave
 	SimulateNodeFailure
+	// SimulateLeaveRequestFullReconnect asks the server to send a reconnect
+	// LeaveRequest that drops the current region, exercising region failover.
+	SimulateLeaveRequestFullReconnect
 )
 
 type ConnectionState string


### PR DESCRIPTION
Adding light mocking so that region walk behavior can be tested.
Exposing simulation scenario - which could be used to trigger region failover. Tested the egress region failover with it successfully.
