### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildtest.yaml
+++ b/.github/workflows/buildtest.yaml
@@ -14,6 +14,9 @@
 
 name: Test
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 3 * * 1,5' # 03:00 each Mon and Fri


### PR DESCRIPTION
Potential fix for [https://github.com/livekit/server-sdk-go/security/code-scanning/8](https://github.com/livekit/server-sdk-go/security/code-scanning/8)

Add an explicit top-level `permissions` block to `.github/workflows/buildtest.yaml` so all jobs in this workflow default to least privilege.

Best single fix (no functional change): insert at workflow root (after `name` and before `on`) this block:

```yaml
permissions:
  contents: read
```

Why here: root-level applies to all jobs unless overridden, keeps policy centralized, and matches CodeQL’s suggested minimal starting point for this workflow.

No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
