### PR TITLE
Always append SimulcastCodecs to AddTrackRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
 	github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f
 	github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095
-	github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b
+	github.com/livekit/protocol v1.51.1-0.20260903060125-0cf5ba018b8e
 	github.com/magefile/mage v1.17.2
 	github.com/moby/buildkit v0.32.2
 	github.com/moby/patternmatcher v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f h1:NhAeNlfiQrHZt
 github.com/livekit/media-sdk v0.0.0-20260828235137-cb2363a4cb4f/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095 h1:BcliKAXoMhl/nWmzQweQ5kmh4Qqagxl4s3Z5pvM/7AY=
 github.com/livekit/mediatransportutil v0.0.0-20260821083140-f234b534b095/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
-github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b h1:OOqCnFt5AZRVdSjYzaOzCR9KiB9IeeTPMGls+C1Ti2g=
-github.com/livekit/protocol v1.50.5-0.20260829123501-a469dd43727b/go.mod h1:x7m1nX86XfvS0YoqXnVe0jixkCmAZglR4mcbRHURSro=
+github.com/livekit/protocol v1.51.1-0.20260903060125-0cf5ba018b8e h1:QAfYvElm7Jr4ZHs1NiX4OTKpVnRO2d9hzSfCPzGMyMI=
+github.com/livekit/protocol v1.51.1-0.20260903060125-0cf5ba018b8e/go.mod h1:qt6LOKs6pzIwJF+P/dSUKHJE1SPowzFWDK6byqktdfU=
 github.com/livekit/psrpc v0.7.5 h1:WxfJIQ41X1b+48A1uzc8Gy9FhYEMxBJNCpCYqPdO/Ds=
 github.com/livekit/psrpc v0.7.5/go.mod h1:rAI+m2+/cb4x9RXhLRtUx5ZwdfjjXOl4zi46IjEetaw=
 github.com/mackerelio/go-osstat v0.2.8 h1:I2duicTaCGWoM53XwAwA9OIe1inu0xnVs8/pqOWWVr4=

--- a/integration_test.go
+++ b/integration_test.go
@@ -899,6 +899,51 @@ func TestLimitPayloadSize(t *testing.T) {
 	pub.Disconnect()
 }
 
