### PR TITLE
feat: add WithSettingEngineFunc ConnectOption to customize the SettingEngine

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -409,6 +409,7 @@ func (e *RTCEngine) createPublisherPCLocked(configuration webrtc.Configuration) 
 		OnRTTUpdate:                e.setRTT,
 		IsSender:                   true,
 		DTLSEllipticCurves:         e.connParams.DTLSEllipticCurves,
+		SettingEngineFunc:          e.connParams.SettingEngineFunc,
 	}); err != nil {
 		return err
 	}
@@ -519,6 +520,7 @@ func (e *RTCEngine) createSubscriberPCLocked(configuration webrtc.Configuration)
 		Interceptors:               e.connParams.Interceptors,
 		IncludeDefaultInterceptors: e.connParams.IncludeDefaultInterceptors,
 		DTLSEllipticCurves:         e.connParams.DTLSEllipticCurves,
+		SettingEngineFunc:          e.connParams.SettingEngineFunc,
 	}); err != nil {
 		return err
 	}

--- a/room.go
+++ b/room.go
@@ -175,6 +175,17 @@ func WithICETransportPolicy(iceTransportPolicy webrtc.ICETransportPolicy) Connec
 	}
 }
 
+// WithSettingEngineFunc customizes the pion SettingEngine (ICE interface/IP
+// filters, NAT1To1 mappings, timeouts) before the WebRTC API is constructed.
+// fn is invoked for every PeerConnection the SDK creates (publisher and
+// subscriber). Use it when the host has interfaces or IPs that must be excluded
+// from ICE candidate gathering and the existing options are insufficient.
+func WithSettingEngineFunc(fn func(*webrtc.SettingEngine)) ConnectOption {
+	return func(p *connParams) {
+		p.SettingEngineFunc = fn
+	}
+}
+
 // WithDisableTURN removes TURN/TURNS URLs from the ICE server configuration
 // provided by the SFU. Use this when the client is co-located with the SFU
 // and does not need relay candidates.

--- a/setting_engine_test.go
+++ b/setting_engine_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lksdk
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+
+	"github.com/livekit/server-sdk-go/v2/signalling"
+)
+
+func TestWithSettingEngineFunc(t *testing.T) {
+	p := &connParams{ConnectParams: &signalling.ConnectParams{}}
+
+	called := false
+	WithSettingEngineFunc(func(se *webrtc.SettingEngine) { called = true })(p)
+
+	if p.SettingEngineFunc == nil {
+		t.Fatal("WithSettingEngineFunc must set ConnectParams.SettingEngineFunc")
+	}
+
+	p.SettingEngineFunc(&webrtc.SettingEngine{})
+	if !called {
+		t.Fatal("the stored func must be the one supplied to WithSettingEngineFunc")
+	}
+}

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -91,6 +91,13 @@ type ConnectParams struct {
 
 	ICETransportPolicy webrtc.ICETransportPolicy
 
+	// SettingEngineFunc, if set, is invoked with the pion SettingEngine after the
+	// SDK builds it (per PeerConnection) and before the WebRTC API is created. It
+	// lets callers customize ICE behavior the SDK does not otherwise expose — for
+	// example SetInterfaceFilter / SetIPFilter to exclude interfaces or IPs from
+	// candidate gathering. See WithSettingEngineFunc.
+	SettingEngineFunc func(*webrtc.SettingEngine)
+
 	// DisableTURN removes TURN/TURNS URLs from the ICE server list provided by the SFU.
 	// Use this when the client is co-located with the SFU and does not need relay candidates.
 	DisableTURN bool

--- a/transport.go
+++ b/transport.go
@@ -81,6 +81,7 @@ type PCTransportParams struct {
 	OnRTTUpdate                func(rtt uint32)
 	IsSender                   bool
 	DTLSEllipticCurves         []dtlsElliptic.Curve
+	SettingEngineFunc          func(*webrtc.SettingEngine)
 }
 
 func (t *PCTransport) registerDefaultInterceptors(params PCTransportParams, i *interceptor.Registry) error {
@@ -218,6 +219,11 @@ func NewPCTransport(params PCTransportParams) (*PCTransport, error) {
 	lf := pionlogger.NewLoggerFactory(logger)
 	if lf != nil {
 		se.LoggerFactory = lf
+	}
+	// Allow callers to customize the SettingEngine (ICE interface/IP filters,
+	// NAT1To1, etc.) before the API is built.
+	if params.SettingEngineFunc != nil {
+		params.SettingEngineFunc(&se)
 	}
 
 	api := webrtc.NewAPI(webrtc.WithMediaEngine(m), webrtc.WithSettingEngine(se), webrtc.WithInterceptorRegistry(i))


### PR DESCRIPTION
## Motivation

`NewPCTransport` builds its `webrtc.SettingEngine` internally with no extension point, so callers cannot influence ICE behavior beyond `WithICETransportPolicy` / `WithDisableTURN`.

We run a server-side agent **co-located with the SFU** on a host that has many interfaces (docker bridges, `veth*`, IPv6). pion gathers ICE host candidates from all of them and sometimes selects an unreachable one, silently breaking the subscriber media path (the agent goes "deaf"). The remedy is `SettingEngine.SetInterfaceFilter` / `SetIPFilter`, which the SDK doesn't expose.

## Change

Adds a single, opt-in `ConnectOption`:

```go
// WithSettingEngineFunc customizes the pion SettingEngine before the WebRTC
// API is constructed. Invoked for every PeerConnection (publisher + subscriber).
func WithSettingEngineFunc(fn func(*webrtc.SettingEngine)) ConnectOption
```

`fn` runs after the SDK finishes configuring the `SettingEngine` and before `webrtc.NewAPI`, so callers can layer ICE interface/IP filters, `SetNAT1To1IPs`, etc. without losing the SDK's own settings.

Usage:
```go
room, err := lksdk.ConnectToRoom(url, info, cb,
    lksdk.WithSettingEngineFunc(func(se *webrtc.SettingEngine) {
        se.SetInterfaceFilter(func(name string) bool { return name == "eth0" || name == "lo" })
        se.SetIPFilter(func(ip net.IP) bool { return ip.To4() != nil })
    }),
)
```

## Details
- `signalling.ConnectParams.SettingEngineFunc` carries the hook; `WithSettingEngineFunc` sets it (mirrors the existing option pattern).
- Threaded into both `NewPCTransport` calls (publisher + subscriber) and invoked in `NewPCTransport` just before `webrtc.NewAPI`.
- **No behavior change when unset.** Unit test included (`TestWithSettingEngineFunc`). `go build ./... && go test` green.

Happy to adjust naming or scope to fit your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)