### PR TITLE
server-sdk-go: add unified StartEgress convenience method

### DIFF
--- a/egressclient.go
+++ b/egressclient.go
@@ -44,6 +44,14 @@ func newEgressClient(url string, auth authBase, httpClient *http.Client, opts ..
 	}
 }
 
+func (c *EgressClient) StartEgress(ctx context.Context, req *livekit.StartEgressRequest) (*livekit.EgressInfo, error) {
+	ctx, err := c.prepareContext(ctx, withVideoGrant{RoomRecord: true})
+	if err != nil {
+		return nil, err
+	}
+	return c.egressClient.StartEgress(ctx, req)
+}
+
 func (c *EgressClient) StartRoomCompositeEgress(ctx context.Context, req *livekit.RoomCompositeEgressRequest) (*livekit.EgressInfo, error) {
 	ctx, err := c.prepareContext(ctx, withVideoGrant{RoomRecord: true})
 	if err != nil {

--- a/livekitapi_test.go
+++ b/livekitapi_test.go
@@ -260,6 +260,19 @@ func TestAPI_EgressStartSmoke(t *testing.T) {
 		return []*livekit.EncodedFileOutput{{FileType: livekit.EncodedFileType_MP4, Filepath: path}}
 	}
 	runCalls(t, map[string]func() error{
+		"Unified": func() error {
+			_, e := api.Egress().StartEgress(ctx, &livekit.StartEgressRequest{
+				RoomName: "test-room",
+				Source:   &livekit.StartEgressRequest_Web{Web: &livekit.WebSource{Url: "https://example.com/scene"}},
+				Outputs: []*livekit.Output{
+					{Config: &livekit.Output_Stream{Stream: &livekit.StreamOutput{
+						Protocol: livekit.StreamProtocol_RTMP,
+						Urls:     []string{"rtmps://a.example.com/live/key"},
+					}}},
+				},
+			})
+			return e
+		},
 		"RoomComposite": func() error {
 			_, e := api.Egress().StartRoomCompositeEgress(ctx, &livekit.RoomCompositeEgressRequest{
 				RoomName:    "test-room",


### PR DESCRIPTION
server-sdk-go's EgressClient exposes a unified StartEgress that calls the Egress.StartEgress RPC with the v2 StartEgressRequest, matching the now-implemented API
