### PR TITLE
Support LengthPrefixed streaming format for H.265

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -41,4 +41,5 @@ var (
 	ErrAborted                  = errors.New("operation was aborted")
 	ErrMissingPrimaryCodec      = errors.New("primary track must be TrackLocalWithCodec when backup codec is present")
 	ErrPublishRequiresSinglePC  = errors.New("WithTrack requires WithSinglePeerConnection() to be enabled")
+	ErrNALTooLarge              = errors.New("length-prefixed NAL exceeds the maximum size")
 )

--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -276,7 +276,9 @@ func (p *ReaderSampleProvider) OnBind() error {
 			p.h264reader, err = h264reader.NewReaderWithOptions(p.reader, h264reader.WithIncludeSEI(true))
 		}
 	case webrtc.MimeTypeH265:
-		p.h265reader, err = h265reader.NewReaderWithOptions(p.reader, h265reader.WithIncludeSEI(true))
+		if p.h26xStreamingFormat == H26xStreamingFormatAnnexB {
+			p.h265reader, err = h265reader.NewReaderWithOptions(p.reader, h265reader.WithIncludeSEI(true))
+		}
 	case webrtc.MimeTypeVP8, webrtc.MimeTypeVP9, webrtc.MimeTypeAV1:
 		var ivfHeader *ivfreader.IVFFileHeader
 		p.ivfReader, ivfHeader, err = ivfreader.NewWith(p.reader)
@@ -677,24 +679,54 @@ func (w *wavReader) readFrame() ([]byte, error) {
 	return buf[:n], nil
 }
 
