### PR TITLE
Publish DTMF Helper for Local Participant

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -266,13 +266,13 @@ func TestPublishDTMF(t *testing.T) {
 
 	require.Equal(t, sub.LocalParticipant.Identity(), <-remoteParticipantsOfPub)
 
-	// Send a short sequence; the reliable channel must deliver every key, in order.
+	// The reliable data channel must deliver every key in order.
 	keys := []struct {
 		code  uint32
 		digit string
 	}{{1, "1"}, {2, "2"}, {3, "3"}, {11, "#"}}
 	for _, k := range keys {
-		// An explicit lossy request is overridden; PublishDTMF always sends reliably.
+		// PublishDTMF always sends reliably and overrides an explicit lossy request.
 		require.NoError(t, pub.LocalParticipant.PublishDTMF(k.code, k.digit, WithDataPublishReliable(false)))
 	}
 
@@ -290,6 +290,24 @@ func TestPublishDTMF(t *testing.T) {
 		require.Equal(t, k.code, received[i].dtmf.Code)
 		require.Equal(t, k.digit, received[i].dtmf.Digit)
 	}
+
+	// The receiver never sees packet Kind, so check the publisher's data channel, and
+	// every digit must have left on the reliable channel and none on the lossy one.
+	pubTransport, ok := pub.engine.Publisher()
+	require.True(t, ok)
+	var reliableSent, lossySent uint32
+	for _, s := range pubTransport.PeerConnection().GetStats() {
+		if dc, ok := s.(webrtc.DataChannelStats); ok {
+			switch dc.Label {
+			case reliableDataChannelName:
+				reliableSent += dc.MessagesSent
+			case lossyDataChannelName:
+				lossySent += dc.MessagesSent
+			}
+		}
+	}
+	require.Equal(t, uint32(len(keys)), reliableSent)
+	require.Zero(t, lossySent)
 }
 
 func TestJoinError(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -231,6 +231,67 @@ func TestJoin(t *testing.T) {
 	require.Equal(t, ConnectionStateDisconnected, sub.ConnectionState())
 }
 
+func TestPublishDTMF(t *testing.T) {
+	remoteParticipantsOfPub := make(chan string, 1)
+	pub, err := createAgent(t.Name(), &RoomCallback{
+		OnParticipantConnected: func(participant *RemoteParticipant) {
+			remoteParticipantsOfPub <- participant.Identity()
+		},
+	}, "publisher")
+	require.NoError(t, err)
+	defer pub.Disconnect()
+
+	type receivedDTMF struct {
+		sender string
+		dtmf   *livekit.SipDTMF
+	}
+	var (
+		dtmfLock sync.Mutex
+		received []receivedDTMF
+	)
+	sub, err := createAgent(t.Name(), &RoomCallback{
+		ParticipantCallback: ParticipantCallback{
+			OnDataPacket: func(data DataPacket, params DataReceiveParams) {
+				// The packet must surface to the callback as the protocol type, not as user data.
+				if dtmf, ok := data.(*livekit.SipDTMF); ok {
+					dtmfLock.Lock()
+					received = append(received, receivedDTMF{sender: params.SenderIdentity, dtmf: dtmf})
+					dtmfLock.Unlock()
+				}
+			},
+		},
+	}, "subscriber")
+	require.NoError(t, err)
+	defer sub.Disconnect()
+
+	require.Equal(t, sub.LocalParticipant.Identity(), <-remoteParticipantsOfPub)
+
+	// Send a short sequence; the reliable channel must deliver every key, in order.
+	keys := []struct {
+		code  uint32
+		digit string
+	}{{1, "1"}, {2, "2"}, {3, "3"}, {11, "#"}}
+	for _, k := range keys {
+		// An explicit lossy request is overridden; PublishDTMF always sends reliably.
+		require.NoError(t, pub.LocalParticipant.PublishDTMF(k.code, k.digit, WithDataPublishReliable(false)))
+	}
+
+	require.Eventually(t, func() bool {
+		dtmfLock.Lock()
+		defer dtmfLock.Unlock()
+		return len(received) >= len(keys)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	dtmfLock.Lock()
+	defer dtmfLock.Unlock()
+	require.Len(t, received, len(keys))
+	for i, k := range keys {
+		require.Equal(t, pub.LocalParticipant.Identity(), received[i].sender)
+		require.Equal(t, k.code, received[i].dtmf.Code)
+		require.Equal(t, k.digit, received[i].dtmf.Digit)
+	}
+}
+
 func TestJoinError(t *testing.T) {
 	_, err := ConnectToRoomWithToken(host, "invalid", nil)
 	require.Error(t, err)

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -663,11 +663,14 @@ func (p *LocalParticipant) PublishDataPacket(pck DataPacket, opts ...DataPublish
 // PublishDTMF sends a SIP DTMF digit to the room as a livekit.SipDTMF data packet.
 // code is the RFC 4733 event code and digit is the key it represents, e.g. 11 and "#".
 //
-// DTMF is always sent via the RELIABLE channel so that digits arrive in order,
-// see WithDataPublishDestination for choosing specific participants.
+// DTMF always uses the RELIABLE channel so digits arrive in order, overriding any
+// WithDataPublishReliable(false). See WithDataPublishDestination to target participants.
 func (p *LocalParticipant) PublishDTMF(code uint32, digit string, opts ...DataPublishOption) error {
-	opts = append(opts, WithDataPublishReliable(true))
-	return p.PublishDataPacket(&livekit.SipDTMF{Code: code, Digit: digit}, opts...)
+	// Copy opts so appending never modifies the caller's slice.
+	allOpts := make([]DataPublishOption, 0, len(opts)+1)
+	allOpts = append(allOpts, opts...)
+	allOpts = append(allOpts, WithDataPublishReliable(true))
+	return p.PublishDataPacket(&livekit.SipDTMF{Code: code, Digit: digit}, allOpts...)
 }
 
 // UnpublishTrack stops publishing a track and removes it from the room.

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -659,6 +659,16 @@ func (p *LocalParticipant) PublishDataPacket(pck DataPacket, opts ...DataPublish
 	return p.engine.publishDataPacket(dataPacket, kind)
 }
 
+// PublishDTMF sends a SIP DTMF digit to the room as a livekit.SipDTMF data packet.
+// code is the RFC 4733 event code and digit is the key it represents, e.g. 11 and "#".
+//
+// DTMF is always sent via the RELIABLE channel so that digits arrive in order,
+// see WithDataPublishDestination for choosing specific participants.
+func (p *LocalParticipant) PublishDTMF(code uint32, digit string, opts ...DataPublishOption) error {
+	opts = append(opts, WithDataPublishReliable(true))
+	return p.PublishDataPacket(&livekit.SipDTMF{Code: code, Digit: digit}, opts...)
+}
+
 // UnpublishTrack stops publishing a track and removes it from the room.
 func (p *LocalParticipant) UnpublishTrack(sid string) error {
 	obj, loaded := p.tracks.LoadAndDelete(sid)

--- a/localparticipant.go
+++ b/localparticipant.go
@@ -644,7 +644,8 @@ func (p *LocalParticipant) PublishDataPacket(pck DataPacket, opts ...DataPublish
 		}
 	}
 
-	// This matches the default value of Kind on protobuf level.
+	// Lossy by default to keep the old PublishData behavior.
+	// The protobuf zero value of Kind is RELIABLE, so this is not the proto default.
 	kind := livekit.DataPacket_LOSSY
 	if options.Reliable != nil && *options.Reliable {
 		kind = livekit.DataPacket_RELIABLE


### PR DESCRIPTION
**Problem**

The JavaScript, Rust, Python, and Node SDKs have DTMF publishing helpers that always use the reliable data channel. The Go SDK has no equivalent, so developers have to build the packet themselves and remember to pass `WithDataPublishReliable(true)`.

That matters because `PublishDataPacket` has defaulted to the lossy channel since #421 (v2.1.0), and the lossy channel has been unordered since #659 (v2.8.0). Digits sent with the default can be dropped or arrive out of order.

**Changes**

- Added `PublishDTMF(code, digit)` to `LocalParticipant`. It wraps `PublishDataPacket` with `WithDataPublishReliable(true)`, so a `SipDTMF` packet always goes over the reliable channel. The helper accepts no publishing options.
- Updated a stale comment above the default in `PublishDataPacket`. It said the Go default matches the protobuf default. That was true when #415 wrote it, since both defaulted to reliable. #421 flipped the Go default to lossy but left the comment, and the protobuf zero value is still `RELIABLE`.

**Testing**

`TestPublishDTMF` publishes `1 2 3 #` and asserts that the subscriber receives four `*livekit.SipDTMF` packets with the expected codes and digits in order. It also checks the publisher’s WebRTC `GetStats` for four messages on the `_reliable` data channel and none on `_lossy`.

- The updated integration test passed against a local LiveKit server with `CGO_ENABLED=0`.
- `mage test`, which includes `-race`, passed locally before this API simplification. The latest full-suite attempt was blocked by a missing local `soxr` dependency.

**Notes**

- The helper sends DTMF digits to all participants in the room.
- Reliable delivery matches the other SDKs.