### PR TITLE
sync engine: bound timeline drift, preserve OWD across NTP rebuilds

### DIFF
--- a/pkg/synchronizer/ntpestimator.go
+++ b/pkg/synchronizer/ntpestimator.go
@@ -122,8 +122,10 @@ func (e *NtpEstimator) Reset() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.resetLocked()
+	e.owdEstimator = latency.NewOWDEstimator(latency.OWDEstimatorParamsDefault)
 }
 
+// resetLocked clears regression state only; OWD is kept because outlier-triggered rebuilds are residual-pattern changes, not network changes — resetting OWD would shift sessionPTS by the reconvergence delta and thrash the tempo controller.
 func (e *NtpEstimator) resetLocked() {
 	e.samples = [maxSRSamples]srSample{}
 	e.sampleLen = 0
@@ -137,10 +139,6 @@ func (e *NtpEstimator) resetLocked() {
 	e.residStd = 0
 	e.ready = false
 	e.consecutiveOutliers = 0
-	// Reset OWD: a sender NTP step that triggered the regression rebuild also
-	// invalidates the previously-measured clock offset, so the estimator must
-	// re-converge from the new sender state.
-	e.owdEstimator = latency.NewOWDEstimator(latency.OWDEstimatorParamsDefault)
 }
 
 // SRResult indicates the outcome of processing a sender report.

--- a/pkg/synchronizer/ntpestimator.go
+++ b/pkg/synchronizer/ntpestimator.go
@@ -115,9 +115,7 @@ func NewNtpEstimator(clockRate uint32) *NtpEstimator {
 	}
 }
 
-// Reset clears all state, returning the estimator to its initial condition.
-// Used when a stream discontinuity is detected (e.g., stream restart with a new
-// RTP offset) and the old regression is no longer valid.
+// Reset clears all state including OWD. Called via SessionTimeline.ResetTrack for true stream discontinuities where every prior sample is stale.
 func (e *NtpEstimator) Reset() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -125,7 +123,7 @@ func (e *NtpEstimator) Reset() {
 	e.owdEstimator = latency.NewOWDEstimator(latency.OWDEstimatorParamsDefault)
 }
 