+// A plain video publish must come back with a mime type on its TrackInfo. The
+// server only populates that for codecs declared in
+// AddTrackRequest.SimulcastCodecs, and never sends the publisher the corrected
+// TrackInfo it builds once media arrives, so a publication that does not
+// declare its codec cannot tell its own codec from a backup codec request in a
+// SubscribedQualityUpdate.
+func TestPublishTrackMimeType(t *testing.T) {
+	for _, codec := range []webrtc.RTPCodecCapability{
+		{MimeType: webrtc.MimeTypeVP8, ClockRate: 90000},
+		{MimeType: webrtc.MimeTypeH264, ClockRate: 90000},
+	} {
+		t.Run(codec.MimeType, func(t *testing.T) {
+			pub, err := createAgent(t.Name(), nil, "publisher")
+			require.NoError(t, err)
+			defer pub.Disconnect()
+
+			track, err := NewLocalTrack(codec)
+			require.NoError(t, err)
+			provider := NewSampleTestProvider(codec)
+			track.OnBind(func() {
+				if err := track.StartWrite(provider, func() {}); err != nil {
+					track.log.Errorw("Could not start writing", err)
+				}
+			})
+
+			localPub, err := pub.LocalParticipant.PublishTrack(track, &TrackPublicationOptions{Name: "video"})
+			require.NoError(t, err)
+
+			require.True(
+				t,
+				strings.EqualFold(codec.MimeType, localPub.MimeType()),
+				"expected mime type %s, got %q", codec.MimeType, localPub.MimeType(),
+			)
+
+			ti := localPub.TrackInfo()
+			require.Len(t, ti.Codecs, 1)
+			require.True(
+				t,
+				strings.EqualFold(codec.MimeType, ti.Codecs[0].MimeType),
+				"expected codec mime type %s, got %q", codec.MimeType, ti.Codecs[0].MimeType,
+			)
+		})
+	}
+}
+
 func TestSimulcastCodec(t *testing.T) {
 	cases := []struct {
 		name                      string

--- a/livekitapi_test.go
+++ b/livekitapi_test.go
@@ -703,7 +703,7 @@ func TestAPI_SIPCallErrors(t *testing.T) {
 		grpcCode codes.Code
 		sipCode  livekit.SIPStatusCode
 	}{
-		{"busy", sipStatus{Code: 486, Status: "Busy Here"}, codes.ResourceExhausted, livekit.SIPStatusCode_SIP_STATUS_BUSY_HERE},
+		{"busy", sipStatus{Code: 486, Status: "Busy Here"}, codes.FailedPrecondition, livekit.SIPStatusCode_SIP_STATUS_BUSY_HERE},
 		{"declined", sipStatus{Code: 603, Status: "Decline"}, codes.PermissionDenied, livekit.SIPStatusCode_SIP_STATUS_GLOBAL_DECLINE},
 	}
 	for _, tc := range cases {

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -150,23 +150,29 @@ func (p *LocalParticipant) prepareTrackPublication(track webrtc.TrackLocal, opts
 		}
 	}
 
-	// TODO: support e2ee for backup codecs
-	if pubOptions.backupCodecTrack != nil {
-		if req.Encryption == livekit.Encryption_NONE {
-			req.SimulcastCodecs = []*livekit.SimulcastCodec{
-				{
-					Codec: primaryCodec.MimeType,
-					Cid:   track.ID(),
-				},
-				{
-					Codec: pubOptions.backupCodecTrack.Codec().MimeType,
-					Cid:   pubOptions.backupCodecTrack.ID(),
-				},
-			}
-			pub.setBackupCodecTrack(pubOptions.backupCodecTrack)
-		} else {
-			p.log.Warnw("backup codec publication with encryption is not supported, ignoring backup codec", nil)
+	withBackupCodec := pubOptions.backupCodecTrack != nil
+	if withBackupCodec && req.Encryption != livekit.Encryption_NONE {
+		// TODO: support e2ee for backup codecs
+		p.log.Warnw("backup codec publication with encryption is not supported, ignoring backup codec", nil)
+		withBackupCodec = false
+	}
+
+	if primaryCodec.MimeType != "" && (kind == TrackKindVideo || withBackupCodec) {
+		req.SimulcastCodecs = []*livekit.SimulcastCodec{
+			{
+				Codec: primaryCodec.MimeType,
+				Cid:   track.ID(),
+			},
 		}
+		if withBackupCodec {
+			req.SimulcastCodecs = append(req.SimulcastCodecs, &livekit.SimulcastCodec{
+				Codec: pubOptions.backupCodecTrack.Codec().MimeType,
+				Cid:   pubOptions.backupCodecTrack.ID(),
+			})
+			pub.setBackupCodecTrack(pubOptions.backupCodecTrack)
+		}
+	} else if withBackupCodec {
+		p.log.Warnw("backup codec publication requires a known primary codec, ignoring backup codec", nil)
 	}
 	return pub, req, nil
 }

--- a/publication.go
+++ b/publication.go
@@ -76,21 +76,15 @@ func (p *trackPublicationBase) Track() Track {
 }
 
 func (p *trackPublicationBase) MimeType() string {
-	// This requires some more work.
-	// TrackInfo has a top level MimeType which is not set
-	// on server side till the track is published.
-	// So, it is not available in the TrackPublishedResponse.
+	// TrackInfo has a top level MimeType which is not set on server side till
+	// the track is published, so it is not available in the
+	// TrackPublishedResponse. The per-codec mime type is, but only for codecs
+	// the client declared in AddTrackRequest.SimulcastCodecs, which publishing
+	// from here always does for video and does for audio when there is a backup
+	// codec. Take the first codec with a mime type.
 	//
-	// But, if client specified SimulcastCodecs in AddTrackRequest,
-	// the TrackPublishedResponse will have Codecs populated and
-	// that will have the MimeType specified in AddTrackRequest.
-	// Just taking the first one here which has a non-nil MimeType.
-	// This is okay (for tracks published from here)
-	// as of 2025-05-12, 1:30 pm Pacific as
-	// Go SDK does not (yet) support simulcast codec feature.
-	//
-	// When simulcast codec feature is added, this struct needs
-	// to be updated to handle multiple mime types
+	// TODO: a publication with a backup codec has more than one mime type, this
+	// struct needs to be updated to handle that.
 	if info, ok := p.info.Load().(*livekit.TrackInfo); ok {
 		if info.MimeType != "" {
 			return info.MimeType


### PR DESCRIPTION
The server may return a track info without mimetype if there is no codec info in AddTrackRequest. Then the publisher could warn `subscriber requested backup codec but no track found` when subscriber request quality changing.