### PR TITLE
Guard the sync engine against out-of-domain sender reports

### DIFF
--- a/pkg/synchronizer/participantclock.go
+++ b/pkg/synchronizer/participantclock.go
@@ -32,6 +32,13 @@ type ParticipantClock struct {
 	tracks        map[string]*NtpEstimator
 	seenFirstSR   map[string]bool
 	outliers      map[string]int
+	abnormalPTS   map[string]*abnormalPTSEpisode
+}
+
+type abnormalPTSEpisode struct {
+	count int
+	first time.Duration
+	worst time.Duration
 }
 
 // NewParticipantClock creates a new ParticipantClock.
@@ -42,6 +49,7 @@ func NewParticipantClock(l logger.Logger, participantID string) *ParticipantCloc
 		tracks:        make(map[string]*NtpEstimator),
 		seenFirstSR:   make(map[string]bool),
 		outliers:      make(map[string]int),
+		abnormalPTS:   make(map[string]*abnormalPTSEpisode),
 	}
 }
 
@@ -134,6 +142,59 @@ func (pc *ParticipantClock) RtpToReceiverClock(trackID string, rtpTimestamp uint
 	return ntpTime.Add(est.EstimatedOWD()), nil
 }
 
+// NoteSessionPTS returns the session PTS for a track and whether it is abnormal.
+// Sustained abnormal values are logged once per episode, not once per packet.
+func (pc *ParticipantClock) NoteSessionPTS(trackID string, rtpTimestamp uint32, receiverTime, sessionStart time.Time) (time.Duration, bool) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	sessionPTS := receiverTime.Sub(sessionStart)
+	if sessionPTS >= -maxNegativeSessionPTS && sessionPTS <= 24*time.Hour {
+		pc.endAbnormalEpisodeLocked(trackID)
+		return sessionPTS, false
+	}
+
+	ep, ok := pc.abnormalPTS[trackID]
+	if !ok {
+		pc.abnormalPTS[trackID] = &abnormalPTSEpisode{count: 1, first: sessionPTS, worst: sessionPTS}
+		if pc.logger != nil {
+			pc.logger.Warnw("GetSessionPTS: abnormal result", nil,
+				"participantID", pc.participantID,
+				"trackID", trackID,
+				"rtpTimestamp", rtpTimestamp,
+				"receiverTime", receiverTime,
+				"sessionStart", sessionStart,
+				"sessionPTS", sessionPTS,
+			)
+		}
+		return sessionPTS, true
+	}
+
+	ep.count++
+	if sessionPTS.Abs() > ep.worst.Abs() {
+		ep.worst = sessionPTS
+	}
+	return sessionPTS, true
+}
+
+func (pc *ParticipantClock) endAbnormalEpisodeLocked(trackID string) {
+	ep, ok := pc.abnormalPTS[trackID]
+	if !ok {
+		return
+	}
+
+	if pc.logger != nil {
+		pc.logger.Infow("abnormal session PTS episode ended",
+			"participantID", pc.participantID,
+			"trackID", trackID,
+			"abnormalPackets", ep.count,
+			"first", ep.first,
+			"worst", ep.worst,
+		)
+	}
+	delete(pc.abnormalPTS, trackID)
+}
+
 // ResetTrack clears the NTP estimator for a track, forcing it to rebuild
 // from new sender reports. Used when a stream discontinuity is detected.
 func (pc *ParticipantClock) ResetTrack(trackID string) {
@@ -143,6 +204,7 @@ func (pc *ParticipantClock) ResetTrack(trackID string) {
 	if est, ok := pc.tracks[trackID]; ok {
 		est.Reset()
 		delete(pc.outliers, trackID)
+		pc.endAbnormalEpisodeLocked(trackID)
 	}
 }
 
@@ -154,6 +216,7 @@ func (pc *ParticipantClock) RemoveTrack(trackID string) {
 	delete(pc.tracks, trackID)
 	delete(pc.seenFirstSR, trackID)
 	delete(pc.outliers, trackID)
+	delete(pc.abnormalPTS, trackID)
 }
 
 // HasTrack returns true if the participant has a track with the given ID.

--- a/pkg/synchronizer/participantclock.go
+++ b/pkg/synchronizer/participantclock.go
@@ -142,14 +142,20 @@ func (pc *ParticipantClock) RtpToReceiverClock(trackID string, rtpTimestamp uint
 	return ntpTime.Add(est.EstimatedOWD()), nil
 }
 
+func classifySessionPTS(receiverTime, sessionStart time.Time) (time.Duration, bool) {
+	sessionPTS := receiverTime.Sub(sessionStart)
+	return sessionPTS, sessionPTS < -maxNegativeSessionPTS || sessionPTS > maxSessionPTS
+}
+
 // NoteSessionPTS returns the session PTS for a track and whether it is abnormal.
 // Sustained abnormal values are logged once per episode, not once per packet.
 func (pc *ParticipantClock) NoteSessionPTS(trackID string, rtpTimestamp uint32, receiverTime, sessionStart time.Time) (time.Duration, bool) {
+	sessionPTS, abnormal := classifySessionPTS(receiverTime, sessionStart)
+
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
 
-	sessionPTS := receiverTime.Sub(sessionStart)
-	if sessionPTS >= -maxNegativeSessionPTS && sessionPTS <= 24*time.Hour {
+	if !abnormal {
 		pc.endAbnormalEpisodeLocked(trackID)
 		return sessionPTS, false
 	}

--- a/pkg/synchronizer/participantclock_test.go
+++ b/pkg/synchronizer/participantclock_test.go
@@ -53,3 +53,44 @@ func TestParticipantClock_RemoveTrack(t *testing.T) {
 	pc.RemoveTrack("audio-1")
 	require.False(t, pc.HasTrack("audio-1"))
 }
+
+func noteAt(pc *ParticipantClock, trackID string, sessionPTS time.Duration) (time.Duration, bool) {
+	base := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	return pc.NoteSessionPTS(trackID, 0, base.Add(sessionPTS), base)
+}
+
+func TestParticipantClock_AbnormalPTSEpisode(t *testing.T) {
+	pc := NewParticipantClock(nil, "alice")
+
+	_, abnormal := noteAt(pc, "audio-1", -5*time.Second)
+	require.True(t, abnormal)
+
+	for i := 0; i < 3; i++ {
+		_, abnormal = noteAt(pc, "audio-1", -9*time.Second)
+		require.True(t, abnormal)
+	}
+
+	pc.mu.Lock()
+	ep := pc.abnormalPTS["audio-1"]
+	pc.mu.Unlock()
+	require.NotNil(t, ep)
+	require.Equal(t, 4, ep.count, "every abnormal packet is counted, not logged")
+	require.Equal(t, -5*time.Second, ep.first)
+	require.Equal(t, -9*time.Second, ep.worst, "worst tracks the largest magnitude seen")
+
+	pts, abnormal := noteAt(pc, "audio-1", 2*time.Second)
+	require.False(t, abnormal)
+	require.Equal(t, 2*time.Second, pts)
+
+	pc.mu.Lock()
+	require.NotContains(t, pc.abnormalPTS, "audio-1", "recovery ends the episode")
+	pc.mu.Unlock()
+
+	_, abnormal = noteAt(pc, "audio-1", -5*time.Second)
+	require.True(t, abnormal)
+	pc.RemoveTrack("audio-1")
+
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	require.NotContains(t, pc.abnormalPTS, "audio-1", "removing the track clears the episode")
+}

--- a/pkg/synchronizer/sessiontimeline.go
+++ b/pkg/synchronizer/sessiontimeline.go
@@ -32,6 +32,9 @@ var (
 // OWD and regression noise put a participant's first frames slightly before a session start set by another track
 const maxNegativeSessionPTS = time.Second
 
+// deliberate max-session-length policy, not derived from the RTP wrap period
+const maxSessionPTS = 24 * time.Hour
+
 // SessionTimeline establishes a shared recording timeline and maps each
 // participant's NTP clock domain onto it using OWD (one-way delay)
 // normalization. This is the key component that fixes cross-participant
@@ -177,6 +180,16 @@ func (st *SessionTimeline) OnSenderReport(participantID, trackID string, clockRa
 //
 // The formula is: sessionPTS = ntpTime + estimatedOWD - sessionStart
 func (st *SessionTimeline) GetSessionPTS(participantID, trackID string, rtpTimestamp uint32) (time.Duration, error) {
+	return st.sessionPTS(participantID, trackID, rtpTimestamp, true)
+}
+
+// sampleSessionPTS is GetSessionPTS for callers that only read the value; it leaves
+// abnormal-episode state untouched so a diagnostic cannot perturb the packet path's.
+func (st *SessionTimeline) sampleSessionPTS(participantID, trackID string, rtpTimestamp uint32) (time.Duration, error) {
+	return st.sessionPTS(participantID, trackID, rtpTimestamp, false)
+}
+
+func (st *SessionTimeline) sessionPTS(participantID, trackID string, rtpTimestamp uint32, note bool) (time.Duration, error) {
 	st.mu.RLock()
 	if !st.hasStart {
 		st.mu.RUnlock()
@@ -195,7 +208,13 @@ func (st *SessionTimeline) GetSessionPTS(participantID, trackID string, rtpTimes
 		return 0, err
 	}
 
-	sessionPTS, abnormal := pc.NoteSessionPTS(trackID, rtpTimestamp, receiverTime, sessionStart)
+	var sessionPTS time.Duration
+	var abnormal bool
+	if note {
+		sessionPTS, abnormal = pc.NoteSessionPTS(trackID, rtpTimestamp, receiverTime, sessionStart)
+	} else {
+		sessionPTS, abnormal = classifySessionPTS(receiverTime, sessionStart)
+	}
 	if abnormal {
 		return 0, errAbnormalSessionPTS
 	}

--- a/pkg/synchronizer/sessiontimeline.go
+++ b/pkg/synchronizer/sessiontimeline.go
@@ -24,9 +24,13 @@ import (
 )
 
 var (
-	errNoSenderReports = errors.New("SessionTimeline: no sender reports received for track")
-	errNoSessionStart  = errors.New("SessionTimeline: session start time not set")
+	errNoSenderReports    = errors.New("SessionTimeline: no sender reports received for track")
+	errNoSessionStart     = errors.New("SessionTimeline: session start time not set")
+	errAbnormalSessionPTS = errors.New("SessionTimeline: session PTS outside plausible range")
 )
+
+// OWD and regression noise put a participant's first frames slightly before a session start set by another track
+const maxNegativeSessionPTS = time.Second
 
 // SessionTimeline establishes a shared recording timeline and maps each
 // participant's NTP clock domain onto it using OWD (one-way delay)
@@ -168,7 +172,8 @@ func (st *SessionTimeline) OnSenderReport(participantID, trackID string, clockRa
 }
 
 // GetSessionPTS maps an RTP timestamp for a participant's track to a position
-// on the shared session timeline.
+// on the shared session timeline. It returns errAbnormalSessionPTS when the
+// result falls outside the plausible range.
 //
 // The formula is: sessionPTS = ntpTime + estimatedOWD - sessionStart
 func (st *SessionTimeline) GetSessionPTS(participantID, trackID string, rtpTimestamp uint32) (time.Duration, error) {
@@ -190,18 +195,9 @@ func (st *SessionTimeline) GetSessionPTS(participantID, trackID string, rtpTimes
 		return 0, err
 	}
 
-	sessionPTS := receiverTime.Sub(sessionStart)
-
-	if (sessionPTS < 0 || sessionPTS > 24*time.Hour) && st.logger != nil {
-		st.logger.Warnw("GetSessionPTS: abnormal result",
-			nil,
-			"participantID", participantID,
-			"trackID", trackID,
-			"rtpTimestamp", rtpTimestamp,
-			"receiverTime", receiverTime,
-			"sessionStart", sessionStart,
-			"sessionPTS", sessionPTS,
-		)
+	sessionPTS, abnormal := pc.NoteSessionPTS(trackID, rtpTimestamp, receiverTime, sessionStart)
+	if abnormal {
+		return 0, errAbnormalSessionPTS
 	}
 
 	return sessionPTS, nil

--- a/pkg/synchronizer/sessiontimeline_test.go
+++ b/pkg/synchronizer/sessiontimeline_test.go
@@ -221,3 +221,41 @@ func TestSessionTimeline_FallbackBeforeSRs(t *testing.T) {
 	_, err = st.GetSessionPTS("unknown", "track-x", 1000)
 	require.Error(t, err)
 }
+
+func TestSessionTimeline_AbnormalSessionPTS(t *testing.T) {
+	const clockRate = 48000
+
+	// session start sits offset after the participant's NTP epoch, so RTP 0 maps to -offset;
+	// 3ms is CS-2011's observed legitimate negative, from OWD and regression noise
+	for _, tc := range []struct {
+		name     string
+		offset   time.Duration
+		abnormal bool
+	}{
+		{"negative beyond deadband", 5 * time.Second, true},
+		{"negative within deadband", 3 * time.Millisecond, false},
+		{"beyond 24h", -25 * time.Hour, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := NewSessionTimeline(nil)
+			baseNTP := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+			st.SetSessionStart(baseNTP.Add(tc.offset))
+			st.AddParticipant("alice")
+
+			for i := 0; i < 5; i++ {
+				senderNTP := baseNTP.Add(time.Duration(i) * 2 * time.Second)
+				st.OnSenderReport("alice", "audio-a", clockRate, ntpToUint64(senderNTP), uint32(i)*2*clockRate, senderNTP)
+			}
+
+			pts, err := st.GetSessionPTS("alice", "audio-a", 0)
+			if tc.abnormal {
+				require.ErrorIs(t, err, errAbnormalSessionPTS)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Less(t, pts, time.Duration(0))
+			require.Greater(t, pts, -maxNegativeSessionPTS)
+		})
+	}
+}

--- a/pkg/synchronizer/sessiontimeline_test.go
+++ b/pkg/synchronizer/sessiontimeline_test.go
@@ -225,8 +225,7 @@ func TestSessionTimeline_FallbackBeforeSRs(t *testing.T) {
 func TestSessionTimeline_AbnormalSessionPTS(t *testing.T) {
 	const clockRate = 48000
 
-	// session start sits offset after the participant's NTP epoch, so RTP 0 maps to -offset;
-	// 3ms is CS-2011's observed legitimate negative, from OWD and regression noise
+	// 3ms is the observed legitimate negative, from OWD and regression noise
 	for _, tc := range []struct {
 		name     string
 		offset   time.Duration
@@ -247,9 +246,16 @@ func TestSessionTimeline_AbnormalSessionPTS(t *testing.T) {
 				st.OnSenderReport("alice", "audio-a", clockRate, ntpToUint64(senderNTP), uint32(i)*2*clockRate, senderNTP)
 			}
 
+			if tc.abnormal {
+				_, sampleErr := st.sampleSessionPTS("alice", "audio-a", 0)
+				require.ErrorIs(t, sampleErr, errAbnormalSessionPTS)
+				require.Empty(t, st.GetParticipantClock("alice").abnormalPTS, "the diagnostic path must not open an episode")
+			}
+
 			pts, err := st.GetSessionPTS("alice", "audio-a", 0)
 			if tc.abnormal {
 				require.ErrorIs(t, err, errAbnormalSessionPTS)
+				require.Len(t, st.GetParticipantClock("alice").abnormalPTS, 1, "the packet path does")
 				return
 			}
 

--- a/pkg/synchronizer/syncengine.go
+++ b/pkg/synchronizer/syncengine.go
@@ -319,8 +319,8 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 		st.mu.Unlock()
 		return
 	}
-	st.endSRDomainEpisodeLocked()
-	if !st.initialized {
+	st.noteSRDomainAcceptLocked()
+	if !st.initialized && e.srDomainThreshold > 0 {
 		st.srBeforeInit = true
 	}
 	e.timeline.OnSenderReport(participantID, trackID, clockRate, sr.NTPTime, sr.RTPTime, now)
@@ -336,7 +336,7 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 		return
 	}
 
-	sessionPTS, err := e.timeline.GetSessionPTS(participantID, trackID, sr.RTPTime)
+	sessionPTS, err := e.timeline.sampleSessionPTS(participantID, trackID, sr.RTPTime)
 	if err != nil {
 		return
 	}

--- a/pkg/synchronizer/syncengine.go
+++ b/pkg/synchronizer/syncengine.go
@@ -320,6 +320,9 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 		return
 	}
 	st.endSRDomainEpisodeLocked()
+	if !st.initialized {
+		st.srBeforeInit = true
+	}
 	e.timeline.OnSenderReport(participantID, trackID, clockRate, sr.NTPTime, sr.RTPTime, now)
 	onSR := st.onSR
 	st.mu.Unlock()

--- a/pkg/synchronizer/syncengine.go
+++ b/pkg/synchronizer/syncengine.go
@@ -36,6 +36,9 @@ const (
 	// we clamp to wall clock. This prevents bad publishers from dragging PTS far
 	// from reality.
 	defaultNtpTrustThreshold = 500 * time.Millisecond
+
+	// Wrong-domain sender reports are mutually consistent, so NtpEstimator's own guards cannot see them
+	defaultSRDomainThreshold = 5 * time.Second
 )
 
 // SyncEngineOption configures a SyncEngine.
@@ -68,6 +71,14 @@ func WithSyncEngineOldPacketThreshold(d time.Duration) SyncEngineOption {
 func WithSyncEngineNtpTrustThreshold(d time.Duration) SyncEngineOption {
 	return func(e *SyncEngine) {
 		e.ntpTrustThreshold = d
+	}
+}
+
+// WithSyncEngineSRDomainThreshold sets the max divergence between a sender report's
+// RTP timestamp and the track's media RTP timeline. Zero disables the check.
+func WithSyncEngineSRDomainThreshold(d time.Duration) SyncEngineOption {
+	return func(e *SyncEngine) {
+		e.srDomainThreshold = d
 	}
 }
 
@@ -122,6 +133,7 @@ type SyncEngine struct {
 	enableStartGate       bool
 	oldPacketThreshold    time.Duration
 	ntpTrustThreshold     time.Duration // max NTP-vs-wall divergence before clamping to wall clock
+	srDomainThreshold     time.Duration // max SR-RTP-vs-wall divergence before rejecting the sender report
 	audioDriftCompensated bool          // audio drift handled externally (e.g., tempo controller)
 	onStarted             func()
 
@@ -137,6 +149,7 @@ func NewSyncEngine(opts ...SyncEngineOption) *SyncEngine {
 		trackIDs:           make(map[string]*syncEngineTrack),
 		oldPacketThreshold: defaultOldPacketThreshold,
 		ntpTrustThreshold:  defaultNtpTrustThreshold,
+		srDomainThreshold:  defaultSRDomainThreshold,
 	}
 	for _, opt := range opts {
 		opt(e)
@@ -293,6 +306,20 @@ func (e *SyncEngine) OnRTCP(packet rtcp.Packet) {
 		st.mu.Unlock()
 		return
 	}
+	if gap, ok := st.rtpVsWallGapLocked(sr.RTPTime, now); ok && e.srDomainThreshold > 0 &&
+		(gap > e.srDomainThreshold || gap < -e.srDomainThreshold) {
+		if st.noteSRDomainRejectLocked(gap, now) {
+			st.logger.Warnw("rejecting sender report outside media RTP domain", nil,
+				"rtpTimestamp", sr.RTPTime,
+				"lastTS", st.lastTS,
+				"gap", gap,
+				"threshold", e.srDomainThreshold,
+			)
+		}
+		st.mu.Unlock()
+		return
+	}
+	st.endSRDomainEpisodeLocked()
 	e.timeline.OnSenderReport(participantID, trackID, clockRate, sr.NTPTime, sr.RTPTime, now)
 	onSR := st.onSR
 	st.mu.Unlock()

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -651,6 +651,23 @@ func TestSyncEngine_OnRTCP_RejectsWrongDomainSR(t *testing.T) {
 			require.Zero(t, srDomainRejectCount(st), "an in-domain SR ends the episode")
 		})
 	}
+
+	t.Run("pre-roll", func(t *testing.T) {
+		engine := NewSyncEngine(WithSyncEngineOldPacketThreshold(0))
+		ts := engine.AddTrack(newMockAudioTrack("audio-1", 1000), "alice")
+
+		now := time.Now()
+		for i := 1; i <= minSamplesReady; i++ {
+			engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now.Add(time.Duration(i)*time.Second)), 484740415+uint32(i)*48000))
+		}
+		require.True(t, estimatorReady(engine, "alice", "audio-1"), "the guard is disarmed until the first packet, so these build a fit")
+
+		pkt := makeExtPacket(48000, 0, now)
+		ts.PrimeForStart(pkt)
+		ts.GetPTS(pkt)
+
+		require.False(t, estimatorReady(engine, "alice", "audio-1"), "the wrong-domain fit must not survive initialization")
+	})
 }
 
 func TestSyncEngine_OnRTCP_AcceptsSRAcrossMediaGap(t *testing.T) {

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -134,6 +134,9 @@ func TestSyncEngine_TransitionsToNTPAfterSRs(t *testing.T) {
 		engine.OnRTCP(sr)
 	}
 
+	// without this, a tightened SR domain threshold would starve the regression and the PTS check alone would still pass
+	require.True(t, estimatorReady(engine, "alice", "audio-1"), "NTP regression should be ready")
+
 	// Get PTS after NTP transition - should still be valid and advancing.
 	pkt2 := makeExtPacket(48000, 2, now.Add(time.Second))
 	pts2, err := ts.GetPTS(pkt2)
@@ -353,6 +356,8 @@ func TestSyncEngine_OnRTCP_DriftCallback_NotCalledBeforeTrackInitialized(t *test
 	}
 
 	require.False(t, fired, "onSR must not fire before any packets have initialized the track")
+	require.True(t, estimatorReady(engine, "alice", "audio-1"),
+		"SRs arriving before the first media packet must not be judged against the media domain")
 }
 
 // primeNTPReady drives enough SRs and forward packets through the track to
@@ -585,4 +590,78 @@ func TestSyncEngine_OnSR_NotCalledAfterRemoveTrack(t *testing.T) {
 	tr.mu.Unlock()
 
 	require.False(t, fired, "no callback should have fired during Close")
+}
+
+// parks the media head at RTP 48000 so sender reports can be aimed at a chosen offset from it
+func primeGuardTrack(t *testing.T, engine *SyncEngine, receivedAt time.Time) (TrackSync, *syncEngineTrack) {
+	t.Helper()
+	track := newMockAudioTrack("audio-1", 1000)
+	ts := engine.AddTrack(track, "alice")
+	pkt := makeExtPacket(48000, 0, receivedAt)
+	ts.PrimeForStart(pkt)
+	ts.GetPTS(pkt)
+	return ts, ts.(*syncEngineTrack)
+}
+
+func srDomainRejectCount(st *syncEngineTrack) int {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.srRejected
+}
+
+// GetSessionPTS is not a substitute: synthetic SR NTP ahead of receivedAt gives a negative OWD that trips the deadband
+func estimatorReady(engine *SyncEngine, participantID, trackID string) bool {
+	pc := engine.timeline.GetParticipantClock(participantID)
+	if pc == nil {
+		return false
+	}
+
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	est, ok := pc.tracks[trackID]
+	return ok && est.IsReady()
+}
+
+func TestSyncEngine_OnRTCP_RejectsWrongDomainSR(t *testing.T) {
+	// the CS-2011 reference track, and the smaller EG_d9sUZVjEHmuD magnitude that a 60s bound accepts
+	for _, tc := range []struct {
+		name   string
+		offset uint32
+	}{
+		{"10098s", 484740415},
+		{"37.9s", 1819200},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := NewSyncEngine(WithSyncEngineOldPacketThreshold(0))
+			ts, st := primeGuardTrack(t, engine, time.Now())
+
+			fired := false
+			ts.OnSenderReport(func(time.Duration) { fired = true })
+
+			now := time.Now()
+			for i := 1; i <= 6; i++ {
+				engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now.Add(time.Duration(i)*time.Second)), 48000+tc.offset+uint32(i)*48000))
+			}
+
+			require.Equal(t, 6, srDomainRejectCount(st), "every wrong-domain SR should be rejected")
+			require.False(t, fired, "a rejected SR must not produce a drift sample")
+			require.False(t, estimatorReady(engine, "alice", "audio-1"), "no SR should have reached the estimator")
+
+			engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now), 48000))
+			require.Zero(t, srDomainRejectCount(st), "an in-domain SR ends the episode")
+		})
+	}
+}
+
+func TestSyncEngine_OnRTCP_AcceptsSRAcrossMediaGap(t *testing.T) {
+	// silence suppression freezes the media head while sender reports keep advancing
+	engine := NewSyncEngine(WithSyncEngineOldPacketThreshold(0))
+	_, st := primeGuardTrack(t, engine, time.Now().Add(-10*time.Second))
+
+	for i := 1; i <= 5; i++ {
+		engine.OnRTCP(makeSenderReport(1000, ntpToUint64(time.Now()), 48000+10*48000+uint32(i)*960))
+	}
+
+	require.Zero(t, srDomainRejectCount(st), "a 10s media gap must not read as a domain mismatch")
+	require.True(t, estimatorReady(engine, "alice", "audio-1"))
 }

