### PR TITLE
Record subscription intent and reconcile until converged

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -76,13 +76,15 @@ type engineHandler interface {
 	OnSubscribedQualityUpdate(subscribedQualityUpdate *livekit.SubscribedQualityUpdate)
 	OnSubscribedAudioCodecUpdate(subscribedAudioCodecUpdate *livekit.SubscribedAudioCodecUpdate)
 	OnMediaSectionsRequirement(mediaSectionsRequirement *livekit.MediaSectionsRequirement)
+	OnSubscriptionResponse(subscriptionResponse *livekit.SubscriptionResponse)
 }
 
 // -------------------------------------------
 
 var (
-	_ signalling.SignalTransportHandler = (*RTCEngine)(nil)
-	_ signalling.SignalProcessor        = (*RTCEngine)(nil)
+	_ signalling.SignalTransportHandler        = (*RTCEngine)(nil)
+	_ signalling.SignalProcessor               = (*RTCEngine)(nil)
+	_ signalling.SubscriptionResponseProcessor = (*RTCEngine)(nil)
 )
 
 // -------------------------------------------
@@ -129,6 +131,8 @@ type RTCEngine struct {
 	trackPublishedListenersLock sync.Mutex
 	trackPublishedListeners     map[string]chan *livekit.TrackPublishedResponse
 
+	subscriptionDesires *subscriptionDesireStore
+
 	subscriberPrimary bool
 	hasPublish        atomic.Bool
 	closed            atomic.Bool
@@ -155,6 +159,7 @@ func NewRTCEngine(
 		trackPublishedListeners:  make(map[string]chan *livekit.TrackPublishedResponse),
 		reliableMsgSeq:           1,
 		connectionManager:        newConnectionManager(regionProvider),
+		subscriptionDesires:      newSubscriptionDesireStore(),
 	}
 	e.signalHandler = signalling.NewSignalHandler(signalling.SignalHandlerParams{
 		Logger:    e.log,
@@ -1661,6 +1666,10 @@ func (e *RTCEngine) OnSubscribedAudioCodecUpdate(subscribedAudioCodecUpdate *liv
 
 func (e *RTCEngine) OnMediaSectionsRequirement(mediaSectionsRequirement *livekit.MediaSectionsRequirement) {
 	e.engineHandler.OnMediaSectionsRequirement(mediaSectionsRequirement)
+}
+
+func (e *RTCEngine) OnSubscriptionResponse(subscriptionResponse *livekit.SubscriptionResponse) {
+	e.engineHandler.OnSubscriptionResponse(subscriptionResponse)
 }
 
 // ------------------------------------

--- a/publication.go
+++ b/publication.go
@@ -175,18 +175,33 @@ func (p *RemoteTrackPublication) Receiver() *webrtc.RTPReceiver {
 
 // SetSubscribed subscribes or unsubscribes from this track.
 // When subscribed, track data will be received from the server.
+// On success the intent is recorded and re-asserted by the room until the
+// subscription state converges, surviving lost signal messages and
+// reconnects. On error the request is abandoned and previously recorded
+// intent is left as it was: retrying remains the caller's responsibility.
 func (p *RemoteTrackPublication) SetSubscribed(subscribed bool) error {
-	return p.engine.SendUpdateSubscription(
+	trackSID := p.sid.Load()
+	prevSubscribe, hadPrev := p.engine.subscriptionDesires.desired(trackSID)
+	p.engine.subscriptionDesires.set(trackSID, subscribed)
+	err := p.engine.SendUpdateSubscription(
 		&livekit.UpdateSubscription{
 			Subscribe: subscribed,
 			ParticipantTracks: []*livekit.ParticipantTracks{
 				{
 					ParticipantSid: p.participantID,
-					TrackSids:      []string{p.sid.Load()},
+					TrackSids:      []string{trackSID},
 				},
 			},
 		},
 	)
+	if err != nil {
+		if hadPrev {
+			p.engine.subscriptionDesires.set(trackSID, prevSubscribe)
+		} else {
+			p.engine.subscriptionDesires.clear(trackSID)
+		}
+	}
+	return err
 }
 
 // IsEnabled returns whether the track is enabled (not disabled).

--- a/publication.go
+++ b/publication.go
@@ -178,11 +178,9 @@ func (p *RemoteTrackPublication) Receiver() *webrtc.RTPReceiver {
 // On success the intent is recorded and re-asserted by the room until the
 // subscription state converges, surviving lost signal messages and
 // reconnects. On error the request is abandoned and previously recorded
-// intent is left as it was: retrying remains the caller's responsibility.
+// intent is untouched: retrying remains the caller's responsibility.
 func (p *RemoteTrackPublication) SetSubscribed(subscribed bool) error {
 	trackSID := p.sid.Load()
-	prevSubscribe, hadPrev := p.engine.subscriptionDesires.desired(trackSID)
-	p.engine.subscriptionDesires.set(trackSID, subscribed)
 	err := p.engine.SendUpdateSubscription(
 		&livekit.UpdateSubscription{
 			Subscribe: subscribed,
@@ -195,13 +193,10 @@ func (p *RemoteTrackPublication) SetSubscribed(subscribed bool) error {
 		},
 	)
 	if err != nil {
-		if hadPrev {
-			p.engine.subscriptionDesires.set(trackSID, prevSubscribe)
-		} else {
-			p.engine.subscriptionDesires.clear(trackSID)
-		}
+		return err
 	}
-	return err
+	p.engine.subscriptionDesires.set(trackSID, subscribed)
+	return nil
 }
 
 // IsEnabled returns whether the track is enabled (not disabled).

--- a/remoteparticipant.go
+++ b/remoteparticipant.go
@@ -150,6 +150,7 @@ func (p *RemoteParticipant) unpublishTrack(sid string, sendUnpublish bool) {
 		p.videoTracks.Delete(sid)
 	}
 	p.tracks.Delete(sid)
+	p.engine.subscriptionDesires.clear(sid)
 
 	track := pub.TrackRemote()
 	if track != nil {

--- a/room.go
+++ b/room.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/frostbyte73/core"
 	"github.com/pion/interceptor"
 	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v4"
@@ -342,6 +343,10 @@ type Room struct {
 	textStreamReaders  *sync.Map
 	rpcHandlers        *sync.Map
 
+	subReconcileKick  chan struct{}
+	subReconcileStart sync.Once
+	subReconcileStop  core.Fuse
+
 	lock sync.RWMutex
 }
 
@@ -360,11 +365,13 @@ func NewRoom(callback *RoomCallback) *Room {
 		textStreamHandlers: &sync.Map{},
 		textStreamReaders:  &sync.Map{},
 		rpcHandlers:        &sync.Map{},
+		subReconcileKick:   make(chan struct{}, 1),
 	}
 	r.callback.Merge(callback)
 
 	r.engine = NewRTCEngine(r.useSinglePeerConnection, r, r.getLocalParticipantSID, r.regionURLProvider)
 	r.LocalParticipant = newLocalParticipant(r.engine, r.callback, r.serverInfo, r.log)
+	r.engine.subscriptionDesires.setOnDirty(r.ensureSubscriptionReconciler)
 	return r
 }
 
@@ -729,7 +736,13 @@ func (r *Room) sendSyncState() {
 	sendUnsub := r.engine.getConnectParams().AutoSubscribe
 	for _, rp := range r.GetRemoteParticipants() {
 		for _, t := range rp.TrackPublications() {
-			if t.IsSubscribed() != sendUnsub {
+			// use recorded intent when present so a subscription whose request
+			// was lost in flight is replayed by the sync state
+			subscribed := t.IsSubscribed()
+			if desired, ok := r.engine.subscriptionDesires.desired(t.SID()); ok {
+				subscribed = desired
+			}
+			if subscribed != sendUnsub {
 				trackSids = append(trackSids, t.SID())
 			}
 
@@ -806,6 +819,9 @@ func (r *Room) cleanup() {
 
 	r.rpcHandlers.Clear()
 	r.LocalParticipant.cleanup()
+
+	r.subReconcileStop.Break()
+	r.engine.subscriptionDesires.clearAll()
 }
 
 func (r *Room) setSid(sid string, allowEmpty bool) {
@@ -1103,6 +1119,8 @@ func (r *Room) OnRestarted(
 	r.OnParticipantUpdate(otherParticipants)
 
 	r.LocalParticipant.republishTracks()
+	r.engine.subscriptionDesires.resetAttempts()
+	r.kickSubscriptionReconcile()
 
 	r.callback.OnReconnected()
 }
@@ -1115,6 +1133,8 @@ func (r *Room) OnResumed() {
 	r.callback.OnReconnected()
 	r.sendSyncState()
 	r.LocalParticipant.updateSubscriptionPermission()
+	r.engine.subscriptionDesires.resetAttempts()
+	r.kickSubscriptionReconcile()
 }
 
 func (r *Room) OnDataPacket(identity string, dataPacket DataPacket) {
@@ -1392,6 +1412,30 @@ func (r *Room) OnMediaSectionsRequirement(mediaSectionsRequirement *livekit.Medi
 	addTransceivers(publisher, webrtc.RTPCodecTypeAudio, mediaSectionsRequirement.NumAudios)
 	addTransceivers(publisher, webrtc.RTPCodecTypeVideo, mediaSectionsRequirement.NumVideos)
 	publisher.Negotiate()
+}
+
+func (r *Room) OnSubscriptionResponse(subscriptionResponse *livekit.SubscriptionResponse) {
+	if subscriptionResponse == nil || subscriptionResponse.GetErr() == livekit.SubscriptionError_SE_UNKNOWN {
+		return
+	}
+
+	trackSID := subscriptionResponse.GetTrackSid()
+
+	// the server rejected the subscription; stop re-asserting it and surface
+	// the failure instead of letting consumers wait on a timeout
+	r.engine.subscriptionDesires.clear(trackSID)
+	r.log.Warnw(
+		"server rejected subscription", errors.New(subscriptionResponse.GetErr().String()),
+		"trackID", trackSID,
+	)
+
+	for _, rp := range r.GetRemoteParticipants() {
+		if rp.getPublication(trackSID) != nil {
+			rp.Callback.OnTrackSubscriptionFailed(trackSID, rp)
+			r.callback.OnTrackSubscriptionFailed(trackSID, rp)
+			return
+		}
+	}
 }
 
 func (r *Room) OnStreamHeader(streamHeader *livekit.DataStream_Header, participantIdentity string) {

--- a/signalling/interfaces.go
+++ b/signalling/interfaces.go
@@ -182,3 +182,10 @@ type SignalProcessor interface {
 	OnSubscribedAudioCodecUpdate(subscribedAudioCodecUpdate *livekit.SubscribedAudioCodecUpdate)
 	OnMediaSectionsRequirement(mediaSectionsRequirement *livekit.MediaSectionsRequirement)
 }
+
+// SubscriptionResponseProcessor is an optional extension of SignalProcessor.
+// Processors that also implement it receive server responses to subscription
+// requests; others continue to compile and behave as before.
+type SubscriptionResponseProcessor interface {
+	OnSubscriptionResponse(subscriptionResponse *livekit.SubscriptionResponse)
+}

--- a/signalling/signalhandler.go
+++ b/signalling/signalhandler.go
@@ -121,6 +121,11 @@ func (s *signalhandler) HandleMessage(msg proto.Message) error {
 
 	case *livekit.SignalResponse_MediaSectionsRequirement:
 		s.params.Processor.OnMediaSectionsRequirement(payload.MediaSectionsRequirement)
+
+	case *livekit.SignalResponse_SubscriptionResponse:
+		if p, ok := s.params.Processor.(SubscriptionResponseProcessor); ok {
+			p.OnSubscriptionResponse(payload.SubscriptionResponse)
+		}
 	}
 
 	return nil

--- a/subscriptiondesire.go
+++ b/subscriptiondesire.go
@@ -1,0 +1,273 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lksdk
+
+import (
+	"sync"
+	"time"
+
+	"github.com/livekit/protocol/livekit"
+)
+
+const (
+	subscriptionReconcileInterval   = 3 * time.Second
+	subscriptionReconcileMaxBackoff = 24 * time.Second
+
+	// desires that never matched a known track are dropped after this long
+	subscriptionDesireTTL = 2 * time.Minute
+
+	// an unsubscribe has no client-side observable to confirm convergence:
+	// the SDK never clears the attached track on unsubscribe, so
+	// IsSubscribed() remains true. Unsubscribe desires are therefore
+	// re-asserted a bounded number of times per connection epoch instead of
+	// reconciled to convergence.
+	maxUnsubscribeAttempts = 3
+)
+
+// subscriptionDesire records the intended subscription state for a remote
+// track. UpdateSubscription signal messages are fire-and-forget with no
+// delivery acknowledgement; recording intent allows the room to re-assert it
+// until the actual subscription state converges.
+type subscriptionDesire struct {
+	subscribe   bool
+	updatedAt   time.Time
+	lastAttempt time.Time
+	attempts    int
+}
+
+type subscriptionDesireStore struct {
+	mu      sync.Mutex
+	desires map[string]*subscriptionDesire
+	onDirty func()
+}
+
+func newSubscriptionDesireStore() *subscriptionDesireStore {
+	return &subscriptionDesireStore{
+		desires: make(map[string]*subscriptionDesire),
+	}
+}
+
+// setOnDirty registers a hook invoked whenever a desire is recorded, allowing
+// the reconciler to be started lazily on first use.
+func (s *subscriptionDesireStore) setOnDirty(onDirty func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onDirty = onDirty
+}
+
+func (s *subscriptionDesireStore) set(trackSID string, subscribe bool) {
+	now := time.Now()
+	s.mu.Lock()
+	s.desires[trackSID] = &subscriptionDesire{
+		subscribe:   subscribe,
+		updatedAt:   now,
+		lastAttempt: now,
+	}
+	onDirty := s.onDirty
+	s.mu.Unlock()
+
+	if onDirty != nil {
+		onDirty()
+	}
+}
+
+func (s *subscriptionDesireStore) desired(trackSID string) (subscribe bool, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if d, ok := s.desires[trackSID]; ok {
+		return d.subscribe, true
+	}
+	return false, false
+}
+
+func (s *subscriptionDesireStore) clear(trackSID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.desires, trackSID)
+}
+
+func (s *subscriptionDesireStore) clearAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.desires = make(map[string]*subscriptionDesire)
+}
+
+// dueAttempt reports whether the desire for trackSID diverges from the actual
+// subscription state and is due for a re-send, marking the attempt if so.
+// Realized desires have their retry backoff reset.
+func (s *subscriptionDesireStore) dueAttempt(trackSID string, actual bool, force bool) (due bool, subscribe bool, attempts int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	d, ok := s.desires[trackSID]
+	if !ok {
+		return false, false, 0
+	}
+	if d.subscribe == actual {
+		d.attempts = 0
+		return false, false, 0
+	}
+	if !d.subscribe && d.attempts >= maxUnsubscribeAttempts {
+		return false, false, 0
+	}
+
+	backoff := subscriptionReconcileInterval << min(d.attempts, 3)
+	if backoff > subscriptionReconcileMaxBackoff {
+		backoff = subscriptionReconcileMaxBackoff
+	}
+	now := time.Now()
+	if !force && now.Sub(d.lastAttempt) < backoff {
+		return false, false, 0
+	}
+
+	d.lastAttempt = now
+	d.attempts++
+	return true, d.subscribe, d.attempts
+}
+
+// resetAttempts starts a fresh assertion epoch, used after reconnects where
+// requests sent on the previous connection may have been lost.
+func (s *subscriptionDesireStore) resetAttempts() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, d := range s.desires {
+		d.attempts = 0
+	}
+}
+
+func (s *subscriptionDesireStore) pruneStale(known func(trackSID string) bool) {
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for sid, d := range s.desires {
+		if !known(sid) && now.Sub(d.updatedAt) > subscriptionDesireTTL {
+			delete(s.desires, sid)
+		}
+	}
+}
+
+// -----------------------------------------------------------
+
+// ensureSubscriptionReconciler starts the reconcile loop on first use so that
+// rooms which never subscribe selectively never spawn it. Starting after
+// cleanup is harmless: the loop observes the broken fuse and exits
+// immediately.
+func (r *Room) ensureSubscriptionReconciler() {
+	if r.subReconcileStop.IsBroken() {
+		return
+	}
+	r.subReconcileStart.Do(func() {
+		go r.subscriptionReconcileLoop()
+	})
+}
+
+func (r *Room) subscriptionReconcileLoop() {
+	ticker := time.NewTicker(subscriptionReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.subReconcileStop.Watch():
+			return
+		case <-r.subReconcileKick:
+			r.reconcileSubscriptions(true)
+		case <-ticker.C:
+			r.reconcileSubscriptions(false)
+		}
+	}
+}
+
+// kickSubscriptionReconcile triggers an immediate reconcile pass, bypassing
+// the retry backoff. Used after reconnects, where requests in flight on the
+// previous connection may have been lost.
+func (r *Room) kickSubscriptionReconcile() {
+	select {
+	case r.subReconcileKick <- struct{}{}:
+	default:
+	}
+}
+
+// reconcileSubscriptions re-sends UpdateSubscription for tracks whose actual
+// subscription state has not converged to the recorded desired state.
+func (r *Room) reconcileSubscriptions(force bool) {
+	if r.ConnectionState() != ConnectionStateConnected {
+		return
+	}
+
+	store := r.engine.subscriptionDesires
+	knownSids := make(map[string]bool)
+	subscribe := make(map[string][]string)
+	unsubscribe := make(map[string][]string)
+
+	for _, rp := range r.GetRemoteParticipants() {
+		for _, t := range rp.TrackPublications() {
+			pub, ok := t.(*RemoteTrackPublication)
+			if !ok {
+				continue
+			}
+			sid := pub.SID()
+			knownSids[sid] = true
+
+			due, sub, attempts := store.dueAttempt(sid, pub.IsSubscribed(), force)
+			if !due {
+				continue
+			}
+			if sub {
+				subscribe[pub.participantID] = append(subscribe[pub.participantID], sid)
+			} else {
+				unsubscribe[pub.participantID] = append(unsubscribe[pub.participantID], sid)
+			}
+			r.log.Infow(
+				"subscription not converged, re-sending",
+				"trackID", sid,
+				"participant", rp.Identity(),
+				"subscribe", sub,
+				"attempts", attempts,
+			)
+		}
+	}
+
+	store.pruneStale(func(sid string) bool { return knownSids[sid] })
+
+	r.sendSubscriptionUpdate(subscribe, true)
+	r.sendSubscriptionUpdate(unsubscribe, false)
+}
+
+func (r *Room) sendSubscriptionUpdate(sidsByParticipant map[string][]string, subscribe bool) {
+	if len(sidsByParticipant) == 0 {
+		return
+	}
+
+	participantTracks := make([]*livekit.ParticipantTracks, 0, len(sidsByParticipant))
+	var trackSids []string
+	for participantSid, sids := range sidsByParticipant {
+		participantTracks = append(participantTracks, &livekit.ParticipantTracks{
+			ParticipantSid: participantSid,
+			TrackSids:      sids,
+		})
+		trackSids = append(trackSids, sids...)
+	}
+
+	if err := r.engine.SendUpdateSubscription(&livekit.UpdateSubscription{
+		Subscribe:         subscribe,
+		ParticipantTracks: participantTracks,
+	}); err != nil {
+		r.log.Warnw(
+			"could not re-send subscription request", err,
+			"trackIDs", trackSids,
+			"subscribe", subscribe,
+		)
+	}
+}


### PR DESCRIPTION
UpdateSubscription signal messages are fire-and-forget: SetSubscribed sends one message and keeps no record of it. If that message is lost (stalled controller, dropped relay stream, reconnect race), desired and actual subscription state diverge permanently - the SDK waits forever and sync state on resume only replays subscriptions that already attached.

- record desired subscription state per track in SetSubscribed
- reconcile loop per room re-sends UpdateSubscription (batched, with backoff) until the subscription attaches or is cleared; started lazily on the first recorded desire so rooms that never subscribe selectively never spawn it, stopped on room cleanup
- unsubscribes have no client-side convergence observable (the attached track is never cleared), so they are re-asserted a bounded number of times per connection epoch instead of reconciled to convergence
- sendSyncState replays recorded intent, not just attached tracks
- reconcile kicked (and attempt counters reset) after resume and full reconnect
- handle SubscriptionResponse errors: stop re-asserting rejected subscriptions and fire OnTrackSubscriptionFailed instead of timing out; routed via a new optional SubscriptionResponseProcessor interface so existing SignalProcessor implementations keep compiling

No breaking API changes