### PR TITLE
failover: retry the same host when no fallback region exists, and cover the Cloud API hosts

### DIFF
--- a/failover.go
+++ b/failover.go
@@ -265,7 +265,9 @@ func (t *failoverTransport) failover(req *http.Request, maxAttempts int, timeout
 		}
 		nextScheme, nextHost, ok := nextRegion(regions, tried)
 		if !ok {
-			return terminate(resp, err, cancel) // no untried region left
+			// With no fallback region, a retryable failure is retried against
+			// the same host.
+			nextScheme, nextHost = scheme, host
 		}
 
 		status := 0

--- a/failover.go
+++ b/failover.go
@@ -69,13 +69,20 @@ type failoverConfig struct {
 }
 
 // attempts returns the total request attempts for a host; 1 means no failover.
-// Failover engages only when enabled and the host is a LiveKit Cloud domain
-// (or force is set).
+// Failover engages only when enabled and the host is a LiveKit Cloud project
+// or Cloud API domain (or force is set).
 func (c failoverConfig) attempts(hostname string) int {
-	if c.enabled && (c.force || isCloud(hostname)) {
+	if c.enabled && (c.force || isCloud(hostname) || isCloudAPI(hostname)) {
 		return failoverMaxAttempts
 	}
 	return 1
+}
+
+// isCloudAPI reports whether the hostname is a LiveKit Cloud API endpoint
+// (cloud-api.livekit.io or a cloud-api.<env>.livekit.io variant).
+func isCloudAPI(hostname string) bool {
+	hostname = strings.ToLower(hostname)
+	return strings.HasPrefix(hostname, "cloud-api.") && strings.HasSuffix(hostname, ".livekit.io")
 }
 
 type failoverEnabledKey struct{}
@@ -238,6 +245,8 @@ func (t *failoverTransport) failover(req *http.Request, maxAttempts int, timeout
 	scheme, host := req.URL.Scheme, req.URL.Host
 	tried := map[string]struct{}{strings.ToLower(host): {}}
 	var regions *livekit.RegionSettings // discovered lazily on the first failure
+	// A Cloud API host has a single origin; region discovery is never consulted.
+	discover := !isCloudAPI(req.URL.Hostname())
 
 	var resp *http.Response
 	var err error
@@ -259,7 +268,7 @@ func (t *failoverTransport) failover(req *http.Request, maxAttempts int, timeout
 			return terminate(resp, err, cancel)
 		}
 
-		if regions == nil {
+		if regions == nil && discover {
 			u := url.URL{Scheme: req.URL.Scheme, Host: req.URL.Host, Path: "/settings/regions"}
 			regions, _ = t.regions.get(req.URL.Host, u.String(), req.Header, 0)
 		}

--- a/failover_internal_test.go
+++ b/failover_internal_test.go
@@ -409,3 +409,64 @@ func TestFailoverRetriesOn5xxWithinBudget(t *testing.T) {
 		t.Fatalf("expected 2 attempts (5xx then success), got %d", n)
 	}
 }
+
+// newSingleHostTransport wires a failoverTransport with no fallback region: the
+// cache lists only the request's own host.
+func newSingleHostTransport(stub http.RoundTripper, host string) *failoverTransport {
+	rc := newRegionCache()
+	rc.cache[strings.ToLower(host)] = &regionCacheEntry{
+		settings:  &livekit.RegionSettings{Regions: []*livekit.RegionInfo{{Url: "http://" + host}}},
+		fetchedAt: time.Now(),
+		ttl:       time.Hour,
+	}
+	return &failoverTransport{base: stub, regions: rc}
+}
+
+// Without a fallback region, a transport error retries the same host.
+func TestFailoverRetriesSameHostOnTransportError(t *testing.T) {
+	const host = "cloud-api.example.com"
+
+	stub := &stubRoundTripper{behave: func(attempt int, _ context.Context) (*http.Response, error) {
+		if attempt == 0 {
+			return nil, errors.New("read: connection reset by peer")
+		}
+		return stubResponse(http.StatusOK), nil
+	}}
+	tr := newSingleHostTransport(stub, host)
+
+	ctx := withFailoverForce(context.Background(), time.Millisecond)
+	resp, err := tr.RoundTrip(stubRequest(ctx, host))
+	if err != nil {
+		t.Fatalf("a lost request should be retried on the same host, got error: %v", err)
+	}
+	_ = resp.Body.Close()
+	if n := stub.count(); n != 2 {
+		t.Fatalf("expected 2 attempts (transport error then success), got %d", n)
+	}
+}
+
+// Without a fallback region, a 5xx retries the same host.
+func TestFailoverRetriesSameHostOn5xx(t *testing.T) {
+	const host = "cloud-api.example.com"
+
+	stub := &stubRoundTripper{behave: func(attempt int, _ context.Context) (*http.Response, error) {
+		if attempt == 0 {
+			return stubResponse(http.StatusBadGateway), nil
+		}
+		return stubResponse(http.StatusOK), nil
+	}}
+	tr := newSingleHostTransport(stub, host)
+
+	ctx := withFailoverForce(context.Background(), time.Millisecond)
+	resp, err := tr.RoundTrip(stubRequest(ctx, host))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after a same-host retry, got %d", resp.StatusCode)
+	}
+	if n := stub.count(); n != 2 {
+		t.Fatalf("expected 2 attempts (5xx then success), got %d", n)
+	}
+}

--- a/failover_internal_test.go
+++ b/failover_internal_test.go
@@ -39,6 +39,11 @@ func TestFailoverAttempts(t *testing.T) {
 		{failoverConfig{enabled: true}, "myproject.livekit.cloud", failoverMaxAttempts},
 		{failoverConfig{enabled: true}, "myproject.region.livekit.cloud", failoverMaxAttempts},
 		{failoverConfig{enabled: true}, "myproject.livekit.io", 1},
+		// The LiveKit Cloud API hosts fail over too (same-host retry, see failover).
+		{failoverConfig{enabled: true}, "cloud-api.livekit.io", failoverMaxAttempts},
+		{failoverConfig{enabled: true}, "cloud-api.staging.livekit.io", failoverMaxAttempts},
+		{failoverConfig{enabled: true}, "CLOUD-API.LIVEKIT.IO", failoverMaxAttempts},
+		{failoverConfig{enabled: true}, "cloud-api.example.com", 1},
 		{failoverConfig{enabled: true}, "example.com", 1},
 		{failoverConfig{enabled: true}, "127.0.0.1", 1},
 		{failoverConfig{enabled: true}, "notlivekit.cloud", 1},
@@ -468,5 +473,35 @@ func TestFailoverRetriesSameHostOn5xx(t *testing.T) {
 	}
 	if n := stub.count(); n != 2 {
 		t.Fatalf("expected 2 attempts (5xx then success), got %d", n)
+	}
+}
+
+// A Cloud API host has a single origin: its retries never call region discovery.
+func TestFailoverCloudAPISkipsRegionDiscovery(t *testing.T) {
+	const host = "cloud-api.livekit.io"
+
+	stub := &stubRoundTripper{behave: func(attempt int, _ context.Context) (*http.Response, error) {
+		if attempt == 0 {
+			return nil, errors.New("read: connection reset by peer")
+		}
+		return stubResponse(http.StatusOK), nil
+	}}
+	discovery := &stubRoundTripper{behave: func(int, context.Context) (*http.Response, error) {
+		return nil, errors.New("discovery must not be called")
+	}}
+	rc := newRegionCache()
+	rc.client = &http.Client{Transport: discovery}
+	tr := &failoverTransport{base: stub, regions: rc}
+
+	resp, err := tr.RoundTrip(stubRequest(context.Background(), host))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = resp.Body.Close()
+	if n := stub.count(); n != 2 {
+		t.Fatalf("expected 2 attempts, got %d", n)
+	}
+	if n := discovery.count(); n != 0 {
+		t.Fatalf("expected no region discovery for a Cloud API host, got %d fetches", n)
 	}
 }


### PR DESCRIPTION
## Why

A CLI call to `cloud-api.livekit.io` hung for 10 seconds and timed out on 2026-09-11 at 14:44Z. The request reached Cloudflare's edge and was acknowledged there, but no LiveKit system ever saw it: traefik's per-backend counters, the OCI load balancer's metrics, and cloud-api's request spans were all clean for that minute. Every other call in the surrounding minutes succeeded. The failure was a single lost request between Cloudflare and the origin.

The SDK's failover transport could not help, for two reasons:

- `isCloud` only matches `*.livekit.cloud`, so a `cloud-api.livekit.io` request always got exactly one attempt.
- Even with failover engaged, the loop gives up as soon as no untried region exists, which is always the case for cloud-api because it has a single origin and `/settings/regions` returns 404.

## What

Two commits, each test-first:

1. **Retry the same host when no fallback region exists.** A retryable failure with no untried region used to be surfaced after one attempt. It now retries against the same host, bounded by the existing attempt count and backoff. This matches the cross-region path, which already retries both transport errors and 5xx responses. `TestAPI_RegionDiscoveryUnreachable` still holds: a region that fails deterministically is surfaced once attempts are exhausted.
2. **Enable retries for the LiveKit Cloud API hosts.** A new `isCloudAPI` check matches `cloud-api.<env>.livekit.io` case-insensitively and joins `isCloud` in the attempts policy. Cloud API hosts skip `/settings/regions` discovery entirely, since they have a single origin and the endpoint 404s; otherwise every retry would pay the independent 2-second discovery timeout. `isCloud` itself is unchanged since it also drives region-URL parsing for project hosts.

The existing `minFailoverTimeout` gate still applies, so requests with a budget under 5 seconds get a single attempt as before.

## Behavior change

For cloud-api calls with a budget of 5 seconds or more, a lost request now costs up to three attempts with backoff. A truly dead origin takes up to three times the per-attempt budget to surface instead of one. A single lost request becomes a sub-second blip.

## Cross-SDK parity

Same change in the other server SDKs: livekit/python-sdks#811 and livekit/node-sdks#723.

## Testing

- `go test ./ -run 'Failover|PrepareContext|DialContext'` passes.
- New tests: `TestFailoverRetriesSameHostOnTransportError`, `TestFailoverRetriesSameHostOn5xx`, `TestFailoverCloudAPISkipsRegionDiscovery`, plus cloud-api rows in `TestFailoverAttempts`. Each was confirmed failing before its implementation commit.
- The root package's `integration_test.go` cases need a running LiveKit server and fail identically on `main`.