--- a/pkg/synchronizer/syncengine_test.go
+++ b/pkg/synchronizer/syncengine_test.go
@@ -623,13 +623,14 @@ func estimatorReady(engine *SyncEngine, participantID, trackID string) bool {
 }
 
 func TestSyncEngine_OnRTCP_RejectsWrongDomainSR(t *testing.T) {
-	// the CS-2011 reference track, and the smaller EG_d9sUZVjEHmuD magnitude that a 60s bound accepts
+	// the two magnitudes observed in production, plus a row whose 7s floor brackets the threshold from above
 	for _, tc := range []struct {
 		name   string
 		offset uint32
 	}{
 		{"10098s", 484740415},
 		{"37.9s", 1819200},
+		{"6s", 288000},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			engine := NewSyncEngine(WithSyncEngineOldPacketThreshold(0))
@@ -647,10 +648,28 @@ func TestSyncEngine_OnRTCP_RejectsWrongDomainSR(t *testing.T) {
 			require.False(t, fired, "a rejected SR must not produce a drift sample")
 			require.False(t, estimatorReady(engine, "alice", "audio-1"), "no SR should have reached the estimator")
 
-			engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now), 48000))
-			require.Zero(t, srDomainRejectCount(st), "an in-domain SR ends the episode")
+			engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now), 240000))
+			require.NotZero(t, srDomainRejectCount(st), "one in-domain SR is not enough to end the episode")
+
+			for i := 1; i < srDomainRecoveryRun; i++ {
+				engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now.Add(time.Duration(i)*time.Millisecond)), 240000))
+			}
+			require.Zero(t, srDomainRejectCount(st), "a 4s in-domain gap must still be accepted, and a run of them ends the episode")
 		})
 	}
