### PR TITLE
Fix deadlock between Synchronizer.End() and sender report processing

### DIFF
--- a/pkg/synchronizer/participant.go
+++ b/pkg/synchronizer/participant.go
@@ -37,9 +37,10 @@ func newParticipantSynchronizer() *participantSynchronizer {
 
 func (p *participantSynchronizer) onSenderReport(pkt *rtcp.SenderReport) {
 	p.Lock()
-	defer p.Unlock()
+	t := p.tracks[pkt.SSRC]
+	p.Unlock()
 
-	if t := p.tracks[pkt.SSRC]; t != nil {
+	if t != nil {
 		t.onSenderReport(pkt)
 	}
 }

--- a/pkg/synchronizer/synchronizer.go
+++ b/pkg/synchronizer/synchronizer.go
@@ -16,6 +16,7 @@ package synchronizer
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pion/rtcp"
@@ -227,8 +228,10 @@ type Synchronizer struct {
 	psBySSRC     map[uint32]*participantSynchronizer
 	ssrcByID     map[string]uint32
 
-	// start time of the external live media (if used, 0 otherwise)
-	externalMediaStartTime time.Time
+	// lock-free: read by track/participant code that may run under child locks
+	mediaRunningTime atomic.Pointer[func() (time.Duration, bool)]
+	// start time of the external live media (if used, nil otherwise)
+	externalMediaStartTime atomic.Pointer[time.Time]
 }
 
 func NewSynchronizer(onStarted func()) *Synchronizer {
@@ -266,13 +269,15 @@ func NewSynchronizerWithOptions(opts ...SynchronizerOption) *Synchronizer {
 	}
 	config.normalizeLegacySenderReportSyncMode()
 
-	return &Synchronizer{
+	s := &Synchronizer{
 		onStarted:    config.OnStarted,
 		psByIdentity: make(map[string]*participantSynchronizer),
 		psBySSRC:     make(map[uint32]*participantSynchronizer),
 		ssrcByID:     make(map[string]uint32),
 		config:       config,
 	}
+	s.SetMediaRunningTime(config.MediaRunningTime)
+	return s
 }
 
 func (s *Synchronizer) AddTrack(track TrackRemote, participantID string) *TrackSynchronizer {
@@ -320,9 +325,11 @@ func (s *Synchronizer) GetStartedAt() int64 {
 // SetMediaRunningTime updates the external media running time provider after the synchronizer has been created.
 // Passing a nil provider clears the configuration.
 func (s *Synchronizer) SetMediaRunningTime(mediaRunningTime func() (time.Duration, bool)) {
-	s.Lock()
-	s.config.MediaRunningTime = mediaRunningTime
-	s.Unlock()
+	if mediaRunningTime == nil {
+		s.mediaRunningTime.Store(nil)
+	} else {
+		s.mediaRunningTime.Store(&mediaRunningTime)
+	}
 }
 
 func (s *Synchronizer) getOrSetStartedAt(now int64) int64 {
@@ -403,28 +410,25 @@ func (s *Synchronizer) AsSyncInterface() Sync {
 }
 
 func (s *Synchronizer) getExternalMediaDeadline() (time.Duration, bool) {
-	s.RLock()
-	startTime := s.externalMediaStartTime
-	cb := s.config.MediaRunningTime
-	maxDelay := s.config.MaxMediaRunningTimeDelay
-	s.RUnlock()
-
 	now := time.Now()
 
-	if startTime.IsZero() && cb != nil {
-		if mediaRunningTime, ok := cb(); ok {
-			startTime = now.Add(-mediaRunningTime)
-			s.Lock()
-			if s.externalMediaStartTime.IsZero() {
-				s.externalMediaStartTime = startTime
-			}
-			s.Unlock()
+	startTime := s.externalMediaStartTime.Load()
+	if startTime == nil {
+		cb := s.mediaRunningTime.Load()
+		if cb == nil {
+			return 0, false
+		}
+		mediaRunningTime, ok := (*cb)()
+		if !ok {
+			return 0, false
+		}
+		st := now.Add(-mediaRunningTime)
+		if !s.externalMediaStartTime.CompareAndSwap(nil, &st) {
+			startTime = s.externalMediaStartTime.Load()
+		} else {
+			startTime = &st
 		}
 	}
 
-	if startTime.IsZero() {
-		return 0, false
-	}
-
-	return now.Sub(startTime) - maxDelay, true
+	return now.Sub(*startTime) - s.config.MaxMediaRunningTimeDelay, true
 }

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -333,10 +333,6 @@ func TestEnd_RemovedTracks_StillContributeDuration(t *testing.T) {
 		"duration must reflect removed track's PTS; got %v", duration)
 }
 
-// Regression: End() holds the synchronizer lock while calling into participant
-// synchronizers, while sender report processing holds the participant lock and
-// reads the external media deadline from the synchronizer — an ABBA deadlock if
-// either side nests the other's lock.
 func TestEnd_NoDeadlockWithConcurrentSenderReports(t *testing.T) {
 	done := make(chan struct{})
 	go func() {

--- a/pkg/synchronizer/synchronizer_test.go
+++ b/pkg/synchronizer/synchronizer_test.go
@@ -1,6 +1,7 @@
 package synchronizer_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -330,4 +331,61 @@ func TestEnd_RemovedTracks_StillContributeDuration(t *testing.T) {
 	duration := time.Duration(s.GetEndedAt() - s.GetStartedAt())
 	require.Greater(t, duration, time.Second,
 		"duration must reflect removed track's PTS; got %v", duration)
+}
+
+// Regression: End() holds the synchronizer lock while calling into participant
+// synchronizers, while sender report processing holds the participant lock and
+// reads the external media deadline from the synchronizer — an ABBA deadlock if
+// either side nests the other's lock.
+func TestEnd_NoDeadlockWithConcurrentSenderReports(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			s := synchronizer.NewSynchronizerWithOptions(
+				synchronizer.WithRTCPSenderReportRebaseEnabled(),
+				synchronizer.WithMediaRunningTime(func() (time.Duration, bool) {
+					return time.Second, true
+				}, time.Second),
+			)
+
+			const ssrc = uint32(0xA001)
+			tr := fakeAudio48k(ssrc)
+			tsync := s.AddTrack(tr, "p1")
+			tsync.Initialize(pkt(1000).Packet)
+			_, _ = tsync.GetPTS(pkt(1000))
+
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			for g := 0; g < 4; g++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case <-stop:
+							return
+						default:
+							s.OnRTCP(&rtcp.SenderReport{
+								SSRC:    ssrc,
+								NTPTime: uint64(mediatransportutil.ToNtpTime(time.Now())),
+								RTPTime: 1000,
+							})
+						}
+					}
+				}()
+			}
+
+			time.Sleep(time.Millisecond)
+			s.End()
+			close(stop)
+			wg.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("deadlock between End() and concurrent sender report processing")
+	}
 }


### PR DESCRIPTION
We found long-lived egress handlers wedged at EOS with goroutine dumps showing a classic ABBA lock cycle in pkg/synchronizer: `Synchronizer.End()` holds the synchronizer write lock and calls `participantSynchronizer.getMaxPTSAdjusted()`, which needs the participant mutex — while an RTCP worker inside `participantSynchronizer.onSenderReport` holds the participant mutex and calls `onSenderReportWithRebase → getSynchronizerDeadline → getExternalMediaDeadline`, which needs the synchronizer lock. Neither can proceed, and every other synchronizer user (`GetEndedAt`, `GetPTS`, other RTCP workers) piles up behind them. The window is one in-flight sender report at the instant `End()` fires, and it requires the rebased sender report mode plus a configured `MediaRunningTime`.

This is the same deadlock class #841 fixed at the track-lock level, one lock-level up: #865 added the deadline fetch to the sender report path and correctly placed it before the track lock per #841's rule, but the call site can't see that its caller holds the participant lock. Since call-site discipline has now failed twice, this PR fixes the specific inversion and removes the discipline requirement entirely.

`participantSynchronizer.onSenderReport` now looks up the track under the participant lock, releases it, and then processes the report — the same pattern `OnRTCP` already uses at the synchronizer level. And `getExternalMediaDeadline` is now lock-free: the `MediaRunningTime` callback lives in an `atomic.Pointer` (kept in sync by the option and by `SetMediaRunningTime`), and the lazily-set external media start time is an `atomic.Pointer[time.Time]` set once via CAS, preserving the monotonic clock reading so wall-clock adjustments can't move the deadline. With no code path acquiring the synchronizer lock from under a child lock, `End()`'s parent→child nesting is acyclic by construction and stays unchanged.

The new regression test spins up sender report processing concurrently with `End()` across many fresh synchronizers; it reliably deadlocks on main within its watchdog and passes with this change. The full package passes `go test -race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)