### PR TITLE
chore(cloudagents): inject attributes header in byoc deploys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.81.1
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/cloudagents/auth.go
+++ b/pkg/cloudagents/auth.go
@@ -16,6 +16,8 @@ package cloudagents
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,7 +27,7 @@ import (
 )
 
 // newRequestWithContext creates a new HTTP request with the auth and version headers.
-func (c *Client) newRequestWithContext(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequestWithContext(ctx context.Context, method, url string, body io.Reader, attrs map[string]string) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
@@ -33,7 +35,9 @@ func (c *Client) newRequestWithContext(ctx context.Context, method, url string, 
 	if err := c.setAuthToken(req); err != nil {
 		return nil, err
 	}
-	c.setLivekitHeaders(req)
+	if err := c.setLivekitHeaders(req, attrs); err != nil {
+		return nil, err
+	}
 	return req, nil
 }
 
@@ -50,9 +54,17 @@ func (c *Client) setAuthToken(req *http.Request) error {
 }
 
 // setLivekitHeaders set the LiveKit headers in the request header.
-func (c *Client) setLivekitHeaders(req *http.Request) {
+func (c *Client) setLivekitHeaders(req *http.Request, attrs map[string]string) error {
 	for k, v := range c.headers {
 		req.Header.Set(k, v)
 	}
 	req.Header.Set("X-LIVEKIT-CLI-VERSION", lksdk.Version)
+	if len(attrs) > 0 {
+		encoded, err := json.Marshal(attrs)
+		if err != nil {
+			return fmt.Errorf("failed to encode attributes: %w", err)
+		}
+		req.Header.Set(attributesHeader, base64.StdEncoding.EncodeToString(encoded))
+	}
+	return nil
 }

--- a/pkg/cloudagents/build.go
+++ b/pkg/cloudagents/build.go
@@ -37,7 +37,7 @@ func (c *Client) build(ctx context.Context, id string, attributes map[string]str
 		params.Add("deployment", agentDeployment)
 	}
 
-	// Attributes travel in the X-LIVEKIT-AGENT-ATTRIBUTES header (set by
+	// Attributes travel in the X-LIVEKIT-AGENT-VERSION-ATTRIBUTES header (set by
 	// newRequestWithContext), the same channel BYOC pushes use. cloud-agents still
 	// accepts the legacy `attributes` query param from older CLI versions.
 	fullUrl := fmt.Sprintf("%s/build?%s", c.agentsURL, params.Encode())

--- a/pkg/cloudagents/build.go
+++ b/pkg/cloudagents/build.go
@@ -36,16 +36,12 @@ func (c *Client) build(ctx context.Context, id string, attributes map[string]str
 	if agentDeployment != "" {
 		params.Add("deployment", agentDeployment)
 	}
-	if len(attributes) > 0 {
-		encoded, err := json.Marshal(attributes)
-		if err != nil {
-			return fmt.Errorf("failed to encode attributes: %w", err)
-		}
-		params.Add("attributes", string(encoded))
-	}
 
+	// Attributes travel in the X-LIVEKIT-AGENT-ATTRIBUTES header (set by
+	// newRequestWithContext), the same channel BYOC pushes use. cloud-agents still
+	// accepts the legacy `attributes` query param from older CLI versions.
 	fullUrl := fmt.Sprintf("%s/build?%s", c.agentsURL, params.Encode())
-	req, err := c.newRequestWithContext(ctx, "POST", fullUrl, nil)
+	req, err := c.newRequestWithContext(ctx, "POST", fullUrl, nil, attributes)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudagents/client.go
+++ b/pkg/cloudagents/client.go
@@ -63,7 +63,9 @@ func New(opts ...ClientOption) (*Client, error) {
 		lksdk.WithTwirpClientOptions(
 			twirp.WithClientHooks(&twirp.ClientHooks{
 				RequestPrepared: func(ctx context.Context, req *http.Request) (context.Context, error) {
-					client.setLivekitHeaders(req)
+					if err := client.setLivekitHeaders(req, nil); err != nil {
+						return ctx, err
+					}
 					return ctx, nil
 				},
 			})))

--- a/pkg/cloudagents/logs.go
+++ b/pkg/cloudagents/logs.go
@@ -42,7 +42,7 @@ func (c *Client) StreamLogs(ctx context.Context, logType, agentID, agentDeployme
 		params.Add("deployment", agentDeployment)
 	}
 	fullUrl := fmt.Sprintf("%s/logs?%s", c.getAgentsURL(serverRegion), params.Encode())
-	req, err := c.newRequestWithContext(ctx, "GET", fullUrl, nil)
+	req, err := c.newRequestWithContext(ctx, "GET", fullUrl, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudagents/push.go
+++ b/pkg/cloudagents/push.go
@@ -23,6 +23,11 @@ import (
 	"net/url"
 )
 
+// attributesHeader carries base64-encoded JSON deploy attributes on prebuilt-image
+// (BYOC) pushes. cloud-agents reads it on the manifest PUT and persists the attributes
+// on the AgentVersion. Must match the header name expected by the cloud-agents proxy.
+const attributesHeader = "X-LIVEKIT-AGENT-ATTRIBUTES"
+
 // PushTarget describes where and how the CLI should push a prebuilt image.
 type PushTarget struct {
 	// ProxyHost is the OCI registry host exposed by cloud-agents (e.g. "agents.livekit.io").
@@ -41,7 +46,7 @@ func (c *Client) GetPushTarget(ctx context.Context, agentID string) (*PushTarget
 	params.Add("agent_id", agentID)
 	fullURL := fmt.Sprintf("%s/push-target?%s", c.agentsURL, params.Encode())
 
-	req, err := c.newRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	req, err := c.newRequestWithContext(ctx, http.MethodGet, fullURL, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -63,16 +68,18 @@ func (c *Client) GetPushTarget(ctx context.Context, agentID string) (*PushTarget
 
 // NewRegistryTransport returns an http.RoundTripper that injects the LiveKit JWT on every
 // request. Pass this to crane via crane.WithTransport when pushing to the cloud-agents
-// OCI proxy so the proxy's auth middleware accepts the requests.
-func (c *Client) NewRegistryTransport() http.RoundTripper {
-	return &lkRegistryTransport{base: http.DefaultTransport, client: c}
+// OCI proxy so the proxy's auth middleware accepts the requests. Any attributes are
+// forwarded to cloud-agents so they can be recorded on the resulting AgentVersion.
+func (c *Client) NewRegistryTransport(attributes map[string]string) http.RoundTripper {
+	return &lkRegistryTransport{base: http.DefaultTransport, client: c, attributes: attributes}
 }
 
 // lkRegistryTransport injects LK auth headers on every HTTP request, allowing crane
 // to push through the cloud-agents OCI proxy without doing OCI token negotiation.
 type lkRegistryTransport struct {
-	base   http.RoundTripper
-	client *Client
+	base       http.RoundTripper
+	client     *Client
+	attributes map[string]string
 }
 
 func (t *lkRegistryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -80,6 +87,8 @@ func (t *lkRegistryTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	if err := t.client.setAuthToken(req); err != nil {
 		return nil, err
 	}
-	t.client.setLivekitHeaders(req)
+	if err := t.client.setLivekitHeaders(req, t.attributes); err != nil {
+		return nil, err
+	}
 	return t.base.RoundTrip(req)
 }

--- a/pkg/cloudagents/push.go
+++ b/pkg/cloudagents/push.go
@@ -26,7 +26,7 @@ import (
 // attributesHeader carries base64-encoded JSON deploy attributes on prebuilt-image
 // (BYOC) pushes. cloud-agents reads it on the manifest PUT and persists the attributes
 // on the AgentVersion. Must match the header name expected by the cloud-agents proxy.
-const attributesHeader = "X-LIVEKIT-AGENT-ATTRIBUTES"
+const attributesHeader = "X-LIVEKIT-AGENT-VERSION-ATTRIBUTES"
 
 // PushTarget describes where and how the CLI should push a prebuilt image.
 type PushTarget struct {

--- a/version.go
+++ b/version.go
@@ -14,7 +14,7 @@
 
 package lksdk
 
-const Version = "2.18.0"
+const Version = "2.18.1"
 
 // userAgent identifies the SDK and version to the server on every request.
 const userAgent = "livekit-server-sdk-go/" + Version


### PR DESCRIPTION
https://linear.app/livekit/issue/AP-956/byoc-deploy-attributes-are-not-persisted-on-agent-versions

What: injects any user-defined deployment attributes as a request header (`X-LIVEKIT-AGENT-ATTRIBUTES`) after completing image upload in a BYOC deployment.

BYOC agent deployments are currently a 2-step process:
1. SDK requests a push endpoint from cloud-agents service (generated by `crane`) to upload an image to
2. SDK calls cloud-agents`/v2` callback endpoint when the push is complete

The cloud-agents service then creates a record of the agent version and spins it up. In order to support custom user-defined attributes in BYOC cloud agent deployments, we have to forward them to cloud-agents svc *after* pushing the image, because this transaction is stateless from the perspective of cloud-agents svc.

In the Non-BYOC case, which is very similar, we had been appending these attributes as URL parameters. For consistency's sake, I have now standardized both cases to use the header value (with backward compatibility for the parameter).

REF: https://github.com/livekit/cloud-agents/pull/736, https://github.com/livekit/livekit-cli/pull/914