+
+	t.Run("interleaved domains", func(t *testing.T) {
+		engine := NewSyncEngine(WithSyncEngineOldPacketThreshold(0))
+		_, st := primeGuardTrack(t, engine, time.Now())
+
+		now := time.Now()
+		for i := 1; i <= 4; i++ {
+			engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now.Add(time.Duration(i)*time.Second)), 48000+1819200+uint32(i)*48000))
+			engine.OnRTCP(makeSenderReport(1000, ntpToUint64(now.Add(time.Duration(i)*time.Second)), 48000))
+		}
+
+		require.Equal(t, 4, srDomainRejectCount(st), "alternating domains must not flush the episode on every accepted SR")
+	})
 
 	t.Run("pre-roll", func(t *testing.T) {
 		engine := NewSyncEngine(WithSyncEngineOldPacketThreshold(0))
@@ -667,6 +686,19 @@ func TestSyncEngine_OnRTCP_RejectsWrongDomainSR(t *testing.T) {
 		ts.GetPTS(pkt)
 
 		require.False(t, estimatorReady(engine, "alice", "audio-1"), "the wrong-domain fit must not survive initialization")
+
+		disabled := NewSyncEngine(WithSyncEngineOldPacketThreshold(0), WithSyncEngineSRDomainThreshold(0))
+		dts := disabled.AddTrack(newMockAudioTrack("audio-1", 1000), "alice")
+
+		for i := 1; i <= minSamplesReady; i++ {
+			disabled.OnRTCP(makeSenderReport(1000, ntpToUint64(now.Add(time.Duration(i)*time.Second)), 484740415+uint32(i)*48000))
+		}
+
+		dpkt := makeExtPacket(48000, 0, now)
+		dts.PrimeForStart(dpkt)
+		dts.GetPTS(dpkt)
+
+		require.True(t, estimatorReady(disabled, "alice", "audio-1"), "a disabled guard rejects nothing, so the estimator can still rebuild itself and nothing is discarded")
 	})
 }
 

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -84,6 +84,10 @@ type syncEngineTrack struct {
 	clampStartPTS  time.Duration
 	clampMaxDiff   time.Duration
 
+	srRejected     int
+	srRejectFirst  time.Time
+	srRejectMaxGap time.Duration
+
 	// pipeline time feedback
 	lastTimelyPacket time.Time
 
@@ -508,6 +512,35 @@ func (st *syncEngineTrack) endClampEpisodeLocked(wallPTS time.Duration) {
 	st.clampMaxDiff = 0
 }
 
+func (st *syncEngineTrack) noteSRDomainRejectLocked(gap time.Duration, now time.Time) bool {
+	st.srRejected++
+	if st.srRejected == 1 {
+		st.srRejectFirst = now
+		st.srRejectMaxGap = gap
+		return true
+	}
+
+	if gap.Abs() > st.srRejectMaxGap.Abs() {
+		st.srRejectMaxGap = gap
+	}
+	return false
+}
+
+func (st *syncEngineTrack) endSRDomainEpisodeLocked() {
+	if st.srRejected == 0 {
+		return
+	}
+
+	st.logger.Infow("sender report domain rejection episode ended",
+		"rejected", st.srRejected,
+		"episodeSpan", time.Since(st.srRejectFirst),
+		"maxGap", st.srRejectMaxGap,
+	)
+	st.srRejected = 0
+	st.srRejectFirst = time.Time{}
+	st.srRejectMaxGap = 0
+}
+
 func (st *syncEngineTrack) wallClockPTS(pkt jitter.ExtPacket) (slewed, unslewed time.Duration) {
 	return st.wallClockPTSForRTPLocked(pkt.Timestamp, pkt.ReceivedAt)
 }
@@ -562,6 +595,34 @@ func (st *syncEngineTrack) wallClockPTSForRTPLocked(ts uint32, receivedAt time.T
 	return slewedRTP - absorbed, unslewed
 }
 
+func (st *syncEngineTrack) signedRTPDuration(ts uint32) time.Duration {
+	// widen before negating; -int32(math.MinInt32) overflows
+	d := int64(int32(ts - st.lastTS))
+	if d < 0 {
+		return -st.converter.ToDuration(uint32(-d))
+	}
+	return st.converter.ToDuration(uint32(d))
+}
+
+// rtpVsWallGapLocked returns how far ts projects ahead of wall clock in the track's media domain; !ok before the first packet
+func (st *syncEngineTrack) rtpVsWallGapLocked(ts uint32, receivedAt time.Time) (time.Duration, bool) {
+	if !st.initialized {
+		return 0, false
+	}
+
+	if receivedAt.IsZero() {
+		receivedAt = time.Now()
+	}
+
+	wallElapsed := receivedAt.Sub(st.startTime) + st.sessionOffset
+	if wallElapsed < 0 {
+		wallElapsed = 0
+	}
+
+	// slewed tracks wall clock; the unslewed baseline accumulates publisher skew and would trip the guard on long sessions
+	return st.lastWallPTSSlewed + st.signedRTPDuration(ts) - wallElapsed, true
+}
+
 // OnSenderReport implements TrackSync. It stores a callback invoked on sender reports.
 func (st *syncEngineTrack) OnSenderReport(f func(drift time.Duration)) {
 	st.mu.Lock()
@@ -598,6 +659,7 @@ func (st *syncEngineTrack) Close() {
 // an unacceptable constraint on what the callback may do.
 func (st *syncEngineTrack) closeLocked() {
 	st.endClampEpisodeLocked(st.lastPTSAdjusted)
+	st.endSRDomainEpisodeLocked()
 
 	st.closed = true
 	// Clear the field too: OnRTCP invocations that arrive AFTER close and

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -40,6 +40,11 @@ const (
 	// before its PTS is force-corrected forward.
 	maxTimelyPacketAge = 10 * time.Second
 
+	// srDomainRecoveryRun is how many consecutive in-domain sender reports end a
+	// rejection episode. A publisher interleaving two SR domains alternates
+	// accept/reject, which would re-arm the warning on every pair if one sufficed.
+	srDomainRecoveryRun = 3
+
 	// slewRatePerSecond is the maximum rate at which PTS corrections are absorbed.
 	slewRatePerSecond = 5 * time.Millisecond
 
@@ -85,6 +90,7 @@ type syncEngineTrack struct {
 	clampMaxDiff   time.Duration
 
 	srRejected     int
+	srAccepted     int
 	srRejectFirst  time.Time
 	srRejectMaxGap time.Duration
 	srBeforeInit   bool // an SR reached the timeline while the domain guard was still disarmed
@@ -522,6 +528,7 @@ func (st *syncEngineTrack) endClampEpisodeLocked(wallPTS time.Duration) {
 
 func (st *syncEngineTrack) noteSRDomainRejectLocked(gap time.Duration, now time.Time) bool {
 	st.srRejected++
+	st.srAccepted = 0
 	if st.srRejected == 1 {
 		st.srRejectFirst = now
 		st.srRejectMaxGap = gap
@@ -532,6 +539,17 @@ func (st *syncEngineTrack) noteSRDomainRejectLocked(gap time.Duration, now time.
 		st.srRejectMaxGap = gap
 	}
 	return false
+}
+
+func (st *syncEngineTrack) noteSRDomainAcceptLocked() {
+	if st.srRejected == 0 {
+		return
+	}
+
+	st.srAccepted++
+	if st.srAccepted >= srDomainRecoveryRun {
+		st.endSRDomainEpisodeLocked()
+	}
 }
 
 func (st *syncEngineTrack) endSRDomainEpisodeLocked() {
@@ -545,6 +563,7 @@ func (st *syncEngineTrack) endSRDomainEpisodeLocked() {
 		"maxGap", st.srRejectMaxGap,
 	)
 	st.srRejected = 0
+	st.srAccepted = 0
 	st.srRejectFirst = time.Time{}
 	st.srRejectMaxGap = 0
 }
@@ -616,10 +635,6 @@ func (st *syncEngineTrack) signedRTPDuration(ts uint32) time.Duration {
 func (st *syncEngineTrack) rtpVsWallGapLocked(ts uint32, receivedAt time.Time) (time.Duration, bool) {
 	if !st.initialized {
 		return 0, false
-	}
-
-	if receivedAt.IsZero() {
-		receivedAt = time.Now()
 	}
 
 	wallElapsed := receivedAt.Sub(st.startTime) + st.sessionOffset

--- a/pkg/synchronizer/syncenginetrack.go
+++ b/pkg/synchronizer/syncenginetrack.go
@@ -87,6 +87,7 @@ type syncEngineTrack struct {
 	srRejected     int
 	srRejectFirst  time.Time
 	srRejectMaxGap time.Duration
+	srBeforeInit   bool // an SR reached the timeline while the domain guard was still disarmed
 
 	// pipeline time feedback
 	lastTimelyPacket time.Time
@@ -158,6 +159,13 @@ func (st *syncEngineTrack) initializeLocked(pkt jitter.ExtPacket) func() {
 	st.lastTS = pkt.Timestamp
 	st.lastTimelyPacket = receivedAt
 	st.initialized = true
+
+	// Those SRs were admitted unchecked, and once the guard arms it rejects the very
+	// SRs whose outliers would have rebuilt a wrong-domain fit. Drop it now instead.
+	if st.srBeforeInit {
+		st.srBeforeInit = false
+		st.engine.timeline.ResetTrack(st.participantID, st.track.ID())
+	}
 
 	// Initialize the engine's session start time.
 	sessionStart, onStarted := st.engine.initializeIfNeeded(receivedAt)


### PR DESCRIPTION
The new egress sync engine rejects RTCP sender reports whose RTP timestamps are not in the same domain as the track's media stream, GetSessionPTS no longer returns a value it has flagged as abnormal, and the abnormal-result warn is rate-limited
