### PR TITLE
fix: guard room ConnectionState nil engine

### DIFF
--- a/room.go
+++ b/room.go
@@ -536,6 +536,10 @@ func (r *Room) ConnectionState() ConnectionState {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
+	if r.engine == nil {
+		return ConnectionStateDisconnected
+	}
+
 	switch r.engine.currentState() {
 	case connectionManagerStateInitial, connectionManagerStateClosed:
 		return ConnectionStateDisconnected

--- a/room_test.go
+++ b/room_test.go
@@ -116,3 +116,9 @@ func TestOnRoomUpdateDeliversLateSID(t *testing.T) {
 		return room.SID() == "RM_late"
 	}, time.Second, 10*time.Millisecond, "SID() never returned the SID delivered via OnRoomUpdate")
 }
+
+func TestConnectionStateWithoutEngine(t *testing.T) {
+	room := Room{}
+
+	require.Equal(t, ConnectionStateDisconnected, room.ConnectionState())
+}


### PR DESCRIPTION
* with the refactoring of reading the connection state of a room directly from its non-exposed `engine`, that will panic if `nil` when the connection state is read
* Current workaround: Check for an exposed `LocalParticipant`