-// minimal length-prefixed NAL reeader
-func nextNALH264LengthPrefixed(r io.Reader) (h264reader.NalUnitType, []byte, error) {
+// minimal length-prefixed NAL reeader, 4-byte big-endian length prefix
+func nextNALLengthPrefixed(r io.Reader) ([]byte, error) {
 	var hdr [4]byte
 	if _, err := io.ReadFull(r, hdr[:]); err != nil {
-		return 0, nil, err
+		return nil, err
 	}
 
 	n := int(binary.BigEndian.Uint32(hdr[:]))
 	if n <= 0 {
-		return 0, nil, io.ErrUnexpectedEOF
+		return nil, io.ErrUnexpectedEOF
 	}
 
 	buf := make([]byte, n)
 	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func nextNALH264LengthPrefixed(r io.Reader) (h264reader.NalUnitType, []byte, error) {
+	buf, err := nextNALLengthPrefixed(r)
+	if err != nil {
 		return 0, nil, err
 	}
 
 	return h264reader.NalUnitType(buf[0] & 0x1F), buf, nil
+}
+
+func nextNALH265LengthPrefixed(r io.Reader) (*h265reader.NAL, error) {
+	buf, err := nextNALLengthPrefixed(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(buf) < 2 {
+		// the H265 NAL header is two bytes, anything shorter cannot be parsed
+		return nil, io.ErrUnexpectedEOF
+	}
+
+	// mirrors h265reader's header parse, access unit assembly relies on these fields
+	return &h265reader.NAL{
+		ForbiddenZeroBit: (buf[0] & 0x80) != 0,
+		NalUnitType:      h265reader.NalUnitType((buf[0] & 0x7E) >> 1),
+		LayerID:          ((buf[0] & 0x01) << 5) | ((buf[1] & 0xF8) >> 3),
+		TemporalIDPlus1:  buf[1] & 0x07,
+		Data:             buf,
+	}, nil
 }
 
 func detectWavFormat(r io.Reader) (*wavReader, string, error) {
@@ -714,6 +746,10 @@ func (p *ReaderSampleProvider) nextH265NAL() (*h265reader.NAL, error) {
 		nal := p.h265PendingNAL
 		p.h265PendingNAL = nil
 		return nal, nil
+	}
+
+	if p.h26xStreamingFormat == H26xStreamingFormatLengthPrefixed {
+		return nextNALH265LengthPrefixed(p.reader)
 	}
 	return p.h265reader.NextNAL()
 }

--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -77,6 +77,9 @@ type ReaderSampleProvider struct {
 	trackOpts           []LocalTrackOptions
 	h26xStreamingFormat H26xStreamingFormat
 	appendPacketTrailer bool
+	// max size of a single length-prefixed NAL, resolved in OnBind; a user
+	// value of <= 0 becomes defaultMaxNALSize
+	maxNALSize int
 
 	// When appendPacketTrailer is enabled, we parse LKTS packet trailers from
 	// H264/H265 SEI user_data_unregistered NALs that precede frame NALs.
@@ -172,6 +175,17 @@ func ReaderTrackWithPacketTrailer(enabled bool) func(provider *ReaderSampleProvi
 func ReaderTrackWithH265SingleSliceFlush(enabled bool) func(provider *ReaderSampleProvider) {
 	return func(provider *ReaderSampleProvider) {
 		provider.h265SingleSliceFlush = enabled
+	}
+}
+
+// ReaderTrackWithMaxNALSize sets the maximum size of a single length-prefixed
+// NAL. The buffer is allocated from the size read off the prefix, so this caps
+// run-away values. A size <= 0 keeps the default (defaultMaxNALSize), which is
+// well above any real NAL, including a 4K I-frame. Raise it for larger content
+// such as high-bitrate 8K.
+func ReaderTrackWithMaxNALSize(size int) func(provider *ReaderSampleProvider) {
+	return func(provider *ReaderSampleProvider) {
+		provider.maxNALSize = size
 	}
 }
 
@@ -281,6 +295,11 @@ func NewLocalReaderTrack(in io.ReadCloser, mime string, options ...ReaderSampleP
 }
 
 func (p *ReaderSampleProvider) OnBind() error {
+	// Resolve the length-prefixed NAL limit once, so reads don't branch per NAL.
+	if p.maxNALSize <= 0 {
+		p.maxNALSize = defaultMaxNALSize
+	}
+
 	// If we are not closing on unbind, don't do anything on rebind
 	if p.ivfReader != nil || p.h264reader != nil || p.oggReader != nil || p.h265reader != nil || p.wavReader != nil {
 		return nil
@@ -344,7 +363,7 @@ func (p *ReaderSampleProvider) NextSample(ctx context.Context) (media.Sample, er
 		)
 		switch p.h26xStreamingFormat {
 		case H26xStreamingFormatLengthPrefixed:
-			nalUnitType, nalUnitData, err = nextNALH264LengthPrefixed(p.reader)
+			nalUnitType, nalUnitData, err = nextNALH264LengthPrefixed(p.reader, p.maxNALSize)
 			if err != nil {
 				return sample, err
 			}
@@ -701,21 +720,25 @@ func (w *wavReader) readFrame() ([]byte, error) {
 	return buf[:n], nil
 }
 
-// maxNALSize bounds a single length-prefixed NAL. The buffer is allocated from
-// the size read off the prefix, so this caps run-away values. 16MiB is well
-// above any real NAL, including a 4K I-frame.
-const maxNALSize = 16 << 20
+// defaultMaxNALSize bounds a single length-prefixed NAL when no limit is set
+// via ReaderTrackWithMaxNALSize. The buffer is allocated from the size read off
+// the prefix, so this caps run-away values. 16MiB is well above any real NAL,
+// including a 4K I-frame.
+const defaultMaxNALSize = 16 << 20
 
 // minimal length-prefixed NAL reeader, 4-byte big-endian length prefix
-func nextNALLengthPrefixed(r io.Reader) ([]byte, error) {
+func nextNALLengthPrefixed(r io.Reader, maxSize int) ([]byte, error) {
 	var hdr [4]byte
 	if _, err := io.ReadFull(r, hdr[:]); err != nil {
 		return nil, err
 	}
 
 	n := int(binary.BigEndian.Uint32(hdr[:]))
-	if n <= 0 || n > maxNALSize {
+	if n <= 0 {
 		return nil, io.ErrUnexpectedEOF
+	}
+	if n > maxSize {
+		return nil, ErrNALTooLarge
 	}
 
 	buf := make([]byte, n)
@@ -726,8 +749,8 @@ func nextNALLengthPrefixed(r io.Reader) ([]byte, error) {
 	return buf, nil
 }
 
-func nextNALH264LengthPrefixed(r io.Reader) (h264reader.NalUnitType, []byte, error) {
-	buf, err := nextNALLengthPrefixed(r)
+func nextNALH264LengthPrefixed(r io.Reader, maxSize int) (h264reader.NalUnitType, []byte, error) {
+	buf, err := nextNALLengthPrefixed(r, maxSize)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -735,8 +758,8 @@ func nextNALH264LengthPrefixed(r io.Reader) (h264reader.NalUnitType, []byte, err
 	return h264reader.NalUnitType(buf[0] & 0x1F), buf, nil
 }
 
-func nextNALH265LengthPrefixed(r io.Reader) (*h265reader.NAL, error) {
-	buf, err := nextNALLengthPrefixed(r)
+func nextNALH265LengthPrefixed(r io.Reader, maxSize int) (*h265reader.NAL, error) {
+	buf, err := nextNALLengthPrefixed(r, maxSize)
 	if err != nil {
 		return nil, err
 	}
@@ -776,7 +799,7 @@ func (p *ReaderSampleProvider) nextH265NAL() (*h265reader.NAL, error) {
 	}
 
 	if p.h26xStreamingFormat == H26xStreamingFormatLengthPrefixed {
-		return nextNALH265LengthPrefixed(p.reader)
+		return nextNALH265LengthPrefixed(p.reader, p.maxNALSize)
 	}
 	return p.h265reader.NextNAL()
 }

--- a/readersampleprovider.go
+++ b/readersampleprovider.go
@@ -98,6 +98,8 @@ type ReaderSampleProvider struct {
 	h265reader *h265reader.H265Reader
 	// pending H265 NAL when we detect a new access unit
 	h265PendingNAL *h265reader.NAL
+	// publish each access unit at its slice instead of at the next unit's start
+	h265SingleSliceFlush bool
 
 	// for ogg
 	oggReader *oggreader.OggReader
@@ -155,6 +157,21 @@ func readerTrackWithWavReader(wr *wavReader) func(provider *ReaderSampleProvider
 func ReaderTrackWithPacketTrailer(enabled bool) func(provider *ReaderSampleProvider) {
 	return func(provider *ReaderSampleProvider) {
 		provider.appendPacketTrailer = enabled
+	}
+}
+
+// ReaderTrackWithH265SingleSliceFlush publishes each H265 access unit as soon
+// as its slice arrives, instead of waiting for the next access unit to begin.
+// An access unit boundary is only detectable from the NAL that starts the next
+// one, so aggregation holds every picture for a full frame period; on a live
+// feed that is latency the encoder never intended.
+//
+// Enable this only for streams carrying one slice per picture, which is what
+// hardware encoders typically emit. With multiple slices per picture, each
+// slice is published as its own sample.
+func ReaderTrackWithH265SingleSliceFlush(enabled bool) func(provider *ReaderSampleProvider) {
+	return func(provider *ReaderSampleProvider) {
+		provider.h265SingleSliceFlush = enabled
 	}
 }
 
@@ -457,6 +474,11 @@ func (p *ReaderSampleProvider) NextSample(ctx context.Context) (media.Sample, er
 
 			if nal.NalUnitType < 32 {
 				haveVCL = true
+				if p.h265SingleSliceFlush {
+					// The slice completes the picture, so publish it now
+					// rather than waiting for the next access unit to start.
+					break
+				}
 			} else if !haveVCL {
 				// return it without duration
 				return sample, nil
@@ -679,6 +701,11 @@ func (w *wavReader) readFrame() ([]byte, error) {
 	return buf[:n], nil
 }
 
+// maxNALSize bounds a single length-prefixed NAL. The buffer is allocated from
+// the size read off the prefix, so this caps run-away values. 16MiB is well
+// above any real NAL, including a 4K I-frame.
+const maxNALSize = 16 << 20
+
 // minimal length-prefixed NAL reeader, 4-byte big-endian length prefix
 func nextNALLengthPrefixed(r io.Reader) ([]byte, error) {
 	var hdr [4]byte
@@ -687,7 +714,7 @@ func nextNALLengthPrefixed(r io.Reader) ([]byte, error) {
 	}
 
 	n := int(binary.BigEndian.Uint32(hdr[:]))
-	if n <= 0 {
+	if n <= 0 || n > maxNALSize {
 		return nil, io.ErrUnexpectedEOF
 	}
 

--- a/readersampleprovider_test.go
+++ b/readersampleprovider_test.go
@@ -317,7 +317,7 @@ func TestNextNALH265LengthPrefixed(t *testing.T) {
 		vps := makeH265NALData(32, []byte{0x01, 0x02})
 		r := bytes.NewReader(lengthPrefix(vps))
 
-		nal, err := nextNALH265LengthPrefixed(r)
+		nal, err := nextNALH265LengthPrefixed(r, defaultMaxNALSize)
 		require.NoError(t, err)
 		require.False(t, nal.ForbiddenZeroBit)
 		require.Equal(t, h265reader.NalUnitType(32), nal.NalUnitType)
@@ -327,24 +327,51 @@ func TestNextNALH265LengthPrefixed(t *testing.T) {
 	})
 
 	t.Run("EOF at a clean boundary", func(t *testing.T) {
-		_, err := nextNALH265LengthPrefixed(bytes.NewReader(nil))
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader(nil), defaultMaxNALSize)
 		require.ErrorIs(t, err, io.EOF)
 	})
 
 	t.Run("truncated payload", func(t *testing.T) {
-		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 8, 0x40, 0x01}))
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 8, 0x40, 0x01}), defaultMaxNALSize)
 		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
 
 	t.Run("NAL shorter than the header", func(t *testing.T) {
-		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 1, 0x40}))
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 1, 0x40}), defaultMaxNALSize)
 		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
 
 	t.Run("zero length", func(t *testing.T) {
-		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 0}))
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 0}), defaultMaxNALSize)
 		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
+
+	t.Run("exceeds max size", func(t *testing.T) {
+		// prefix advertises a NAL one byte past the limit; no payload follows,
+		// so a size check that ran after allocation would instead read and fail.
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 5}), 4)
+		require.ErrorIs(t, err, ErrNALTooLarge)
+	})
+}
+
+func TestReaderTrackWithMaxNALSize(t *testing.T) {
+	// OnBind resolves the effective limit once into maxNALSize.
+	bind := func(opts ...ReaderSampleProviderOption) *ReaderSampleProvider {
+		p := &ReaderSampleProvider{
+			Mime:                webrtc.MimeTypeH265,
+			reader:              io.NopCloser(bytes.NewReader(nil)),
+			h26xStreamingFormat: H26xStreamingFormatLengthPrefixed,
+		}
+		for _, opt := range opts {
+			opt(p)
+		}
+		require.NoError(t, p.OnBind())
+		return p
+	}
+
+	require.Equal(t, defaultMaxNALSize, bind().maxNALSize, "unset uses the default")
+	require.Equal(t, defaultMaxNALSize, bind(ReaderTrackWithMaxNALSize(0)).maxNALSize, "0 keeps the default")
+	require.Equal(t, 1<<20, bind(ReaderTrackWithMaxNALSize(1<<20)).maxNALSize)
 }
 
 func TestH265NextSample_LengthPrefixed_SingleAccessUnit(t *testing.T) {

--- a/readersampleprovider_test.go
+++ b/readersampleprovider_test.go
@@ -3,6 +3,7 @@ package lksdk
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"io"
 	"testing"
 
@@ -306,8 +307,203 @@ func TestH265NextSample_WithUserTimestamp(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// H265 NextSample — length-prefixed input
+// ---------------------------------------------------------------------------
+
+func TestNextNALH265LengthPrefixed(t *testing.T) {
+	t.Run("parses the NAL header", func(t *testing.T) {
+		vps := makeH265NALData(32, []byte{0x01, 0x02})
+		r := bytes.NewReader(lengthPrefix(vps))
+
+		nal, err := nextNALH265LengthPrefixed(r)
+		require.NoError(t, err)
+		require.False(t, nal.ForbiddenZeroBit)
+		require.Equal(t, h265reader.NalUnitType(32), nal.NalUnitType)
+		require.Equal(t, uint8(0), nal.LayerID)
+		require.Equal(t, uint8(1), nal.TemporalIDPlus1)
+		require.Equal(t, vps, nal.Data)
+	})
+
+	t.Run("EOF at a clean boundary", func(t *testing.T) {
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader(nil))
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("truncated payload", func(t *testing.T) {
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 8, 0x40, 0x01}))
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("NAL shorter than the header", func(t *testing.T) {
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 1, 0x40}))
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("zero length", func(t *testing.T) {
+		_, err := nextNALH265LengthPrefixed(bytes.NewReader([]byte{0, 0, 0, 0}))
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+}
+
+func TestH265NextSample_LengthPrefixed_SingleAccessUnit(t *testing.T) {
+	// VPS + SPS + PPS + VCL(first slice), each with a 4-byte length prefix.
+	sc := []byte{0, 0, 0, 1}
+	vps := makeH265NALData(32, []byte{0x01, 0x02})
+	sps := makeH265NALData(33, []byte{0x03, 0x04})
+	pps := makeH265NALData(34, []byte{0x05, 0x06})
+	vcl := makeH265VCLData(1, true, []byte{0xAA, 0xBB})
+
+	stream := concat(lengthPrefix(vps), lengthPrefix(sps), lengthPrefix(pps), lengthPrefix(vcl))
+	p := newLengthPrefixedH265Provider(t, stream)
+
+	sample, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, defaultH265FrameDuration, sample.Duration)
+	// the sample is emitted in Annex B form regardless of the input framing
+	want := concat(sc, vps, sc, sps, sc, pps, sc, vcl)
+	require.Equal(t, want, sample.Data)
+}
+
+func TestH265NextSample_LengthPrefixed_MultipleAccessUnits(t *testing.T) {
+	vcl1 := makeH265VCLData(1, true, []byte{0x11, 0x22})
+	vcl2 := makeH265VCLData(1, true, []byte{0x33, 0x44})
+
+	p := newLengthPrefixedH265Provider(t, concat(lengthPrefix(vcl1), lengthPrefix(vcl2)))
+
+	s1, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, defaultH265FrameDuration, s1.Duration)
+	require.Equal(t, vcl1, s1.Data)
+
+	// second access unit, flushed at EOF
+	s2, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, defaultH265FrameDuration, s2.Duration)
+	require.Equal(t, vcl2, s2.Data)
+
+	_, err = p.NextSample(context.Background())
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestH265NextSample_LengthPrefixed_MultiSliceAccessUnit(t *testing.T) {
+	sc := []byte{0, 0, 0, 1}
+	vclFirst := makeH265VCLData(1, true, []byte{0x11})
+	vclCont := makeH265VCLData(1, false, []byte{0x22})
+
+	p := newLengthPrefixedH265Provider(t, concat(lengthPrefix(vclFirst), lengthPrefix(vclCont)))
+
+	sample, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, concat(sc, vclFirst, sc, vclCont), sample.Data)
+}
+
+func TestH265NextSample_LengthPrefixed_NonVCLAfterVCLSplits(t *testing.T) {
+	sc := []byte{0, 0, 0, 1}
+	vcl := makeH265VCLData(1, true, []byte{0x11})
+	vps := makeH265NALData(32, []byte{0x22, 0x33})
+	vcl2 := makeH265VCLData(1, true, []byte{0x44})
+
+	p := newLengthPrefixedH265Provider(t, concat(lengthPrefix(vcl), lengthPrefix(vps), lengthPrefix(vcl2)))
+
+	s1, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, vcl, s1.Data)
+
+	s2, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, concat(sc, vps, sc, vcl2), s2.Data)
+}
+
+func TestH265NextSample_LengthPrefixed_SuffixSEIIgnored(t *testing.T) {
+	vcl1 := makeH265VCLData(1, true, []byte{0x11})
+	suffixSEI := makeH265NALData(40, []byte{0xFF})
+	vcl2 := makeH265VCLData(1, true, []byte{0x22})
+
+	p := newLengthPrefixedH265Provider(t, concat(lengthPrefix(vcl1), lengthPrefix(suffixSEI), lengthPrefix(vcl2)))
+
+	s1, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, vcl1, s1.Data)
+	require.False(t, bytes.Contains(s1.Data, suffixSEI), "s1 should not contain suffix SEI data")
+
+	s2, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, vcl2, s2.Data)
+}
+
+func TestH265NextSample_LengthPrefixed_PrefixSEIBeforeVCLSkipped(t *testing.T) {
+	prefixSEI := makeH265NALData(39, []byte{0xFF, 0xEE})
+
+	p := newLengthPrefixedH265Provider(t, lengthPrefix(prefixSEI))
+
+	sample, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, sample.Data)
+	require.Zero(t, sample.Duration)
+}
+
+func TestH265NextSample_LengthPrefixed_WithUserTimestamp(t *testing.T) {
+	wantMeta := FrameMetadata{UserTimestamp: 9876543210, FrameId: 77}
+	seiNAL := buildH265PacketTrailerSEI(wantMeta)
+	vcl := makeH265VCLData(1, true, []byte{0xAA})
+
+	p := newLengthPrefixedH265Provider(t, concat(lengthPrefix(seiNAL), lengthPrefix(vcl)))
+	p.appendPacketTrailer = true
+
+	// first call returns the SEI-only empty sample
+	s1, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, s1.Data)
+
+	// second call returns the VCL frame with the packet trailer
+	s2, err := p.NextSample(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, defaultH265FrameDuration, s2.Duration)
+	require.True(t, bytes.HasPrefix(s2.Data, vcl), "expected VCL prefix %x in sample data %x", vcl, s2.Data)
+
+	gotMeta, ok := parsePacketTrailer(s2.Data)
+	require.True(t, ok, "expected LKTS trailer in sample data")
+	require.Equal(t, wantMeta.UserTimestamp, gotMeta.UserTimestamp)
+	require.Equal(t, wantMeta.FrameId, gotMeta.FrameId)
+}
+
+func TestH265OnBind_LengthPrefixedSkipsAnnexBReader(t *testing.T) {
+	p := newLengthPrefixedH265Provider(t, nil)
+	require.Nil(t, p.h265reader, "length-prefixed input must not build the Annex B reader")
+
+	pAnnexB := &ReaderSampleProvider{
+		Mime:                webrtc.MimeTypeH265,
+		reader:              io.NopCloser(bytes.NewReader(concat([]byte{0, 0, 0, 1}, makeH265NALData(32, []byte{0x01})))),
+		h26xStreamingFormat: H26xStreamingFormatAnnexB,
+	}
+	require.NoError(t, pAnnexB.OnBind())
+	require.NotNil(t, pAnnexB.h265reader)
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
+
+// lengthPrefix frames a NAL with the 4-byte big-endian length prefix that
+// H26xStreamingFormatLengthPrefixed expects.
+func lengthPrefix(nal []byte) []byte {
+	out := make([]byte, 4, 4+len(nal))
+	binary.BigEndian.PutUint32(out, uint32(len(nal)))
+	return append(out, nal...)
+}
+
+// newLengthPrefixedH265Provider builds a bound provider reading length-prefixed H265.
+func newLengthPrefixedH265Provider(t *testing.T, stream []byte) *ReaderSampleProvider {
+	t.Helper()
+
+	p := &ReaderSampleProvider{
+		Mime:                webrtc.MimeTypeH265,
+		reader:              io.NopCloser(bytes.NewReader(stream)),
+		h26xStreamingFormat: H26xStreamingFormatLengthPrefixed,
+	}
+	require.NoError(t, p.OnBind())
+	return p
+}
 
 func concat(slices ...[]byte) []byte {
 	var out []byte

--- a/readersampleprovider_test.go
+++ b/readersampleprovider_test.go
@@ -6,8 +6,10 @@ import (
 	"encoding/binary"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/pion/webrtc/v4"
+	"github.com/pion/webrtc/v4/pkg/media"
 	"github.com/pion/webrtc/v4/pkg/media/h265reader"
 	"github.com/stretchr/testify/require"
 )
@@ -465,6 +467,69 @@ func TestH265NextSample_LengthPrefixed_WithUserTimestamp(t *testing.T) {
 	require.True(t, ok, "expected LKTS trailer in sample data")
 	require.Equal(t, wantMeta.UserTimestamp, gotMeta.UserTimestamp)
 	require.Equal(t, wantMeta.FrameId, gotMeta.FrameId)
+}
+
+// Access unit aggregation only ends when the NAL that starts the next access
+// unit arrives, so on a live feed every picture is held for a frame period.
+// The reader here is a pipe that stops after one access unit, which is what a
+// bytes.Reader cannot express: it reports EOF and flushes, hiding the wait.
+func TestH265NextSample_SingleSliceFlushPublishesWithoutLookahead(t *testing.T) {
+	aud := makeH265NALData(35, []byte{0x10})
+	vps := makeH265NALData(32, []byte{0x01, 0x02})
+	sps := makeH265NALData(33, []byte{0x03, 0x04})
+	pps := makeH265NALData(34, []byte{0x05, 0x06})
+	vcl := makeH265VCLData(1, true, []byte{0xAA, 0xBB})
+
+	pipeReader, pipeWriter := io.Pipe()
+	defer pipeWriter.Close()
+
+	p := &ReaderSampleProvider{
+		Mime:                 webrtc.MimeTypeH265,
+		reader:               pipeReader,
+		h26xStreamingFormat:  H26xStreamingFormatLengthPrefixed,
+		h265SingleSliceFlush: true,
+	}
+	require.NoError(t, p.OnBind())
+
+	// One access unit, and nothing after it: the next frame has not been
+	// encoded yet, exactly as on a live feed.
+	go func() {
+		_, _ = pipeWriter.Write(concat(
+			lengthPrefix(aud), lengthPrefix(vps), lengthPrefix(sps),
+			lengthPrefix(pps), lengthPrefix(vcl)))
+	}()
+
+	type result struct {
+		sample media.Sample
+		err    error
+	}
+	samples := make(chan result, 4)
+	go func() {
+		for {
+			sample, err := p.NextSample(context.Background())
+			samples <- result{sample, err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case <-timeout:
+			t.Fatal("timed out: the access unit was held waiting for the next one")
+		case got := <-samples:
+			require.NoError(t, got.err)
+			if got.sample.Duration == 0 {
+				continue // the AUD, which is published on its own
+			}
+			require.Equal(t, defaultH265FrameDuration, got.sample.Duration)
+			require.True(t, bytes.HasSuffix(got.sample.Data, vcl),
+				"expected the sample to end with the slice, got %x", got.sample.Data)
+			return
+		}
+	}
 }
 
 func TestH265OnBind_LengthPrefixedSkipsAnnexBReader(t *testing.T) {


### PR DESCRIPTION
H26xStreamingFormatLengthPrefixed was only wired up for H.264. Add the H.265 path so a length-prefixed HEVC stream can be published too.

- factor the 4-byte length-prefix framing out of nextNALH264LengthPrefixed into a shared nextNALLengthPrefixed
- add nextNALH265LengthPrefixed, returning a *h265reader.NAL with the 2-byte header parsed the same way pion's reader does, so the existing access unit assembly (slice boundaries, parameter sets, SEI, LKTS trailers) works unchanged
- dispatch on the format in nextH265NAL, after the pending NAL check so access unit pushback still works
- skip building the Annex-B h265reader in OnBind for length-prefixed input, mirroring H.264

Samples are still emitted in Annex-B form, the format only describes the input framing.

Follow-up commit:

- add ReaderTrackWithH265SingleSliceFlush: publish each H265 access unit as soon as its slice arrives instead of waiting for the NAL that starts the next one. An access unit boundary is only detectable from the next unit, so aggregation otherwise holds every picture for a frame period on a live feed. Enable only for single-slice-per-picture streams (typical hardware encoder output); with multiple slices per picture each slice is published as its own sample.
- bound length-prefixed NAL allocation with maxNALSize (16MiB): the buffer is sized from the prefix, so this caps run-away values. The reader is shared, so this covers H.264 as well.