### PR TITLE
fix: return ConnectionStateDisconnected room ConnectionState if engine is nil

### DIFF
--- a/room.go
+++ b/room.go
@@ -536,6 +536,10 @@ func (r *Room) ConnectionState() ConnectionState {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
+	if r.engine == nil {
+		return ConnectionStateDisconnected
+	}
+
 	switch r.engine.currentState() {
 	case connectionManagerStateInitial, connectionManagerStateClosed:
 		return ConnectionStateDisconnected

--- a/room_test.go
+++ b/room_test.go
@@ -119,5 +119,6 @@ func TestOnRoomUpdateDeliversLateSID(t *testing.T) {
 
 func TestConnectionStateWithoutEngine(t *testing.T) {
 	room := NewRoom(nil)
+	room.engine = nil
 	require.Equal(t, ConnectionStateDisconnected, room.ConnectionState())
 }

--- a/room_test.go
+++ b/room_test.go
@@ -116,3 +116,8 @@ func TestOnRoomUpdateDeliversLateSID(t *testing.T) {
 		return room.SID() == "RM_late"
 	}, time.Second, 10*time.Millisecond, "SID() never returned the SID delivered via OnRoomUpdate")
 }
+
+func TestConnectionStateWithoutEngine(t *testing.T) {
+	room := NewRoom(nil)
+	require.Equal(t, ConnectionStateDisconnected, room.ConnectionState())
+}


### PR DESCRIPTION
- with the refactoring of reading the connection state of a room directly from its engine a not yet connected will panic if the connection state is read and the non-exposed engine is nil. Current workaround: Check for an exposed `LocalParticipant`
- fix: return `ConnectionStateDisconnected`if the engine is `nil`