-// resetLocked clears regression state only; OWD is kept because outlier-triggered rebuilds are residual-pattern changes, not network changes — resetting OWD would shift sessionPTS by the reconvergence delta and thrash the tempo controller.
+// resetLocked clears the regression only; OWD is preserved because outlier-triggered rebuilds don't imply a network change and re-converging OWD would thrash the tempo controller.
 func (e *NtpEstimator) resetLocked() {
 	e.samples = [maxSRSamples]srSample{}
 	e.sampleLen = 0

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -221,17 +221,19 @@ func TestSyncEngineTrack_wallClockPTSForRTP_UsesRTPDelta(t *testing.T) {
 	st.mu.Lock()
 	st.startTime = startTime
 	st.lastTS = 48000 // 1s at 48kHz
-	st.lastWallPTS = time.Second
+	st.lastWallPTSSlewed = time.Second
+	st.lastWallPTSUnslewed = time.Second
 	st.initialized = true
 	st.mu.Unlock()
 
-	// SR RTPTime is 1s ahead of lastTS, wallElapsed matches → returns rtpDerived.
+	// SR RTPTime is 1s ahead of lastTS → sensor returns unslewed baseline + rtpDelta = 2s.
 	wallPTS, ok := st.wallClockPTSForRTP(96000, startTime.Add(2*time.Second))
 	require.True(t, ok)
 	require.Equal(t, 2*time.Second, wallPTS)
 }
 
-func TestSyncEngineTrack_wallClockPTSForRTP_BackwardRTPFallsBackToWallClock(t *testing.T) {
+func TestSyncEngineTrack_wallClockPTSForRTP_BackwardRTPReportsNotOk(t *testing.T) {
+	// Backward RTP would wrap uint32 into a huge unslewed delta — sensor must skip
 	engine := NewSyncEngine()
 	track := newMockAudioTrack("audio-1", 1000)
 	st := engine.AddTrack(track, "alice").(*syncEngineTrack)
@@ -240,15 +242,33 @@ func TestSyncEngineTrack_wallClockPTSForRTP_BackwardRTPFallsBackToWallClock(t *t
 	st.mu.Lock()
 	st.startTime = startTime
 	st.lastTS = 48000 * 100 // 100s of media already
-	st.lastWallPTS = 100 * time.Second
+	st.lastWallPTSSlewed = 100 * time.Second
+	st.lastWallPTSUnslewed = 100 * time.Second
 	st.initialized = true
 	st.mu.Unlock()
 
-	// RTPTime behind lastTS: uint32 wrap → huge rtpDerived → sanity check fails
-	// → falls back to wall-clock elapsed.
-	wallPTS, ok := st.wallClockPTSForRTP(48000, startTime.Add(time.Second))
-	require.True(t, ok)
-	require.Equal(t, time.Second, wallPTS)
+	_, ok := st.wallClockPTSForRTP(48000, startTime.Add(time.Second))
+	require.False(t, ok, "backward RTP (reorder or uint32 wrap) must not produce a sensor value")
+}
+
+func TestSyncEngineTrack_wallClockPTSForRTP_HugeForwardJumpReportsNotOk(t *testing.T) {
+	// 30s+ forward rtpDelta = stream restart before GetPTS re-anchored; sensor must skip
+	engine := NewSyncEngine()
+	track := newMockAudioTrack("audio-1", 1000)
+	st := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	startTime := time.Now()
+	st.mu.Lock()
+	st.startTime = startTime
+	st.lastTS = 48000
+	st.lastWallPTSSlewed = time.Second
+	st.lastWallPTSUnslewed = time.Second
+	st.initialized = true
+	st.mu.Unlock()
+
+	// 31s of forward RTP (48000Hz × 31s).
+	_, ok := st.wallClockPTSForRTP(48000+48000*31, startTime.Add(31*time.Second))
+	require.False(t, ok, "30s+ forward RTP jump must not produce a sensor value")
 }
 
 // driftScenario runs N packets and SRs through an engine and returns the
@@ -384,7 +404,8 @@ func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
 	initialLastNtpPTS := tr.lastNtpPTS
 	initialTransitionSlew := tr.transitionSlew
 	initialLastTS := tr.lastTS
-	initialLastWallPTS := tr.lastWallPTS
+	initialLastWallPTSSlewed := tr.lastWallPTSSlewed
+	initialLastWallPTSUnslewed := tr.lastWallPTSUnslewed
 	initialLastSlewPTS := tr.lastSlewPTS
 	tr.mu.Unlock()
 	require.Greater(t, int64(initialLastNtpPTS), int64(0), "lastNtpPTS should be populated by the prime sequence")
@@ -406,7 +427,8 @@ func TestSyncEngine_BackwardRTPDoesNotResetNTPState(t *testing.T) {
 	// RTP/wall/slew baselines must stay anchored to the last forward packet so
 	// the next forward packet's expected-extrapolation baselines line up.
 	require.Equal(t, initialLastTS, tr.lastTS, "lastTS must not shift backward on reorder")
-	require.Equal(t, initialLastWallPTS, tr.lastWallPTS, "lastWallPTS must not shift backward on reorder")
+	require.Equal(t, initialLastWallPTSSlewed, tr.lastWallPTSSlewed, "lastWallPTSSlewed must not shift backward on reorder")
+	require.Equal(t, initialLastWallPTSUnslewed, tr.lastWallPTSUnslewed, "lastWallPTSUnslewed must not shift backward on reorder")
 	require.Equal(t, initialLastSlewPTS, tr.lastSlewPTS, "lastSlewPTS must not shift backward on reorder")
 }
 
@@ -436,6 +458,105 @@ func TestSyncEngine_ForwardDiscontinuityStillResetsNTPState(t *testing.T) {
 	require.Equal(t, time.Duration(0), tr.lastNtpPTS, "lastNtpPTS must be reset on forward discontinuity")
 	require.Equal(t, time.Duration(0), tr.transitionSlew, "transitionSlew must be reset on forward discontinuity")
 	require.False(t, tr.ntpTransitioned, "ntpTransitioned must be reset on forward discontinuity")
+}
+
+func TestSyncEngine_LatePacketDoesNotPerturbDriftSensor(t *testing.T) {
+	// Late packet must bump slewed (cliff protection) but not unslewed (sensor)
+	engine := NewSyncEngine(WithSyncEngineAudioDriftCompensated())
+	track := newMockAudioTrack("audio-1", 1000)
+	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	now := time.Now()
+	tr.PrimeForStart(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(0, 0, now))
+	for i := 1; i <= 10; i++ {
+		tr.GetPTS(makeExtPacket(uint32(i)*960, uint16(i), now.Add(time.Duration(i)*20*time.Millisecond)))
+	}
+	tr.mu.Lock()
+	baseSlewed := tr.lastWallPTSSlewed
+	baseUnslewed := tr.lastWallPTSUnslewed
+	tr.mu.Unlock()
+
+	// Packet 11: nominal ts, receivedAt +200ms late → slew absorbs 200ms·α = 2ms.
+	tr.GetPTS(makeExtPacket(11*960, 11, now.Add(11*20*time.Millisecond+200*time.Millisecond)))
+
+	tr.mu.Lock()
+	slewedGain := tr.lastWallPTSSlewed - baseSlewed
+	unslewedGain := tr.lastWallPTSUnslewed - baseUnslewed
+	tr.mu.Unlock()
+
+	require.InDelta(t, float64(20*time.Millisecond), float64(unslewedGain), float64(200*time.Microsecond),
+		"unslewed baseline must not absorb receivedAt jitter; got gain %v", unslewedGain)
+	require.InDelta(t, float64(22*time.Millisecond), float64(slewedGain), float64(500*time.Microsecond),
+		"slewed baseline should gain rtpDelta + slew absorption (~22ms); got %v", slewedGain)
+	require.Greater(t, slewedGain-unslewedGain, time.Millisecond,
+		"slewed must move measurably above unslewed on late-packet injection; slewed=%v unslewed=%v",
+		slewedGain, unslewedGain)
+}
+
+func TestSyncEngine_PublisherSkewVisibleToDriftSensor(t *testing.T) {
+	// Slew leaking into the sensor would blind tempo to publisher skew in steady state
+	engine := NewSyncEngine(WithSyncEngineAudioDriftCompensated())
+	track := newMockAudioTrack("audio-1", 1000)
+	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	now := time.Now()
+	tr.PrimeForStart(makeExtPacket(0, 0, now))
+	tr.GetPTS(makeExtPacket(0, 0, now))
+
+	const packets = 500
+	const walltickMs = 20
+	const rtpSamplesPerPacket = 970 // 970/48000 ≈ 20.208ms → ~1% publisher-fast
+	var lastReceivedAt time.Time
+	var lastRTP uint32
+	for i := 1; i <= packets; i++ {
+		lastReceivedAt = now.Add(time.Duration(i*walltickMs) * time.Millisecond)
+		lastRTP = uint32(i) * rtpSamplesPerPacket
+		tr.GetPTS(makeExtPacket(lastRTP, uint16(i), lastReceivedAt))
+	}
+
+	tr.mu.Lock()
+	slewedOverWall := tr.lastWallPTSSlewed - time.Duration(packets*walltickMs)*time.Millisecond
+	unslewedOverWall := tr.lastWallPTSUnslewed - time.Duration(packets*walltickMs)*time.Millisecond
+	tr.mu.Unlock()
+
+	// Slewed steady state ≈ R·δ·(1-α)/α — bounded, not linear.
+	require.Less(t, slewedOverWall, 100*time.Millisecond,
+		"slewed baseline must stay bounded near wallElapsed; got %v", slewedOverWall)
+	// Unslewed grows linearly: 500 × ~0.208ms ≈ 104ms.
+	require.Greater(t, unslewedOverWall, 90*time.Millisecond,
+		"unslewed baseline must track publisher-skew accumulation; got %v", unslewedOverWall)
+
+	sensor, ok := tr.wallClockPTSForRTP(lastRTP, lastReceivedAt)
+	require.True(t, ok)
+	tr.mu.Lock()
+	require.Equal(t, tr.lastWallPTSUnslewed, sensor,
+		"sensor value must equal lastWallPTSUnslewed when SR RTPTime matches lastTS")
+	tr.mu.Unlock()
+}
+
+func TestSyncEngine_DiscontinuityReAnchorsUnslewedBaseline(t *testing.T) {
+	// 30s+ jump with wallclock unchanged must snap both baselines; otherwise unslewed carries phantom drift
+	engine := NewSyncEngine()
+	track := newMockAudioTrack("audio-1", 1000)
+	tr := engine.AddTrack(track, "alice").(*syncEngineTrack)
+
+	now := time.Now()
+	lastRecv := primeNTPReady(t, engine, tr, "alice", "audio-1", now)
+
+	tr.mu.Lock()
+	lastTS := tr.lastTS
+	tr.mu.Unlock()
+
+	bigJumpTS := lastTS + uint32(48000*60)
+	tr.GetPTS(makeExtPacket(bigJumpTS, 200, lastRecv.Add(20*time.Millisecond)))
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	require.Equal(t, tr.lastWallPTSSlewed, tr.lastWallPTSUnslewed,
+		"post-discontinuity, both wall baselines must be re-anchored to the same wallElapsed")
+	require.Less(t, tr.lastWallPTSUnslewed, 30*time.Second,
+		"unslewed baseline must NOT carry the 60s rtpDelta jump forward; got %v", tr.lastWallPTSUnslewed)
 }
 
 func TestSyncEngine_OnSR_NotCalledAfterRemoveTrack(t *testing.T) {

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -423,12 +423,18 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 			if time.Since(st.lastTimelyPacket) > maxTimelyPacketAge {
 				oldPTS := pts
 				pts = deadline - st.engine.maxMediaRunningTimeDelay/2
+				correction := pts - oldPTS
 				st.logger.Warnw("force-correcting PTS forward, track behind pipeline deadline", nil,
 					"oldPTS", oldPTS,
 					"newPTS", pts,
 					"deadline", deadline,
 					"behindBy", limit-oldPTS,
+					"correction", correction,
 				)
+				// Emission-side only: lastWallPTSUnslewed and NTP state must keep seeing true media-vs-wall skew, not our synthetic catch-up
+				st.sessionOffset += correction
+				st.lastWallPTSSlewed += correction
+				preSlewPTS += correction
 				// Reset timeliness clock so a lingering transient deficit doesn't fire force-correction on every subsequent packet, collapsing them into the same newPTS at the mixer.
 				st.lastTimelyPacket = time.Now()
 			}

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -431,9 +431,10 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 					"behindBy", limit-oldPTS,
 					"correction", correction,
 				)
-				// Emission-side only: lastWallPTSUnslewed and NTP state must keep seeing true media-vs-wall skew, not our synthetic catch-up
+				// Emission-side only: lastWallPTSUnslewed and NTP state must keep seeing true media-vs-wall skew, not our synthetic catch-up.
+				// wallPTS was captured pre-correction and is stored back into lastWallPTSSlewed below, so shift the local too or the bump is lost.
 				st.sessionOffset += correction
-				st.lastWallPTSSlewed += correction
+				wallPTS += correction
 				preSlewPTS += correction
 				// Reset timeliness clock so a lingering transient deficit doesn't fire force-correction on every subsequent packet, collapsing them into the same newPTS at the mixer.
 				st.lastTimelyPacket = time.Now()

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -66,11 +66,14 @@ type syncEngineTrack struct {
 	converter *rtputil.RTPConverter
 	startGate startGate // from start_gate.go, nil if not enabled
 
-	mu              sync.Mutex
-	startTime       time.Time
-	sessionOffset   time.Duration // offset from session start to this track's start
-	lastTS          uint32
-	lastWallPTS     time.Duration // last pure wall-clock-derived PTS, independent of NTP corrections; used as the baseline for wallClockPTSForRTPLocked
+	mu            sync.Mutex
+	startTime     time.Time
+	sessionOffset time.Duration // offset from session start to this track's start
+	lastTS        uint32
+
+	lastWallPTSSlewed   time.Duration // emission baseline: slew-adjusted, sanity-clamped
+	lastWallPTSUnslewed time.Duration // drift-sensor baseline: pure rtpDerived
+
 	lastPTSAdjusted time.Duration // last emitted PTS (post-NTP-correction, post-slew, post-monotonicity)
 	initialized     bool          // initializeLocked has run (startTime/sessionOffset/lastTS are set)
 	hasEmitted      bool          // GetPTS has returned at least one PTS; used to distinguish "no prior emission" from "prior emission was zero-valued"
@@ -158,13 +161,9 @@ func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) func() {
 	// Initialize the engine's session start time.
 	sessionStart, onStarted := st.engine.initializeIfNeeded(receivedAt)
 	st.sessionOffset = time.Duration(receivedAt.UnixNano() - sessionStart)
-	// Seed lastWallPTS to sessionOffset so wallClockPTSForRTPLocked returns
-	// sessionOffset (not 0) for the first packet's RTP-delta extrapolation.
-	// Without this, late-joining tracks would have lastWallPTS=0 and emit
-	// wallPTS starting at 0 instead of sessionOffset, then the NTP trust
-	// threshold clamp (500ms) would lock pts to the wrong wallPTS for any
-	// sessionOffset between ~20ms and 5s (the sanity-fallback range).
-	st.lastWallPTS = st.sessionOffset
+	// Seed to sessionOffset, not 0: late-joining tracks would else emit wallPTS from 0 and get NTP-trust-clamped to the wrong baseline
+	st.lastWallPTSSlewed = st.sessionOffset
+	st.lastWallPTSUnslewed = st.sessionOffset
 
 	st.logger.Infow("initialized track",
 		"startTime", st.startTime,
@@ -222,7 +221,7 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 	// Step 1: Try NTP-grounded PTS from SessionTimeline.
 	rawNtpPTS, ntpErr := st.engine.timeline.GetSessionPTS(st.participantID, st.track.ID(), ts)
 
-	wallPTS := st.wallClockPTS(pkt)
+	wallPTS, wallPTSUnslewed := st.wallClockPTS(pkt)
 
 	// Audio tracks with external drift compensation (e.g., tempo controller) skip
 	// NTP PTS corrections — drift is handled by resampling, not PTS adjustment.
@@ -266,6 +265,8 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		// to be cleared: the end-of-iter update overwrites it with the
 		// pre-slew PTS for this packet, providing a valid baseline for the
 		// next iteration's slewPTSDelta.
+		// Re-anchor unslewed; the 30s+ delta would otherwise persist as phantom drift
+		wallPTSUnslewed = wallPTS
 		st.logger.Warnw("stream discontinuity detected, resetting NTP state", nil,
 			"rtpDelta", rtpDelta,
 			"rtpDeltaDuration", rtpDeltaDuration,
@@ -448,24 +449,11 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 		return 0, io.EOF
 	}
 
-	// Update state. lastWallPTS captures the pre-adjustment wall-clock-derived
-	// PTS for this packet so that wallClockPTSForRTPLocked has an NTP-independent
-	// baseline for the next packet's RTP-delta extrapolation. lastSlewPTS holds
-	// the pre-slew/pre-force-correction PTS (captured as preSlewPTS above) so
-	// the next iteration's slewPTSDelta tracks media-time progression rather
-	// than output-space movement — see preSlewPTS comment for why.
-	//
-	// Anchor lastTS / lastWallPTS / lastSlewPTS on forward (signedRTPDelta >= 0)
-	// progression only — matches the lastNtpPTS guard above. A backward
-	// (reordered) packet would otherwise leave the next iteration's
-	// expectedRawNtpPTS (uses lastNtpPTS + (ts - lastTS) extrapolation) reading
-	// from mismatched baselines, and would feed a large positive slewPTSDelta
-	// into the decay loop on the next forward packet — burning slew far faster
-	// than intended. lastPTSAdjusted updates unconditionally so monotonicity
-	// always sees the most recently emitted PTS.
+	// Anchor forward-only: backward packets would mismatch the next iter's expected-jump baselines and burn slew via a bogus slewPTSDelta
 	if signedRTPDelta >= 0 {
 		st.lastTS = ts
-		st.lastWallPTS = wallPTS
+		st.lastWallPTSSlewed = wallPTS
+		st.lastWallPTSUnslewed = wallPTSUnslewed
 		st.lastSlewPTS = preSlewPTS
 	}
 	st.lastPTSAdjusted = pts
@@ -474,26 +462,30 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 	return pts, nil
 }
 
-// wallClockPTS computes a PTS based on wall-clock timing and RTP deltas.
-// Independent of NTP corrections — used as a sanity reference for NTP-derived PTS.
-func (st *syncEngineTrack) wallClockPTS(pkt jitter.ExtPacket) time.Duration {
+func (st *syncEngineTrack) wallClockPTS(pkt jitter.ExtPacket) (slewed, unslewed time.Duration) {
 	return st.wallClockPTSForRTPLocked(pkt.Timestamp, pkt.ReceivedAt)
 }
 
-// wallClockPTSForRTP returns the PTS that would be assigned to an SR's RTP timestamp without emitting it.
+// wallClockPTSForRTP returns the sensor-side wall PTS for OnRTCP; !ok when the value would be a phantom (uninit, backward RTP, or 30s+ jump)
 func (st *syncEngineTrack) wallClockPTSForRTP(ts uint32, receivedAt time.Time) (time.Duration, bool) {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	// closed: closeLocked may have run between OnRTCP releasing st.mu and us reacquiring it; a phantom wallPTS here would arm a tempo correction against audio that is already gone.
 	if !st.initialized || st.closed {
 		return 0, false
 	}
-	return st.wallClockPTSForRTPLocked(ts, receivedAt), true
+	signedDelta := int32(ts - st.lastTS)
+	if signedDelta < 0 {
+		return 0, false
+	}
+	if st.converter.ToDuration(uint32(signedDelta)) >= 30*time.Second {
+		return 0, false
+	}
+	_, unslewed := st.wallClockPTSForRTPLocked(ts, receivedAt)
+	return unslewed, true
 }
 
-// wallClockPTSForRTPLocked is the lock-held implementation of wall-clock PTS
-// computation. Caller must hold st.mu.
-func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.Time) time.Duration {
+// wallClockPTSForRTPLocked returns (slewed for emission, unslewed for drift sensor); slewing both would hide publisher skew from the tempo controller
+func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.Time) (slewed, unslewed time.Duration) {
 	// A zero receivedAt would make wallElapsed hugely negative and lock every downstream clamp onto a bogus baseline.
 	if receivedAt.IsZero() {
 		receivedAt = time.Now()
@@ -505,22 +497,23 @@ func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.T
 	}
 
 	if !st.initialized {
-		return wallElapsed
+		return wallElapsed, wallElapsed
 	}
 
-	// uint32 subtraction wraps for backward RTP timestamps; the sanity check
-	// below catches the resulting huge positive delta and falls back to wall clock.
+	// uint32 wraps for backward RTP; slewed path catches it via the 5s clamp, unslewed relies on caller-side filtering
 	rtpDelta := ts - st.lastTS
-	rtpDerived := st.lastWallPTS + st.converter.ToDuration(rtpDelta)
-	diff := rtpDerived - wallElapsed
+	rtpDur := st.converter.ToDuration(rtpDelta)
+	unslewed = st.lastWallPTSUnslewed + rtpDur
 
+	slewedRTP := st.lastWallPTSSlewed + rtpDur
+	diff := slewedRTP - wallElapsed
 	if diff > wallClockSanityThreshold || diff < -wallClockSanityThreshold {
-		return wallElapsed
+		return wallElapsed, unslewed
 	}
 
-	// Slew rtpDerived toward wallElapsed each packet so publisher sample-clock skew stops accumulating across the sanity band; see wallSlewAlpha for the steady-state math.
+	// Slew keeps emitted PTS near wallElapsed across the sanity band; see wallSlewAlpha for the steady-state math
 	absorbed := time.Duration(float64(diff) * wallSlewAlpha)
-	return rtpDerived - absorbed
+	return slewedRTP - absorbed, unslewed
 }
 
 // OnSenderReport implements TrackSync. It stores a callback invoked on sender reports.

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -52,6 +52,9 @@ const (
 
 	// deadbandThreshold is the minimum |correction| before slew smoothing kicks in.
 	deadbandThreshold = 5 * time.Millisecond
+
+	// wallSlewAlpha bounds publisher sample-clock skew: steady-state |drift| = R·δ·(1-α)/α ≈ 10ms for R=20ms, δ=±500ppm, α=0.01.
+	wallSlewAlpha = 0.01
 )
 
 // syncEngineTrack implements TrackSync for a single track within a SyncEngine.
@@ -425,6 +428,8 @@ func (st *syncEngineTrack) GetPTS(pkt jitter.ExtPacket) (time.Duration, error) {
 					"deadline", deadline,
 					"behindBy", limit-oldPTS,
 				)
+				// Reset timeliness clock so a lingering transient deficit doesn't fire force-correction on every subsequent packet, collapsing them into the same newPTS at the mixer.
+				st.lastTimelyPacket = time.Now()
 			}
 		} else {
 			st.lastTimelyPacket = time.Now()
@@ -489,43 +494,33 @@ func (st *syncEngineTrack) wallClockPTSForRTP(ts uint32, receivedAt time.Time) (
 // wallClockPTSForRTPLocked is the lock-held implementation of wall-clock PTS
 // computation. Caller must hold st.mu.
 func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.Time) time.Duration {
-	// Defense in depth: if receivedAt is the zero time.Time, wallElapsed
-	// below would be a ~63-billion-second negative duration, the sanity
-	// threshold would reject rtpDerived, and the function would return 0
-	// regardless of sessionOffset — locking the trust-threshold clamp onto
-	// a bogus baseline. initializeLocked already substitutes time.Now() for
-	// zero ReceivedAt on the first packet; do the same here in case a later
-	// caller (e.g., OnRTCP using sr.RTPTime + an unset receivedAt) misses it.
+	// A zero receivedAt would make wallElapsed hugely negative and lock every downstream clamp onto a bogus baseline.
 	if receivedAt.IsZero() {
 		receivedAt = time.Now()
 	}
 
-	// Wall-clock elapsed since this track started, plus session offset
 	wallElapsed := receivedAt.Sub(st.startTime) + st.sessionOffset
-
-	// If we have processed at least one packet, use RTP delta from the previous
-	// pure-wall-clock baseline for more precision (immune to receivedAt jitter).
-	// uint32 subtraction wraps for backward RTP timestamps; the sanity check
-	// below catches the resulting huge positive delta and falls back to wall clock.
-	if st.initialized {
-		rtpDelta := ts - st.lastTS
-		rtpDerived := st.lastWallPTS + st.converter.ToDuration(rtpDelta)
-
-		// Sanity check: if RTP-derived PTS diverges from wall-clock by > 5s, use wall clock.
-		diff := rtpDerived - wallElapsed
-		if diff < 0 {
-			diff = -diff
-		}
-		if diff <= wallClockSanityThreshold {
-			return rtpDerived
-		}
-	}
-
-	// Use wall-clock elapsed, ensuring non-negative.
 	if wallElapsed < 0 {
 		wallElapsed = 0
 	}
-	return wallElapsed
+
+	if !st.initialized {
+		return wallElapsed
+	}
+
+	// uint32 subtraction wraps for backward RTP timestamps; the sanity check
+	// below catches the resulting huge positive delta and falls back to wall clock.
+	rtpDelta := ts - st.lastTS
+	rtpDerived := st.lastWallPTS + st.converter.ToDuration(rtpDelta)
+	diff := rtpDerived - wallElapsed
+
+	if diff > wallClockSanityThreshold || diff < -wallClockSanityThreshold {
+		return wallElapsed
+	}
+
+	// Slew rtpDerived toward wallElapsed each packet so publisher sample-clock skew stops accumulating across the sanity band; see wallSlewAlpha for the steady-state math.
+	absorbed := time.Duration(float64(diff) * wallSlewAlpha)
+	return rtpDerived - absorbed
 }
 
 // OnSenderReport implements TrackSync. It stores a callback invoked on sender reports.


### PR DESCRIPTION
## Summary

A small fraction of canary sessions (~0.2% of `room_composite` and `participant` recordings; two extreme sessions in the last 48h) dropped thousands of seconds of audio — one 8.4h session ended up ~97% silent. Two distinct failure modes cause it, both traceable to timeline anchoring in the sync engine.

## Root causes

**Publishers with sample-clock skew** (consumer USB audio, mobile, headsets: ±500ppm is common). `wallClockPTSForRTPLocked` computed `rtpDerived = lastWallPTS + rtpDelta` and wrote the result back into `lastWallPTS` each packet — self-referential. Publisher-vs-wall skew accumulated up to the 5s sanity band before being corrected, and once it crossed the 3s force-correction threshold, force-correction fired on every subsequent packet, snapping each to `deadline - maxDelay/2`. Successive slow-arriving packets collapsed onto the same corrected PTS → downstream audiomixer dropped the collisions.

**Publishers with unstable RTCP SR timing.** `NtpEstimator.resetLocked` reset `owdEstimator` on every outlier-triggered rebuild, forcing OWD to re-converge from scratch. `sessionPTS = ntpTime + OWD - sessionStart` jumped by the reconvergence delta at each rebuild (39 rebuilds in one 3h session). The drift signal fed to the tempo controller (`wallPTS - sessionPTS`) became a burst pattern; the audio pacer chased moving targets, and the resulting pitch changes pushed audio into the mixer at rates that overran its alignment threshold.

## Changes

1. `wallClockPTSForRTPLocked` slews `rtpDerived` toward `wallElapsed` by α=0.01 per packet inside the sanity band. Steady-state `|drift| = R·δ·(1-α)/α ≈ 10ms` for R=20ms, δ=±500ppm — well below force-correction. Preserves jitter immunity (receivedAt noise stays filtered).
2. `NtpEstimator.resetLocked` no longer resets `owdEstimator`. Outlier-triggered rebuilds are residual-pattern changes, not network topology changes; OWD's min-tracking absorbs sender-clock steps via its own convergence. The public `Reset()` (called via `SessionTimeline.ResetTrack` on true stream discontinuity) still resets OWD.
3. Force-correction now resets `lastTimelyPacket` when it fires so a residual transient can't cascade into per-packet re-firing.